### PR TITLE
docs: Google developer-documentation style pass

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,4 +71,4 @@ Single-context: `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/do
 
 ## Compact instructions
 
-When compacting, preserve verbatim: the test invariants above; which plan tasks are complete with commit shas; any deviation from `plans/phase-1a.md` / `plans/phase-1b.md` and why. Discard file reads, test output, and exploration traces.
+When compacting, preserve verbatim: the test invariants in the Test invariants section; which plan tasks are complete with commit shas; any deviation from `plans/phase-1a.md` / `plans/phase-1b.md` and why. Discard file reads, test output, and exploration traces.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Multi-agent paper-trading firm on the Claude Agent SDK (Python). Agents communic
 4. **Default is HOLD.** Any error, timeout, malformed tool input, or ambiguity anywhere in the pipeline resolves to no action — never to a guess.
 5. **Orders are idempotent.** `client_order_id` = gate ticket id, always. Alpaca 422-rejects duplicates; never mint a new id on retry.
 6. **SQLite is the source of truth; Slack is a projection.** Never read workflow state from Slack; never trigger execution from a Slack event.
-7. **Agents emit structured data only via MCP tools** (`submit_signal`, `submit_decision`, strict schemas) — never as free text that code parses.
+7. **Agents emit structured data only through MCP tools** (`submit_signal`, `submit_decision`, strict schemas) — never as free text that code parses.
 
 ## Commands
 
@@ -18,7 +18,7 @@ Multi-agent paper-trading firm on the Claude Agent SDK (Python). Agents communic
 - `make sim-day` — full simulated trading day: injected clock, FakeSlack, recorded LLM decisions, **real** tool/gate/DB execution.
 - `make replay REC=<recording>` — replay a recorded day's LLM decisions against current code.
 - `make live-paper` — real Slack + Alpaca paper + real LLM calls (needs `.env`).
-- `systemctl start fund-daily.service` — one trading day on the VM host. Schedule, cutover and rollback: `ops/README.md`.
+- `systemctl start fund-daily.service` — one trading day on the VM host. Schedule, cutover, and rollback: `ops/README.md`.
 
 ## Architecture map
 
@@ -27,19 +27,19 @@ Multi-agent paper-trading firm on the Claude Agent SDK (Python). Agents communic
 ## Conventions
 
 - Python 3.12, `pydantic` v2, `pytest`; `claude-agent-sdk` and `slack_bolt` pinned in `pyproject.toml`. Model ids and budgets live in `agents/config/*.yaml`, never hardcoded.
-- Every workflow table is a state machine. Allowed transitions are defined in `specs/contracts.md`; apply them only through `state/transition()`. Illegal transition = raise, never overwrite.
+- Every workflow table is a state machine. Allowed transitions are defined in `specs/contracts.md`; apply them only through `state/transition()`. An illegal transition must raise; never overwrite.
 - Time comes from an injected `Clock` protocol. Never call `datetime.now()` or `time.sleep()` in business logic — this is what makes `sim-day` possible.
-- Never put per-run values (timestamps, uuids, tmp paths) into prompts; pass them to tools out-of-band. Baked-in values break replay tests.
+- Never put per-run values (timestamps, UUIDs, tmp paths) into prompts; pass them to tools out-of-band. Baked-in values break replay tests.
 - All hooks (`PreToolUse` order gate, cost recording) are defined in `agents/runtime.py` only.
 - Set `setting_sources=["project"]` in `ClaudeAgentOptions` so this file is loaded for coding/dev seats. **EXCEPTION — order-placing seats (the Execution Trader, and any future seat with `mcp__alpaca__place_*` in its `tools`): `setting_sources=[]` and an explicit `tools=[...]` allow-array (MCP globs only), never the default preset.** A headless trading seat with `.env` + network in scope must not inherit `Bash`/`Write`/`Task` (it can `Read(.env)` + shell around the gate) nor a settings file whose allow-list accumulates dev approvals. `tools` governs availability (the real lock); `allowed_tools`/`disallowed_tools` only govern approval and fail open. Pinned by `tests/test_exec_seat_tool_surface.py` — do not relax.
 - `ResultMessage.total_cost_usd` is a client-side estimate — label it "est." in digests.
 
 ## Specs — read before implementing; schemas there are canonical
 
-- `specs/design.md` — full design doc (seats, daily cycle, gate math)
+- `specs/design.md` — full design doc (seats, daily cycle, gate math).
 - `specs/contracts.md` — DDL, pydantic models, tool schemas, state machines, failure semantics. **Do not invent fields.**
 - `specs/acceptance.md` — per-phase done-criteria. Implement its tests FIRST, then code until green.
-- `specs/strategy.md` — strategy lifecycle: pre-registration, backtest tool rules, gates G1–G4, allocation & kill rules. Evidence behind its numbers lives in `research/strategy-research-report.md` — consult on demand, do NOT load by default.
+- `specs/strategy.md` — strategy lifecycle: pre-registration, backtest tool rules, gates G1–G4, allocation and kill rules. Evidence behind its numbers lives in `research/strategy-research-report.md` — consult on demand, do NOT load by default.
 - `specs/strategy-contracts.md` — canonical ids/DDL/state machine/tool contracts for the strategy pipeline; matches the tested code in `fundbt/` + `stratgate/`. Overrides anything conflicting elsewhere.
 - `specs/calibration.md` — analyst scoring (Brier/BSS, shrinkage) → deterministic PM weights; implemented in `calibration/`.
 - `charters/` — seat system prompts. `_template.md` defines required sections; `pm.md` and `quant.md` are the quality bar.
@@ -47,11 +47,11 @@ Multi-agent paper-trading firm on the Claude Agent SDK (Python). Agents communic
 
 ## Do NOT
 
-- Do not parse tickers/actions/sizes out of free text anywhere.
+- Do not parse tickers, actions, or sizes out of free text anywhere.
 - Do not give a seat a new Alpaca toolset without updating the seat table in `specs/design.md`.
 - Do not write journals except through `state/journal.py`.
 - Do not weaken or delete a red acceptance test to make it pass.
-- Do not run a backtest except through the `run_backtest` tool (it auto-logs the trial registry; an unlogged trial corrupts the deflated-Sharpe correction fund-wide).
+- Do not run a backtest except through the `run_backtest` tool, which auto-logs the trial registry. An unlogged trial corrupts the deflated-Sharpe correction fund-wide.
 - Do not import from `agents/` inside `gate/` or `orchestrator/`.
 
 ## Test invariants
@@ -67,8 +67,8 @@ Issues live as GitHub issues on `benjaminematton/fund`, via the `gh` CLI. See `d
 
 ### Domain docs
 
-Single-context: `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.
+The domain docs are single-context: `CONTEXT.md` and `docs/adr/`, both at the repo root. See `docs/agents/domain.md`.
 
 ## Compact instructions
 
-When compacting, preserve verbatim: the test invariants in the Test invariants section; which plan tasks are complete with commit shas; any deviation from `plans/phase-1a.md` / `plans/phase-1b.md` and why. Discard file reads, test output, and exploration traces.
+When compacting, preserve verbatim: the test invariants in the Test invariants section; which plan tasks are complete with commit SHAs; any deviation from `plans/phase-1a.md` / `plans/phase-1b.md` and why. Discard file reads, test output, and exploration traces.

--- a/HANDOFF-LIVE.md
+++ b/HANDOFF-LIVE.md
@@ -60,7 +60,7 @@ curl -s -H "APCA-API-KEY-ID: $ALPACA_API_KEY" \
         https://paper-api.alpaca.markets/v2/clock
 ```
 
-Expect `"is_open":true`. If it is false, everything below will correctly refuse
+Expect `"is_open":true`. If it is false, every step in this runbook will correctly refuse
 to trade — come back when it is open.
 
 ### Known trap: the Slack token
@@ -71,7 +71,7 @@ audit fails on `undrained outbox events`. Nothing is lost — that post failure
 is transient, so the whole day's projection is still queued in SQLite and
 flushes on the next drain once the token is fixed. Fix the token, not the
 audit. (A *revoked* token is different: `invalid_auth` is permanent, and
-permanent errors dead-letter — see below.)
+permanent errors dead-letter — see the following paragraph.)
 
 **Invite the bot to all five channels the renderers post to — do this before
 anything else.** `not_in_channel` is permanent: those events dead-letter one
@@ -157,7 +157,7 @@ curl -s -H "APCA-API-KEY-ID: $ALPACA_API_KEY" \
 ```
 
 Then open the `#trade-log` message the test posted and **copy its permalink**
-(message ⋯ menu → Copy link).
+(open the message's more-actions menu, then click **Copy link**).
 
 | Evidence | Ticks |
 |---|---|
@@ -278,7 +278,7 @@ Note what that $0.50 is and is not. The per-seat `max_budget_usd` caps in
 exec $1.00); **expected spend is < $0.50/day**; the real figure is **measured
 after the first live day**. The caps are backstops against a runaway turn, not
 the expectation — so a day near $2.25 is an incident to investigate, and the
-$0.50 box below is the number that actually gets ticked.
+$0.50 row in §5 is the number that actually gets ticked.
 
 ---
 
@@ -301,7 +301,7 @@ Paste all five into the commit message (or PR body) that ticks the boxes.
 **STOP, capture, report. Do not retry blind.** Re-running a live day after an
 unexplained failure is how you turn one bad order into two.
 
-### The card — everything below, on one screen
+### The card — every stop condition on one screen
 
 | # | Stop on | You see it | It means |
 |---|---|---|---|
@@ -311,7 +311,7 @@ unexplained failure is how you turn one bad order into two.
 | 4 | An order you did not expect | `#trade-log`, broker | Wrong symbol, wrong side, or qty > ticket `max_qty` |
 | 5 | Paper guard fired | startup | Do NOT export and retry. Find out why it was wrong |
 
-**Then, before touching anything:** run the capture block below (DB copy,
+**Then, before touching anything:** run the capture commands in §6, "The detail" (DB copy,
 audit, checkpoints, decisions, orders, events, broker orders) and report with
 the artefacts attached.
 
@@ -346,7 +346,7 @@ Stop immediately on any of:
 3. **`run_day_failed — …` in `#risk`.** Something raised between the DB
    connection and the audit: a stage body, the watchlist/sectors load, or the
    market-data fetch. The day stopped there and **the audit did not run**, so
-   the DB is mid-flight — capture it below before anything else. Note this can
+   the DB is mid-flight — capture it with the commands in this section before anything else. Note this can
    land after a ticket was minted and an order placed.
 4. **An order you did not expect** — wrong symbol, wrong side, or a quantity
    above the ticket's `max_qty`.

--- a/HANDOFF-LIVE.md
+++ b/HANDOFF-LIVE.md
@@ -19,7 +19,7 @@ cd ~/Developer/fund          # this checkout
 set -a; source .env; set +a
 ```
 
-Now run the sanity check. **Do not proceed until every line reads OK.**
+Now run the preflight checks. **Do not proceed until every line reads OK.**
 
 ```bash
 echo "PAPER=${ALPACA_PAPER_TRADE}"                    # must print exactly: PAPER=true
@@ -49,7 +49,7 @@ curl -s -H "APCA-API-KEY-ID: $ALPACA_API_KEY" \
 ```
 
 Expect `"status": "ACTIVE"`, a non-zero `"equity"`, and — the one that matters —
-the account id should be the paper one you expect. If these credentials are
+the account id must be the paper account you expect. If these credentials are
 rejected by the paper endpoint, they are not paper credentials. **Stop.**
 
 And confirm the market is actually open right now:
@@ -70,11 +70,13 @@ The bot token must start with `xoxb-`. An `xapp-` app-level token cannot call
 audit fails on `undrained outbox events`. Nothing is lost — that post failure
 is transient, so the whole day's projection is still queued in SQLite and
 flushes on the next drain once the token is fixed. Fix the token, not the
-audit. (A *revoked* token is different: `invalid_auth` is permanent, and
+audit.
+
+**Warning:** A *revoked* token is different. `invalid_auth` is permanent, and
 permanent errors dead-letter — see the following paragraph.)
 
-**Invite the bot to all five channels the renderers post to — do this before
-anything else.** `not_in_channel` is permanent: those events dead-letter one
+**Warning:** Invite the bot to all five channels the renderers post to before
+anything else. `not_in_channel` is permanent: those events dead-letter one
 by one (audit: `dead-lettered outbox events`) and never reach Slack, while the
 other four channels keep delivering. An invite afterwards does not bring them
 back.
@@ -83,7 +85,7 @@ back.
 #research  #trading-floor  #risk  #trade-log  #pnl
 ```
 
-In each one: `/invite @<your-bot>`. Then verify — the printed list must
+In each one: `/invite @BOT_NAME`, where `BOT_NAME` is your bot's Slack handle. Then verify — the printed list must
 contain all five:
 
 ```bash
@@ -92,11 +94,11 @@ curl -s -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
   | python3 -c 'import json,sys; print(sorted("#"+c["name"] for c in json.load(sys.stdin)["channels"]))'
 ```
 
-> Rehearsing somewhere harmless? Set
+> **Note:** To rehearse in a channel where nothing matters, set
 > `SLACK_CHANNEL_OVERRIDES=#research=#fund-staging,#trading-floor=#fund-staging,#risk=#fund-staging,#trade-log=#fund-staging,#pnl=#fund-staging`
 > and every post is remapped. Unset it for the real run. On the droplet this is
 > already wired into `/etc/fund/staging-env`; use `make staging-day` rather than
-> hand-rolling it.
+> setting it by hand.
 
 ---
 
@@ -117,7 +119,7 @@ FakeAlpaca and the recordings encoded the *same* wrong assumption. Fixture and
 code agreed with each other and both disagreed with Alpaca. No offline test
 can catch that class of bug by construction; this one asks the server.
 
-If it fails, STOP — do not run the day. A schema change means `gate/tickets.py`
+**Warning:** If it fails, STOP — do not run the day. A schema change means `gate/tickets.py`
 and `charters/exec.md` are describing an order the broker will not accept.
 
 ---
@@ -129,7 +131,7 @@ and `charters/exec.md` are describing an order the broker will not accept.
 ```
 
 **What it does:** seeds one gate ticket, runs a REAL Execution Trader turn
-through the SDK, the seat calls `mcp__alpaca__place_stock_order` with the
+through the SDK. The seat calls `mcp__alpaca__place_stock_order` with the
 ticket id as `client_order_id`, the `PreToolUse` hook validates it against the
 ticket, the order round-trips on the paper account, and the `PostToolUse`
 recorder mirrors it into SQLite. Then it posts to Slack.
@@ -143,8 +145,8 @@ tests/test_live_smoke.py::test_alpaca_source_account_state_and_close_frame PASSE
 2 passed in ...
 ```
 
-Takes up to ~2 minutes: the first `uvx alpaca-mcp-server` start is slow, and
-the test polls the order for up to 90s.
+Takes up to about 2 minutes: the first `uvx alpaca-mcp-server` start is slow,
+and the test polls the order for up to 90 seconds.
 
 **Capture now — evidence for acceptance box §4.1:**
 
@@ -159,18 +161,18 @@ curl -s -H "APCA-API-KEY-ID: $ALPACA_API_KEY" \
 Then open the `#trade-log` message the test posted and **copy its permalink**
 (open the message's more-actions menu, then click **Copy link**).
 
-| Evidence | Ticks |
-|---|---|
-| `/tmp/live-smoke-fill.json` showing status `filled` (or `canceled`) with your `client_order_id` | §4.1 "1-share paper order round-trips" |
-| Slack permalink to the `#trade-log` post | §4.1 "fill in real Slack" |
+Record the following two pieces of evidence:
+
+- **`/tmp/live-smoke-fill.json`** showing status `filled` (or `canceled`) with your `client_order_id` — ticks §4.1 "1-share paper order round-trips".
+- **Slack permalink to the `#trade-log` post** — ticks §4.1 "fill in real Slack".
 
 A `canceled` status is acceptable ONLY if the market closed mid-test. During
 market hours, expect `filled`.
 
-### Then flatten it — do not skip this
+### Close the leftover AAPL share — do not skip this
 
-The smoke **buys** 1 share of AAPL and only cancels the order if it stays
-unfilled. During market hours it fills, and nothing in the test liquidates it.
+The smoke **buys** 1 share of AAPL and cancels the order only if it stays
+unfilled. During market hours the order fills, and nothing in the test liquidates the share.
 §2's universe is `watchlist ∪ positions`, so a leftover AAPL share makes the
 live day run **3 active tickers, not the 2** the reduced config specifies (§7)
 — on the exact run whose purpose is measuring per-seat turn consumption. Close
@@ -215,7 +217,7 @@ run_day: AUDIT CLEAN 2026-MM-DD
 
 and `echo $?` → `0`.
 
-Other legitimate outcomes:
+The following outcomes are also legitimate:
 
 - `run_day: market is closed — no stages run, nothing traded (exit 0)` — you
   ran it outside market hours. Not a failure; not a completed day either.
@@ -228,11 +230,11 @@ Other legitimate outcomes:
   day still completes, still posts a digest, and still prints `AUDIT CLEAN`:
   with no active tickers no seat turn is ever scheduled, so zero `costs` rows
   is that day's correct shape, not a violation. (A day that DID schedule turns
-  and recorded no cost still fails — see §6.2.)
+  and recorded no cost still fails — see §6, "The detail", item 2.)
 - A HOLD day. **This is a success.** The PM deciding HOLD on a boring day is
-  the designed behaviour, not a broken run.
+  the designed behavior, not a broken run.
 
-In Slack you should see: signals in `#research`, the PM's verdict in
+In Slack, verify: signals in `#research`, the PM's verdict in
 `#trading-floor`, a gate ticket or rejection in `#risk`, a fill in
 `#trade-log` if it traded, and the EOD digest in `#pnl`.
 
@@ -240,7 +242,7 @@ In Slack you should see: signals in `#research`, the PM's verdict in
 
 ## 3. The audit
 
-`make live-day` runs this itself, but run it again explicitly — it is the
+`make live-day` runs the audit itself, but run it again explicitly — its output is the
 written evidence:
 
 ```bash
@@ -275,14 +277,16 @@ it is labelled `est.` in the digest for exactly that reason.
 
 Note what that $0.50 is and is not. The per-seat `max_budget_usd` caps in
 `agents/config/*.yaml` sum to **$2.25 worst-case** (analyst $0.50 + pm $0.75 +
-exec $1.00); **expected spend is < $0.50/day**; the real figure is **measured
+exec $1.00); **expected spend is less than $0.50 per day**; the real figure is **measured
 after the first live day**. The caps are backstops against a runaway turn, not
 the expectation — so a day near $2.25 is an incident to investigate, and the
 $0.50 row in §5 is the number that actually gets ticked.
 
 ---
 
-## 5. What ticks what
+## 5. Evidence for each acceptance box
+
+The following table maps each piece of evidence to the acceptance box it ticks:
 
 | Evidence | Where it lands | Acceptance box (`docs/superpowers/specs/2026-08-12-mvf-scope.md` §4) |
 |---|---|---|
@@ -298,7 +302,7 @@ Paste all five into the commit message (or PR body) that ticks the boxes.
 
 ## 6. Abort criteria — read this before you need it
 
-**STOP, capture, report. Do not retry blind.** Re-running a live day after an
+**Warning:** STOP, capture, and report. Do not retry blind. Re-running a live day after an
 unexplained failure is how you turn one bad order into two.
 
 ### The card — every stop condition on one screen
@@ -307,7 +311,7 @@ unexplained failure is how you turn one bad order into two.
 |---|---|---|---|
 | 1 | Hook deny on a live order | `#risk`, run log | An order no ticket authorised. The gate held; the reason it had to is the bug |
 | 2 | Any audit line but `AUDIT CLEAN` | §3 terminal | Each line names its own shape. All counts are ET-day-scoped |
-| 3 | `run_day_failed — …` | `#risk` | Raised BEFORE the audit ran. DB is mid-flight; may be post-order |
+| 3 | `run_day_failed — …` | `#risk` | Raised BEFORE the audit ran. DB is mid-flight; an order might already exist |
 | 4 | An order you did not expect | `#trade-log`, broker | Wrong symbol, wrong side, or qty > ticket `max_qty` |
 | 5 | Paper guard fired | startup | Do NOT export and retry. Find out why it was wrong |
 
@@ -315,12 +319,12 @@ unexplained failure is how you turn one bad order into two.
 audit, checkpoints, decisions, orders, events, broker orders) and report with
 the artefacts attached.
 
-**Re-run ONLY if** it was a crash (killed / slept / network) AND the audit
+**Caution:** Re-run ONLY if the failure was a crash — killed, slept, or network — AND the audit
 shows stages at `running`/`pending` AND no order looks wrong. Checkpoint CAS
 resumes rather than repeats; `client_order_id` idempotency makes a re-placed
 order a broker 422, not a double fill. **When in doubt, do not.**
 
-**Two things that look like aborts and are not:**
+**The following two outcomes look like aborts but are not:**
 - A resumed day reporting `alert events raised: 1` — that is the original
   crash, correctly counted. Read the alert TEXT, not the count. A second,
   different alert (or count > 1) is new and real.
@@ -330,7 +334,7 @@ order a broker 422, not a double fill. **When in doubt, do not.**
 
 ### The detail
 
-Stop immediately on any of:
+Stop immediately if any of the following happens:
 
 1. **A hook deny on a live order.** The seat's `place_*` call came back denied
    by the `PreToolUse` gate. That means an order was attempted that no valid
@@ -341,7 +345,7 @@ Stop immediately on any of:
    `approved`, an order stuck `submitted`, an undrained outbox, a dead-lettered
    event *raised today*, an alert *raised today*, or no cost rows on a day that
    scheduled seat turns. Every count is scoped to the audited ET day, so
-   yesterday's alert never reds today — and the audit's own failure alert is
+   yesterday's alert never fails today's audit — and the audit's own failure alert is
    marked and excluded, so a re-fire cannot compound it.
 3. **`run_day_failed — …` in `#risk`.** Something raised between the DB
    connection and the audit: a stage body, the watchlist/sectors load, or the
@@ -379,7 +383,7 @@ repeats, and `client_order_id` idempotency means a re-placed order is
 
 **A resumed day will NOT print `AUDIT CLEAN`, even on a clean resume, and
 that is expected — do not read it as a fresh abort.** The crash's own
-`run_day_failed` alert (raised by `guarded()`'s except path, BEFORE the audit
+`run_day_failed` alert (raised by the except path of `guarded()`, BEFORE the audit
 ever ran) has no `audit_report` marker on it — only the audit's own
 after-the-fact failure alert carries that, and same-day scoping alone can't
 exclude a genuine alert raised earlier the same ET day. So the resumed run's
@@ -393,7 +397,7 @@ the resume.
 
 **One known non-safety violation to recognise:** if the ONLY audit line is
 `alert events raised: 1` and the alert text starts with `cost_unavailable`,
-the SDK simply did not populate `total_cost_usd` for that turn. The fund
+the SDK did not populate `total_cost_usd` for that turn. The fund
 records no cost row rather than a fake `0.00`. It is still a STOP-and-report —
 capture the `ResultMessage` (see §7) — but it is an accounting gap, not a
 trading fault.
@@ -410,7 +414,7 @@ The first live day deliberately runs **smaller than the design allows**:
 | Analyst `max_turns` | **16** | `agents/config/analyst.yaml` |
 
 Both carry the comment `provisional — right-size from first live
-ResultMessage`. The reason: the analyst charter budgets ≤4 tool calls per
+ResultMessage`. The reason is that the analyst charter budgets ≤4 tool calls per
 ticker, and how the SDK counts a tool call against `max_turns` cannot be
 determined offline. Exhausting the budget degrades safely (the ticker defaults
 to neutral/0), but demo day deserves a real signal — so there is headroom now
@@ -427,11 +431,16 @@ formatting:
 
 ```bash
 grep "turn done:" logs/run_day.out.log
-# run_day: analyst turn done: num_turns=11 est_cost_usd=0.0182
-# run_day: pm turn done: num_turns=6 est_cost_usd=0.0094
 ```
 
-Running interactively, the same lines are on the console. `total_cost_usd` is
+The output is similar to the following:
+
+```
+run_day: analyst turn done: num_turns=11 est_cost_usd=0.0182
+run_day: pm turn done: num_turns=6 est_cost_usd=0.0094
+```
+
+If you run the day interactively, the same lines appear on the console. `total_cost_usd` is
 also in the `costs` table (§4).
 
 Then, in a **follow-up commit**, right-size both values and drop the
@@ -450,8 +459,10 @@ the ceiling before widening the watchlist, not after.
 
 ## 8. After a clean day
 
+Before you copy anything, replace the placeholder path in the unit files, as
+described in README §Scheduling. Then install and enable the timers:
+
 ```bash
-# schedule it (see README §Scheduling — replace the placeholder path first)
 sudo cp ops/fund-*.timer ops/fund-*.service "ops/fund-alert@.service" /etc/systemd/system/
 sudo systemctl daemon-reload
 sudo systemctl enable --now fund-daily.timer fund-pnl.timer fund-backup.timer

--- a/KICKOFF.md
+++ b/KICKOFF.md
@@ -1,8 +1,10 @@
-# Kickoff prompts — fund repo × superpowers
+# Kickoff prompts — fund repo and superpowers
 
 Your doc pack IS the brainstorming output: a validated spec. So you enter the superpowers pipeline at step 2 (`writing-plans`), never re-brainstorm, and repeat plan → execute → review per phase. Prompts below are ready to paste.
 
-## Session 0 — repo assembly + orientation (once, before any planning)
+## Session 0 — repo assembly and orientation
+
+Run this session once, before any planning. Paste the following prompt:
 
 ```
 Read CLAUDE.md, then specs/design.md, specs/contracts.md, specs/acceptance.md,
@@ -20,7 +22,9 @@ Then do two things:
 
 Why: forces full-context reading before any plan exists, surfaces spec bugs while they're cheap, and audits the one pre-built component before anything depends on it.
 
-## Session 1 — plan Phase 1 (`writing-plans`)
+## Session 1 — plan Phase 1
+
+Paste the following prompt to plan Phase 1 with the `writing-plans` skill:
 
 ```
 Planning context: brainstorming is already done. The validated design lives in
@@ -45,7 +49,9 @@ Requirements for the plan:
 Stop after writing the plan. I will review it before execution.
 ```
 
-## Session 2 — execute (`executing-plans`)
+## Session 2 — execute
+
+Paste the following prompt to execute the plan with the `executing-plans` skill:
 
 ```
 Execute plans/phase-1.md with your executing-plans skill. Review checkpoint after
@@ -57,16 +63,18 @@ When the plan is complete: requesting-code-review, with special attention to
 invariant violations (gate purity, idempotency, paper-only, tool-call-only outputs).
 ```
 
-## Later phases — same loop, two adjustments
+## Later phases
 
-- **Phases 2–3** (desk, firm): tasks parallelize well (independent seats, charters, gate math vs. debate mechanics) → use `subagent-driven-development` instead of `executing-plans` at step 2. Keep the same plan-first prompt shape, swapping the phase number and scope line.
+Later phases run the same loop, with two adjustments:
+
+- **Phases 2–3** (desk, firm): tasks parallelize well (independent seats, charters, gate math vs. debate mechanics), so use `subagent-driven-development` instead of `executing-plans` at Session 2. Keep the same plan-first prompt shape, swapping the phase number and scope line.
 - **Phase 5** (the lab): scope line becomes "integration only — fundbt/, stratgate/, and calibration/ are pre-built and tested; extend, don't rewrite" and the plan must start from the Session-0 starter-kit audit findings.
 
-## Worktrees & branches
+## Worktrees and branches
 
 Fresh repo: work on `main` until Phase 1 lands, then one branch per phase with `finishing-a-development-branch` closing each. `using-git-worktrees` becomes worth it from Phase 2 on, when you may want a charter-tuning branch running alongside phase work.
 
-## Prompt principles baked in (so you can adapt them)
+## Principles behind these prompts
 
 These prompts share the following principles:
 

--- a/KICKOFF.md
+++ b/KICKOFF.md
@@ -68,4 +68,13 @@ Fresh repo: work on `main` until Phase 1 lands, then one branch per phase with `
 
 ## Prompt principles baked in (so you can adapt them)
 
-Exact files named, reading order specified · scope fenced to one phase with an explicit "nothing from later phases" · done-criteria checkable and external (acceptance.md), never "when it works" · constraints stated as can't-change invariants · plan externalized to plans/phase-N.md so any future session resumes it · anti-over-engineering clause (spec-minimal) · review gate between plan and execution · deviations surface as questions, not silent fixes.
+These prompts share the following principles:
+
+- Exact files are named, and the reading order is specified.
+- Scope is fenced to one phase, with an explicit "nothing from later phases".
+- Done-criteria are checkable and external (`acceptance.md`), never "when it works".
+- Constraints are stated as invariants that cannot change.
+- The plan is externalized to `plans/phase-N.md`, so any future session can resume it.
+- An anti-over-engineering clause keeps the implementation spec-minimal.
+- A review gate sits between plan and execution.
+- Deviations surface as questions, not silent fixes.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -10,11 +10,13 @@ Update it when a milestone lands or an open item closes — not per commit.
 
 ## Status — 2026-08-18
 
-| | |
+The following table summarizes where the fund stands:
+
+| Item | Value |
 |---|---|
 | **Mode** | Alpaca **paper** only (invariant 1) |
 | **Live since** | 2026-08-17 — first clean end-to-end day |
-| **Tests** | 769 offline green on arm64 at `92ad9f3`; **768 + 1 known failure on x86_64** — see below |
+| **Tests** | 769 offline green on arm64 at `92ad9f3`; **768 + 1 known failure on x86_64** — see Open items |
 | **Watchlist** | NVDA, MSFT, AAPL |
 | **Open position** | NVDA 80 @ 227.09, live stop at 215 |
 | **Scheduled on** | **DigitalOcean droplet `fund-vm` (NYC3, Debian 13, ET clock)** since 2026-08-18 |
@@ -162,7 +164,7 @@ hosts means genuine duplicate orders that `client_order_id` cannot dedupe.
 | `fund-daily.timer` | 09:35 ET Mon–Fri | full trading day, self-audits |
 | `fund-pnl.timer` | 16:35 ET Mon–Fri | posts P&L $ / % vs SPY |
 | `fund-backup.timer` | 17:30 ET daily | atomic, integrity-checked snapshot |
-| `fund-alert@.service` | on any of the above failing | posts the failure to `#risk`, mentioning the operator |
+| `fund-alert@.service` | on any of the preceding three timers failing | posts the failure to `#risk`, mentioning the operator |
 | healthchecks.io `fund-daily` | **when a 09:35 ping does not arrive** | alerts `#risk` + email at 10:20 ET |
 
 The watchdog is off-box on purpose: a dead droplet cannot run its own. It is fed
@@ -231,7 +233,7 @@ either.
 | 2026-08-18 | Slack posts rewritten for a person — mrkdwn, then Block Kit (`02a6848`, `b7bc91e`, `3ae9073`) |
 | 2026-08-18 | workspace cut to one channel per job; host failures split into `#fund-ops` (`92ad9f3`) |
 
-### The one that mattered
+### The stop-leg shape the broker never accepted
 
 `gate/tickets.py` validated a nested `stop_loss: {stop_price}`; the real
 `place_stock_order` takes a **flat** `stop_loss_stop_price` string. Every
@@ -270,7 +272,7 @@ move.
 **Next branches** — each belongs in a **new chat**, per the standing rule that
 new implementation branches get fresh context.
 
-- [ ] **Agent eval.** Scoped: see "Eval scoping" below. Start with the
+- [ ] **Agent eval.** Scoped: see the "Eval scoping" section. Start with the
       injection case at the PM boundary.
 - [ ] **Union asymmetry** in the price-history exclusion (ledgered ruling,
       2026-08-17)
@@ -355,7 +357,7 @@ The three seats, what each can reach, what each writes:
 (`{cash, positions, allowed_actions}`), `journals_root`, `clock`.
 
 **Not injectable**: anything reached through the Alpaca MCP server — news,
-bars, quotes. See the hardcoded `mcp_servers` limitation above.
+bars, quotes. For more information, see the "Known limitations" section.
 
 That split sets the order of work:
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,7 +1,7 @@
 # Progress
 
 Running record of where the fund actually stands. Read this first in a new
-session; `README.md` explains what the system *is*, this explains what it has
+session. `README.md` explains what the system *is*; this file explains what the system has
 *done* and what is *open*.
 
 Update it when a milestone lands or an open item closes — not per commit.
@@ -73,34 +73,34 @@ posts (`b7bc91e`), and a laid-out digest and P&L (`3ae9073`). Every
 `Rejected()` code in `gate/` now has an English gloss, and a static test fails
 if a new code is added without one.
 
-The workspace was reorganised to match:
+The workspace was reorganized to match:
 
-- **`#fund-ops`** now carries host, systemd and deploy failures. A droplet that
+- **`#fund-ops`** now carries host, systemd, and deploy failures. A droplet that
   failed to boot and a position that breached a limit are different
   emergencies with different readers; interleaving them in `#risk` trains you
   to skim both.
 - **`#new-channel` and `#social` archived.** Both were Slack defaults. The
   first had been the rehearsal dumping ground before `#fund-staging` existed.
-- `ops/staging-env.example` still pointed rehearsals at it, so that was fixed
+- `ops/staging-env.example` still pointed rehearsals at `#new-channel`, so that was fixed
   *before* archiving (`92ad9f3`). Order mattered: Slack answers an archived
   channel with `is_archived`, which `RealSlack` classifies as permanent and
   `drain()` dead-letters — a staging day built from that template would have
   lost its whole projection with no error at post time.
 
 Slack scopes now include `chat:write.customize`, `channels:manage`,
-`channels:join` and `channels:history`. **Reinstalling to add a scope does not
+`channels:join`, and `channels:history`. **Reinstalling to add a scope does not
 rotate the bot token** — confirmed twice; `/etc/fund/env` was untouched both
 times.
 
 **Per-agent identity landed** the same day (`f1bbbce`). Each seat posts under
 its own name and face — Nora (Analyst), Vic (PM), Dash (Execution), with Kai
 (Quant) and Ida (Critic) waiting on their charters. Machinery deliberately has
-no persona: the gate, the broker and the orchestrator post as the fund itself,
-because invariant 3 exists to keep the gate free of LLM code and a channel
+no persona: the gate, the broker, and the orchestrator post as the fund itself,
+because invariant 3 exists to keep the gate free of LLM code. A channel
 that gives it a face erases the one distinction a reader most needs.
 
 `RemappedSlack` in `scripts/run_day.py` widened in lockstep with the port —
-worth noting because it is the failure mode that hides: miss it and staging
+this is the failure mode that hides: miss the widening and staging
 loses identity while production keeps it, so the rehearsal is the thing that
 breaks.
 
@@ -108,16 +108,16 @@ breaks.
 
 `agents/seats.py` now launches `alpaca-mcp-server@2.2.1` instead of whatever
 `uvx` resolved that morning. Chosen because it is the version the droplet's warm
-uvx cache already holds *and* PyPI's latest (released 2026-08-10), so the pin
-records today's behaviour rather than changing it — pinning forward would have
+`uvx` cache already holds *and* PyPI's latest (released 2026-08-10), so the pin
+records today's behavior rather than changing it — pinning forward would have
 put a cold download inside the 09:35 launch path, a new failure mode introduced
 by a change whose whole purpose was removing one. Verified by resolving the spec
 `--offline` on the droplet: it returns 2.2.1, and a deliberately wrong pin
-(`@2.1.1`) fails offline, which is what proves the pin is honoured rather than
+(`@2.1.1`) fails offline, which is what proves the pin is honored rather than
 ignored.
 
 **The guard was pointing at the wrong server.**
-`tests/test_live_smoke.py` — the schema pin, the one defence against the
+`tests/test_live_smoke.py` — the schema pin, the one defense against the
 2026-08-17 outage class — launched its own hardcoded `uvx alpaca-mcp-server`
 rather than going through `agents/seats.py`. Pinning only production would have
 left `make schema-pin` validating *latest* while the fund ran 2.2.1: the check
@@ -128,7 +128,7 @@ this was invisible.
 
 **Two more copies of the same drift, caught in review.** `ops/README.md`
 pre-warmed the cache with bare `uvx alpaca-mcp-server`, and the cutover check
-did too. On the next upstream release those warm a version the seats never
+did too. On the next upstream release, those two steps warm a version the seats never
 launch — putting the cold download back inside 09:35, the exact failure the pin
 exists to remove. Both now derive `ALPACA_MCP_SPEC` from the source rather than
 naming a version that rots.
@@ -140,10 +140,10 @@ only way the version can change.
 
 ### The live day, as recorded
 
-All 7 checkpoints `done`, audit clean.
+All seven checkpoints reached `done` and the audit was clean. The stages produced the following:
 
 - **analyst** → 2 signals (NVDA bullish 72%, MSFT bearish 40%)
-- **pm** → 2 decisions: NVDA buy 80 w/ stop 215; MSFT hold 0
+- **pm** → 2 decisions: NVDA buy 80 with stop 215; MSFT hold 0
 - **gate** → 1 ticket, `max_qty` 80, stop 215
 - **exec** → 1 order, filled 80 @ 227.09, `oto` with a flat stop leg
 
@@ -185,11 +185,11 @@ default is HOLD.
 `SIP_DELAY` (16 min), so a 16:15 fire asks for 15:59 — before the closing
 auction writes the bar.
 
-Full layout, cutover and rollback procedure: `ops/README.md`.
+Full layout, cutover, and rollback procedure: `ops/README.md`.
 
 ### The Mac after cutover
 
-`com.fund.pull-backups` is the **only** fund launchd job that should exist here.
+`com.fund.pull-backups` must be the **only** fund launchd job on the Mac.
 `com.fund.daily.plist` was moved out of `~/Library/LaunchAgents` to
 `~/fund-rollback/`, and `.env` was renamed to `.env.MIGRATED-TO-VM` — two
 independent barriers, because `launchctl unload` is session-scoped and
@@ -210,7 +210,7 @@ by construction, not by anyone remembering.
 `run_day.py:25-34` documents a pre-Slack window that posts nothing on failure,
 justified because "the exit is non-zero with a descriptive stderr message, so
 it is a visible failure, just not a Slack one." That premise assumed a human at
-the machine. On a droplet it is false, so systemd `OnFailure=` restores it —
+the machine. On a droplet that premise is false, so systemd `OnFailure=` restores the missing alert —
 verified against a start failure, which is the case the script itself cannot
 cover. Known gap: if the Slack token is what broke, the alert cannot post
 either.
@@ -244,7 +244,7 @@ The entire offline suite was green over a total outage, because
 `tests/fake_alpaca.py` and the recordings encoded the *same* wrong assumption as
 the code. Fixture and code agreed with each other and both disagreed with
 Alpaca. That is why `make schema-pin` exists and why it is step §0b of the
-runbook: it introspects the live server's schema and fails if the field names
+`HANDOFF-LIVE.md` runbook: it introspects the live server's schema and fails if the field names
 move.
 
 ---
@@ -257,11 +257,11 @@ move.
       `data_snapshot_hash` cannot be reproduced on x86_64, so `make test` is
       708/709 on the droplet. Root cause, measured not guessed: `rng.uniform`
       computes `low + (high-low)*x`, and arm64 and x86_64 contract that into FMA
-      differently, so `vol[0]` differs by **1 ULP at the very first draw**
+      differently, so `vol[0]` differs by **one unit in the last place (ULP) at the very first draw**
       (`0x1.6974569e58a45p-6` vs `...44p-6`) and 2520 iterations amplify it. The
       RNG integer stream is identical and the `DIP_PCT` branch is *not* the
       culprit — kick counts match exactly (4837) on both.
-      **Verified fix:** quantizing the market makes hashes bit-identical at 8dp
+      **Verified fix:** quantizing the market makes hashes bit-identical at 8 decimal places
       or coarser (10dp and finer still diverge); `close.round(6)` in
       `tests/synthetic.py` is one line. The work is the re-record: 16 pinned
       values across two tests, and the fixture's *meaning* must survive — golden
@@ -276,7 +276,7 @@ new implementation branches get fresh context.
       injection case at the PM boundary.
 - [ ] **Union asymmetry** in the price-history exclusion (ledgered ruling,
       2026-08-17)
-- [ ] **Resolutions / reflection loop** — nothing currently closes the feedback
+- [ ] **Resolutions and reflection loop** — nothing closes the feedback
       cycle from outcome back into analyst calibration
 - [ ] **Second analyst seat** — the debate mechanic in the design has one voice
 - [ ] README demo recording
@@ -291,7 +291,7 @@ new implementation branches get fresh context.
       `equity × vol_tier × corr_mult ≥ price` (`gate/risk.py:87-91`). At $100
       the budget is $20–27, so the current watchlist rejects `no_headroom`
       every single day, and fitting the money would mean swapping to sub-$10
-      high-vol names — i.e. modifying the system in order to demonstrate it.
+      high-vol names — that is, modifying the system to demonstrate it.
       At ~$1,200 NVDA and AAPL clear, and the live system is **identical** to
       the one with a clean-day record. Downside is bounded by the balance.
 
@@ -340,7 +340,7 @@ new implementation branches get fresh context.
 
 ## Eval scoping
 
-The three seats, what each can reach, what each writes:
+The following table lists the three seats, what each can reach, and what each writes:
 
 | | analyst | pm | exec |
 |---|---|---|---|
@@ -361,7 +361,7 @@ bars, quotes. For more information, see the "Known limitations" section.
 
 That split sets the order of work:
 
-- **PM evals need zero new plumbing** — its entire decision input is the brief,
+- **PM evals need zero new plumbing** — the PM's entire decision input is the brief,
   and you own all of it.
 - **Analyst evals need the MCP seam built first**, because its evidence comes
   off the network.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Agents decide inside a deterministic control envelope. That is the whole idea.
 
 ## Architecture
 
+The following diagram traces one market day, from the scheduled fire to the
+Slack projection, with SQLite as the source of truth and Slack as a read-only
+projection of it:
+
 ```
                        ┌──────────────── one fire per market day ─────────────┐
                        │  launchd 09:35 ET  ->  scripts/run_day.py            │
@@ -213,7 +217,7 @@ schedule) are built and green offline: **556 tests, purity lint clean**.
     exec     filled 80 @ 227.09, oto + stop leg     3 turns   $0.0332
     AUDIT CLEAN 2026-08-17, zero alerts             total     $0.1997
 
-The first run that morning FAILED and the postmortem is worth reading before
+The first run that morning failed, and the postmortem is worth reading before
 trusting anything here: the gate validated a nested stop-leg shape the broker
 has never exposed, so every ticket carrying a stop was undeliverable — and the
 whole offline suite was green over it, because the fixtures encoded the same

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A multi-agent paper-trading firm on the [Claude Agent SDK](https://docs.claude.com/en/api/agent-sdk/overview).
 Analyst and PM agents make a real decision each morning from live market data
-via their own tool calls. Between every LLM decision and every broker order
+through their own tool calls. Between every LLM decision and every broker order
 sits a **deterministic Python gate** that no agent can talk its way past.
 
 Agents decide inside a deterministic control envelope. That is the whole idea.
@@ -62,6 +62,8 @@ projection of it:
 Reading it in one line: **agents → MCP tools → deterministic gate → hook → broker**,
 with SQLite as the source of truth and Slack as a read-only projection of it.
 
+The following table lists each package, what it does, and whether it contains LLM code:
+
 | Package | Role | LLM code? |
 |---|---|---|
 | `scripts/run_day.py` | the live composition root — real clock, Slack, Alpaca, seats | wires it |
@@ -73,7 +75,7 @@ with SQLite as the source of truth and Slack as a read-only projection of it.
 | `slackkit/` | outbox, renderers, real/fake Slack ports | **no** |
 | `fundbt/` `stratgate/` `calibration/` | research stack: backtests, strategy gates G1–G4, analyst scoring | **no** |
 
-`gate/`, `stratgate/`, `calibration/`, `orchestrator/` and `state/` are held
+`gate/`, `stratgate/`, `calibration/`, `orchestrator/`, and `state/` are held
 LLM-free by an AST lint (`scripts/check_purity.py`) that runs in `make test`.
 
 ## What it does
@@ -83,28 +85,30 @@ LLM-free by an AST lint (`scripts/check_purity.py`) that runs in `make test`.
   choose HOLD on a boring day. Neither can place an order.
 - **A deterministic risk gate.** Volatility tiers, correlation multipliers, a
   cash cap, an 8-position limit, a 60% sector cap with resize, and a −3% daily
-  circuit breaker — one code path serves both the advisory pre-gate and the
+  circuit breaker. One code path serves both the advisory pre-gate and the
   enforcement pass, so what the PM was shown is what the gate enforces
   (`tests/test_sim_day.py::test_pm_brief_carries_the_signal_and_the_budget_the_gate_enforces`).
 - **A hook that cannot be argued with.** A `PreToolUse` hook denies any order
   without an open, unexpired gate ticket. Hooks run before permission rules;
-  the agent's only path to the broker goes through it.
+  the agent's only path to the broker goes through the hook.
 - **Idempotent execution.** `client_order_id` is always the ticket id, so a
   retry is 422-rejected by the broker rather than double-filled.
 - **Default HOLD, everywhere.** A missing analyst signal becomes neutral/0; a
   silent PM becomes hold/0 plus an alert; a NaN in the feed rejects the trade;
   an unreadable market clock skips the day. Every one of those is a test.
-- **Slack as the firm's UI.** Signals, gate verdicts, fills and the EOD digest
+- **Slack as the firm's UI.** Signals, gate verdicts, fills, and the end-of-day (EOD) digest
   are projected from an outbox with per-event dead-lettering.
 - **Structured output only.** Agents emit data through MCP tool schemas that
-  are advisory to the model (the pinned SDK has no `strict=True`); the
+  are advisory to the model, because the pinned SDK has no `strict=True`. The
   pydantic handler validates every safety-relevant constraint, so no code
-  anywhere parses a ticker, an action or a size out of free text.
+  anywhere parses a ticker, an action, or a size out of free text.
 - **Record/replay test suite.** 518 offline tests including six full simulated
-  day shapes that run the real gate, hooks, tools, DB and fill-poll against
+  day shapes that run the real gate, hooks, tools, DB, and fill-poll against
   recorded LLM decisions — no network, no API keys, $0 of inference.
 
 ## Run it
+
+The following targets cover the offline suite, a simulated day, and one real day:
 
 ```bash
 make test         # full offline suite + purity lint. No network, no keys.
@@ -112,7 +116,7 @@ make sim-day      # six simulated day shapes: real everything, recorded LLM
 make live-day     # ONE real day: real Slack + Alpaca paper + real LLM seats
 ```
 
-Live runs need `.env` (copy `.env.example`) loaded into the shell:
+Live runs need a `.env` file, copied from `.env.example`. Load it into the shell:
 
 ```bash
 set -a; source .env; set +a
@@ -131,10 +135,12 @@ criteria.
 ### Scheduling
 
 One fire per market day — no daemon. The day is a sequential process that
-exits; checkpoint CAS makes a re-fire resume rather than repeat.
+exits; a checkpoint compare-and-swap (CAS) makes a re-fire resume rather than repeat.
 
-**launchd (macOS).** Replace `/ABSOLUTE/PATH/TO/fund` in
-`ops/com.fund.daily.plist` with this checkout's path, then:
+#### Schedule with launchd (macOS)
+
+Replace `/ABSOLUTE/PATH/TO/fund` in `ops/com.fund.daily.plist` with this
+checkout's path, then run:
 
 ```bash
 cp ops/com.fund.daily.plist ~/Library/LaunchAgents/
@@ -143,7 +149,10 @@ launchctl list | grep com.fund.daily
 # stop with: launchctl unload ~/Library/LaunchAgents/com.fund.daily.plist
 ```
 
-**cron (alternative).**
+#### Schedule with cron
+
+If you don't use launchd, add the following crontab entry instead, replacing
+`/ABSOLUTE/PATH/TO/fund` with this checkout's path:
 
 ```cron
 TZ=America/New_York
@@ -152,7 +161,7 @@ TZ=America/New_York
 
 Both fire at 09:35 ET, Mon–Fri. launchd's `StartCalendarInterval` uses the
 machine's **local** time and ignores `TZ`, so the plist is correct only on a
-machine set to America/New_York — cron's `TZ=` line does honour it.
+machine set to America/New_York. In a crontab, the `TZ=` line does honor the time zone.
 Market holidays and early closes need no schedule change: the run exits 0 on
 the broker's clock.
 
@@ -167,7 +176,7 @@ sudo pmset repeat wakeorpoweron MTWRF 06:30:00   # 5 min before a 06:35 local fi
 pmset -g sched                                    # verify it registered
 ```
 
-You also stay logged in: a LaunchAgent runs in your user session, not as a
+You must also stay logged in: a LaunchAgent runs in your user session, not as a
 daemon. A laptop is a poor host for this — the first trip with the lid shut is
 a day that silently does not happen.
 
@@ -183,12 +192,12 @@ one.
 Runtime is Haiku-tier for the analyst and exec seats, Sonnet-tier for the PM
 (a strong tier for the PM is deliberate — `specs/design.md` §2), with per-seat
 `max_budget_usd` caps in
-`agents/config/*.yaml` — never hardcoded. Three seat turns at MVF's watchlist
+`agents/config/*.yaml` — never hardcoded. Three seat turns at the Minimum Viable Firm (MVF) watchlist
 size is the whole daily spend, and a HOLD day skips the execution turn
 entirely (zero tickets → no LLM call).
 
-The caps are **backstops, not the expectation**, and the two numbers are not
-the same number: **caps sum to $2.25 worst-case** (analyst $0.50 + pm $0.75 +
+The caps are **backstops, not the expectation**, and the caps and the
+expected spend are different numbers: **caps sum to $2.25 worst-case** (analyst $0.50 + pm $0.75 +
 exec $1.00); **expected spend is < $0.50/day**; **measured after the first
 live day**. What bounds the expectation is the watchlist size and each seat's
 `max_turns`, not the caps — a day that actually hits $2.25 is a runaway to
@@ -196,7 +205,7 @@ investigate, not a budget that was spent as designed.
 
 Every turn's cost is recorded to the `costs` table and summed into the EOD
 digest. `ResultMessage.total_cost_usd` is a **client-side estimate**, so it is
-labelled `est.` everywhere it is surfaced. When the SDK does not populate it,
+labeled `est.` everywhere it is surfaced. When the SDK does not populate it,
 the fund records no row and raises an alert rather than writing a `0.00` that
 would make real spend look free.
 
@@ -210,7 +219,7 @@ fund MCP tools, analyst + PM seats, daily loop, fill-poll, digest, audit,
 schedule) are built and green offline: **556 tests, purity lint clean**.
 
 **Live since 2026-08-17.** All nine MVF acceptance boxes are ticked
-(`docs/superpowers/specs/2026-08-12-mvf-scope.md` §4). That day's clean run:
+(`docs/superpowers/specs/2026-08-12-mvf-scope.md` §4). The following output shows that day's clean run:
 
     analyst  NVDA bullish 72 · MSFT neutral 40      7 turns   $0.0504
     pm       NVDA buy 80 @ stop 215 · MSFT hold     5 turns   $0.1161
@@ -226,8 +235,8 @@ with Alpaca. `make schema-pin` now asks the real server before every live day;
 no offline test can catch that class of bug. The failed run's red audit is kept
 in `state/fund-2026-08-17-incident.sqlite`.
 
-Next: the resolutions/reflection loop (decisions currently produce no scored
-outcomes, so `calibration/` has never been fed), then the second analyst seat.
+Next: the resolutions and reflection loop, then the second analyst seat.
+Decisions produce no scored outcomes, so `calibration/` has never been fed.
 
 ## Map of the repo
 
@@ -243,14 +252,14 @@ outcomes, so `calibration/` has never been fed), then the second analyst seat.
 
 ### Research stack
 
-`fundbt/` (backtest engine + trial registry), `stratgate/` (DSR/PSR/MinTRL/WFE
-statistics and the G2/G3 evaluators) and `calibration/` (Brier/BSS scoring →
-deterministic PM weights) are pre-built and tested. Rules they inherit:
+`fundbt/` (backtest engine + trial registry), `stratgate/` (deflated Sharpe (DSR), probabilistic Sharpe (PSR), minimum track record length (MinTRL) and walk-forward efficiency (WFE)
+statistics and the G2/G3 evaluators), and `calibration/` (Brier/BSS scoring →
+deterministic PM weights) are pre-built and tested. Those three packages inherit the following rules:
 
-- LLMs hypothesise; code validates. Nothing in those packages imports LLM code.
+- LLMs hypothesize; code validates. Nothing in those packages imports LLM code.
 - Default is REJECT: NaN/missing/malformed anywhere → the strategy does not advance.
 - Every backtest logs a trial row; family-wide N feeds the deflated Sharpe.
-- The holdout is consumed exactly once per spec, enforced by a PRIMARY KEY.
+- The holdout is consumed exactly once per spec, enforced by a `PRIMARY KEY` constraint.
 - Cost floors are constants, not parameters.
 
 Run a backtest only through the `run_backtest` tool — an unlogged trial

--- a/agents/exec_turn.py
+++ b/agents/exec_turn.py
@@ -60,7 +60,7 @@ async def await_servers_connected(
         poll_s: float = 0.5,
         sleep: Callable[[float], Awaitable[None]] = asyncio.sleep) -> None:
     """(c) live gate: poll client.get_mcp_status() until every required server
-    is 'connected', or raise ExecTurnViolation once timeout_s elapses. `sleep`
+    is 'connected', or raise ExecTurnViolation after timeout_s elapses. `sleep`
     is injected so the wait is deterministic in tests (no wall clock)."""
     elapsed = 0.0
     while True:
@@ -140,7 +140,7 @@ def check_tool_calls(tool_names: list[str], open_ticket_count: int = 0) -> None:
 
     (c) is the first live day's lesson (2026-08-17). The seat read
     list_open_tickets, never reached a place_* call, and (a) passed it because
-    it HAD called a tool. A turn holding an authorised ticket that never even
+    it HAD called a tool. A turn holding an authorized ticket that never even
     attempts to place it is the same silent no-op (a) exists to catch, one
     step further in. This asserts on the ATTEMPT, not the outcome: a denied or
     broker-rejected placement is a different failure, reported elsewhere, and

--- a/agents/replay.py
+++ b/agents/replay.py
@@ -18,6 +18,9 @@ def load_recording(path: str | Path) -> list[dict]:
 async def replay_turn(decisions: list[dict], *, pre_hooks: list,
                       executor: Callable[[str, dict], object],
                       post_hooks: list) -> list[dict]:
+    """Run recorded decisions through the real hooks, in order. Returns one
+    outcome per decision: {"tool", "denied"} when a PreToolUse hook denied it,
+    {"tool", "result"} otherwise."""
     outcomes: list[dict] = []
     for i, d in enumerate(decisions):
         input_data = {"tool_name": d["tool"], "tool_input": d["args"]}

--- a/agents/runtime.py
+++ b/agents/runtime.py
@@ -34,7 +34,7 @@ def _cached(conn_factory):
 
 
 def _deny_alert_text(tool_input, reason) -> str:
-    """Name the ticker, the reason and the 8-char ticket id. The input of a
+    """Name the ticker, the reason, and the 8-char ticket id. The input of a
     DENIED order is untrusted by construction — a malformed-input deny is the
     normal case — so every field degrades to '?' and this never raises."""
     ti = tool_input if isinstance(tool_input, dict) else {}
@@ -57,8 +57,10 @@ def make_order_gate(conn_factory: Callable[[], sqlite3.Connection],
             ok, reason = validate_order(conn(),
                                         input_data.get("tool_input"),
                                         iso(clock.now()))
-        except Exception as exc:  # fail closed (invariant 4): never let an
-            ok, reason = False, f"gate error: {exc}"  # internal error allow
+        # Fail closed (invariant 4): never let an internal error allow the
+        # order.
+        except Exception as exc:
+            ok, reason = False, f"gate error: {exc}"
         if ok:
             return {}
         denial = {"hookSpecificOutput": {
@@ -74,8 +76,9 @@ def make_order_gate(conn_factory: Callable[[], sqlite3.Connection],
             append_event(conn(), "alert", {
                 "text": _deny_alert_text(input_data.get("tool_input"), reason)},
                 iso(clock.now()))
-        except Exception as exc:      # logged, never silent: if this path is
-            log.error(               # broken, denies go dark again and the
+        # Logged, never silent: if this path is broken, denies go dark again.
+        except Exception as exc:
+            log.error(
                 "order gate: DENIED %s but could not record the alert —"
                 " %s: %s; the denial still stands",
                 _deny_alert_text(input_data.get("tool_input"), reason),
@@ -91,7 +94,7 @@ def _extract_order(tool_response):
     under ``data`` with an ``_alpaca_mcp_security`` envelope; FakeAlpaca and the
     offline fixtures return the order dict directly. A rejection (``error`` key,
     or Alpaca ``code``/``message``) -> None: invariant 4, a rejection is never
-    recorded. Numeric fields may be strings ("67") and prices may be null."""
+    recorded. Numeric fields can be strings ("67") and prices can be null."""
     obj = tool_response
     if isinstance(obj, str):
         try:
@@ -111,10 +114,10 @@ def _extract_order(tool_response):
 
 def _parse_fill(order: dict) -> tuple[int | None, float | None]:
     """Coerce filled_qty/filled_avg_price into locals, never raising: returns
-    (None, None) for anything malformed (missing, null, non-positive, or a
-    fractional qty — this fund is whole-share only; orders.filled_qty is
+    (None, None) for anything malformed — missing, null, non-positive, or a
+    fractional qty. This fund is whole-share only and orders.filled_qty is
     INTEGER, so a fractional fill is an anomaly, not something to floor
-    silently). Callers must check for None before transitioning anything."""
+    silently. Callers must check for None before transitioning anything."""
     try:
         raw_qty = float(order["filled_qty"])
         avg_price = float(order["filled_avg_price"])
@@ -130,7 +133,7 @@ def make_order_recorder(conn_factory: Callable[[], sqlite3.Connection],
     """PostToolUse on place_*: mirror the broker's answer into SQLite.
     Idempotent under retry: INSERT OR IGNORE + CAS transitions; the fill
     event is appended only when the order CAS submitted->filled wins.
-    Parses the real MCP envelope (JSON string + `data`) via _extract_order."""
+    Parses the real MCP envelope (JSON string + `data`) with _extract_order."""
     conn_get = _cached(conn_factory)
 
     async def record_order(input_data, tool_use_id, context) -> dict:
@@ -138,7 +141,9 @@ def make_order_recorder(conn_factory: Callable[[], sqlite3.Connection],
             return {}
         order = _extract_order(input_data.get("tool_response"))
         if order is None:
-            return {}  # nothing landed; retry/reconcile is the turn's job (§5.1)
+            # Nothing landed; retry/reconcile is the turn's job
+            # (contracts §5.1).
+            return {}
         conn = conn_get()
         now = iso(clock.now())
         coid = order["client_order_id"]
@@ -151,7 +156,7 @@ def make_order_recorder(conn_factory: Callable[[], sqlite3.Connection],
         conn.commit()
         try_transition(conn, "tickets", {"id": coid}, "open", "consumed", now)
         # A market order acks 'accepted' first; the fill (and thus the fill
-        # event + decision->executed) only lands once status is 'filled' —
+        # event + decision->executed) only lands after status is 'filled' —
         # async fills reconcile on a later turn (Phase 2). Recording the order
         # row + consuming the ticket above is unconditional and idempotent.
         if order.get("status") == "filled":
@@ -203,8 +208,8 @@ def make_decision_recorder(path: str | Path, seat: str):
 
 def record_cost(conn: sqlite3.Connection, run_date: str, agent: str,
                 session_id: str, usd_estimate: float, now_iso: str) -> None:
-    """ResultMessage.total_cost_usd is a client-side ESTIMATE — label 'est.'
-    wherever surfaced (CLAUDE.md)."""
+    """Insert one cost row for a seat turn. ResultMessage.total_cost_usd is a
+    client-side ESTIMATE — label 'est.' wherever surfaced (CLAUDE.md)."""
     conn.execute(
         "INSERT INTO costs (run_date, agent, session_id, usd_estimate,"
         " recorded_at) VALUES (?, ?, ?, ?, ?)",
@@ -224,7 +229,7 @@ def record_turn_result(conn: sqlite3.Connection, run_date: str, seat: str,
     same code the live day runs.
 
     total_cost_usd is Optional[float] in the SDK and is NOT always populated.
-    When it is missing/None/non-finite we write NO cost row and append one
+    When it is missing/None/non-finite this writes NO cost row and appends one
     `alert` instead. Deliberate: costs.usd_estimate is REAL NOT NULL, so the
     only alternatives are a fabricated 0.0 (which would make real spend look
     free in the digest and in the ≤$0.50/day acceptance box) or silence
@@ -239,7 +244,7 @@ def record_turn_result(conn: sqlite3.Connection, run_date: str, seat: str,
     record_cost_guarded() — cost accounting must never take down trading
     (invariant 4), but it must not lie about itself either.
 
-    Returns True iff a cost row was written."""
+    Returns True if a cost row was written; False otherwise."""
     usd = getattr(result, "total_cost_usd", None)
     session_id = str(getattr(result, "session_id", None) or "unknown")
     if isinstance(usd, bool) or not isinstance(usd, (int, float)) \

--- a/agents/seats.py
+++ b/agents/seats.py
@@ -20,11 +20,12 @@ CHARTERS_DIR = Path(__file__).resolve().parents[1] / "charters"
 # 09:35, on a host that trades. An upstream release moving a tool-schema field
 # name overnight is exactly the 2026-08-17 outage class, and `make schema-pin`
 # only defends when someone remembers to run it. Pinned to what the droplet's
-# warm uvx cache already resolves, so this makes today's behaviour explicit
+# warm uvx cache already resolves, so this makes today's behavior explicit
 # rather than changing it — no cold fetch lands in the launch path.
 # tests/test_live_smoke.py's schema pin and ops/README.md's cache pre-warm both
-# derive THIS spec: the guard, the warm cache and the thing guarded cannot drift
-# apart. An upgrade is a deliberate commit with a green `make schema-pin`.
+# derive THIS spec: the guard, the warm cache, and the thing guarded cannot
+# drift apart. An upgrade is a deliberate commit with a green
+# `make schema-pin`.
 ALPACA_MCP_SPEC = "alpaca-mcp-server@2.2.1"
 
 
@@ -34,7 +35,8 @@ def load_seat_config(path: str | Path) -> dict:
 
 def build_seat_options(cfg: dict, db_path: str | Path, clock: Clock, *,
                        snapshot=None, journals_root=None) -> ClaudeAgentOptions:
-    """`snapshot` (zero-arg -> {cash, positions, allowed_actions}) and
+    """Build one seat's ClaudeAgentOptions from its yaml config.
+    `snapshot` (zero-arg -> {cash, positions, allowed_actions}) and
     `journals_root` are this day's stage-brief providers, injected the same
     way the DB and the clock are. Unbound (the default) is legal and safe:
     get_stage_brief then reports the section as unavailable instead of
@@ -55,7 +57,7 @@ def build_seat_options(cfg: dict, db_path: str | Path, clock: Clock, *,
         tools=cfg["tools"],
         # No settings source: no CLAUDE.md, no project/local settings.json feed
         # this seat's context or permission surface. Invariants live in the
-        # charter. Per-seat via cfg; default [] never loads a dev file.
+        # charter. Per-seat from cfg; default [] never loads a dev file.
         setting_sources=cfg.get("setting_sources", []),
         mcp_servers={
             "alpaca": {"command": "uvx", "args": [ALPACA_MCP_SPEC],
@@ -66,9 +68,10 @@ def build_seat_options(cfg: dict, db_path: str | Path, clock: Clock, *,
                                       journals_root=journals_root),
         },
         allowed_tools=["mcp__alpaca__*", "mcp__fund__*"],
-        # Belt over the toolset brace (invariant 2): every non-trading seat's
-        # yaml sets this to deny mcp__alpaca__place_* even if ALPACA_TOOLSETS
-        # is ever misconfigured server-side. Absent for the trading seat.
+        # A second guard over the toolset restriction (invariant 2): every
+        # non-trading seat's yaml sets this to deny mcp__alpaca__place_* even
+        # if ALPACA_TOOLSETS is ever misconfigured server-side. Absent for the
+        # trading seat.
         disallowed_tools=cfg.get("disallowed_tools"),
     )
     # Order gate + recorder hooks belong ONLY to the seat that carries the

--- a/agents/tools/fund_server.py
+++ b/agents/tools/fund_server.py
@@ -25,7 +25,7 @@ from state.models import Decision, Signal
 SIGNAL_SEATS = ("analyst",)
 DECISION_SEATS = ("pm",)
 BRIEF_SEATS = ("analyst", "pm")
-JOURNAL_ENTRIES = 3          # how many past days a seat is shown of its own log
+JOURNAL_ENTRIES = 3          # how many past days of its own log a seat is shown
 
 
 def run_date_from_clock(clock: Clock) -> str:
@@ -68,7 +68,7 @@ def handle_submit_decision(conn: sqlite3.Connection, *, seat: str, args: dict,
     """Validate + UPSERT the PM's final decision, append a projection event.
     Refuses if no critique row exists yet for (run_date, ticker) — enforces
     the draft -> critique -> final ordering (contracts §4). Refuses outright
-    once the decision has left 'submitted' (contracts §4 ruling 2026-08-13,
+    after the decision has left 'submitted' (contracts §4 ruling 2026-08-13,
     "Irrevocable for the day"): a mutable thesis/qty behind a live ticket
     would rewrite the audit trail the gate approved against. Wrong seat,
     invalid payload, missing critique, or non-'submitted' status: no row, no

--- a/agents/wallclock.py
+++ b/agents/wallclock.py
@@ -1,5 +1,5 @@
 """The one real-clock implementation. Lives outside the purity-linted
-packages (orchestrator/ may not call datetime.now); injected at composition
+packages (orchestrator/ must not call datetime.now); injected at composition
 roots only — live-paper mode and the @live smoke test."""
 
 from datetime import datetime, timezone

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,14 +1,16 @@
-# Domain Docs
+# Domain docs
 
 How the engineering skills should consume this repo's domain documentation when exploring the codebase.
 
-## Before exploring, read these
+## Before exploring, read the domain docs
 
-- **`CONTEXT.md`** at the repo root, or
-- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
-- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+Before you explore the codebase, read the following files:
 
-If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+- **`CONTEXT.md`** at the repo root.
+- **`CONTEXT-MAP.md`** — if this file exists at the repo root, read it instead of `CONTEXT.md`. It points at one `CONTEXT.md` per context; read each one relevant to the topic.
+- **`docs/adr/`** — read the architecture decision records (ADRs) that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached through `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
 
 ## File structure
 
@@ -40,13 +42,13 @@ Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
 
 ## Use the glossary's vocabulary
 
-When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, or a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms that the glossary explicitly avoids.
 
-If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+If the concept you need isn't in the glossary yet, that's a signal. Either you're inventing language that the project doesn't use — in that case, reconsider the term — or there's a real gap, so note it for `/domain-modeling`.
 
 ## Flag ADR conflicts
 
-If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+If your output contradicts an existing ADR, surface the conflict explicitly rather than silently overriding the ADR:
 
 > _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_
 

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -5,13 +5,13 @@ Issues and specs for this repo live as GitHub issues. Use the `gh` CLI for all o
 ## Conventions
 
 - **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
-- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **Read an issue**: `gh issue view <number> --comments`. Filter the comments with `jq`, and also fetch the labels.
 - **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
 - **Comment on an issue**: `gh issue comment <number> --body "..."`
-- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
-- **Close**: `gh issue close <number> --comment "..."`
+- **Apply or remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close an issue**: `gh issue close <number> --comment "..."`
 
-Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+`gh` infers the repo from `git remote -v` automatically when you run it inside a clone.
 
 ## Pull requests as a triage surface
 
@@ -21,9 +21,9 @@ When set to `yes`, PRs run through the same labels and states as issues, using t
 
 - **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
 - **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
-- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+- **Comment on, label, or close a PR**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
 
-GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+GitHub shares one number space across issues and PRs, so a bare `#42` might be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
 
 ## When a skill says "publish to the issue tracker"
 
@@ -35,11 +35,11 @@ Run `gh issue view <number> --comments`.
 
 ## Wayfinding operations
 
-Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+The `/wayfinder` command uses these operations. The *map* is a single issue with *child* issues as tickets.
 
-- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
-- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Map**: a single issue labeled `wayfinder:map`, holding a body with Notes, Decisions-so-far, and Fog sections. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). After the ticket is claimed, it's assigned to the driving dev.
 - **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
-- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
-- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
-- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.
+- **Frontier query**: list the map's open children with `gh issue list --state open`, scoped to the map's sub-issues or task list. Drop any child that has an assignee, and any child with an open blocker — that is, `issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line. The first remaining child in map order wins.
+- **Claim**: `gh issue edit <number> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <number> --body "<answer>"`, then `gh issue close <number>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/superpowers/plans/2026-08-17-vm-migration.md
+++ b/docs/superpowers/plans/2026-08-17-vm-migration.md
@@ -864,7 +864,7 @@ git push origin master
 
 ---
 
-# PART B — provisioning (requires the droplet)
+## Part B — provisioning (requires the droplet)
 
 > **Human gate.** `doctl` is not installed and the droplet does not exist.
 > Benjamin creates it in the DigitalOcean console and supplies SSH access
@@ -1238,7 +1238,7 @@ supervised, not scheduled.
 
 ---
 
-# PART C — cutover
+## Part C — cutover
 
 ## Task 11: Silence the Mac, transfer, enable
 

--- a/docs/superpowers/specs/2026-07-12-phase-2-desk-design.md
+++ b/docs/superpowers/specs/2026-07-12-phase-2-desk-design.md
@@ -119,14 +119,14 @@ turn** — acceptance asserts **zero agent turns** are spent on it (cost control
 the full input space (vols, correlations, prices, equity, cash, positions, sector weights, daily
 P&L, held_qty). The Kelly-framed invariants from the kickoff (monotonicity in edge, zero-edge
 limit, fractional-vs-full Kelly ordering) **do not apply** — the gate has no edge input. The set
-below is the tiered-gate replacement; items marked ★ were **not** in the kickoff list and are
+that follows is the tiered-gate replacement; items marked ★ were **not** in the kickoff list and are
 argued for.
 
 1. **Vol-tier non-increasing.** Higher vol ⟹ base-limit % never rises. Boundary cases 14.9 / 15 /
    49.9 / 50 / 50.1.
 2. **Correlation-multiplier non-increasing** in correlation. Boundaries 0.2 / 0.4 / 0.6 / 0.8
    (lower-inclusive per §2.4).
-3. **Caps hold under ALL inputs (master property).** For every generated input, the output
+3. **Caps hold under all inputs (master property).** For every generated input, the output
    `max_qty·price` simultaneously respects the vol dollar-limit, cash, post-trade sector cap, and
    position count — or the gate REJECTs. No input yields a qty that breaches any cap.
 4. **Cash never over-spent.** A buy's `max_qty·price ≤ available cash`.
@@ -134,7 +134,7 @@ argued for.
    so they are scale-free; dollar exposure is homogeneous degree 1 in equity. Scaling equity and
    price by a common k leaves the integer share count unchanged (modulo the floor); scaling equity
    alone by k scales the dollar limit by k. A violation means a unit/absolute-threshold bug.
-6. **Integer floor, rounded DOWN. ★** `max_qty` is always a non-negative integer, floored not
+6. **Integer floor, rounded *down*. ★** `max_qty` is always a non-negative integer, floored not
    rounded. One share over a boundary tips the 60% sector cap or spends cash the account lacks
    (67 vs 68 is a money bug). The kickoff's "caps hold" implies this but the rounding *direction*
    must be asserted independently.
@@ -206,7 +206,7 @@ Behaviors covered (each an assertion that runs identically on both arms):
    `qty`/`filled_qty` string-typed; `filled_avg_price` null until fill; `order_class` `""` for a
    simple order, `"oto"` for a stop exit. (BUG A/B origin.)
 2. **Accepted-not-filled** — a fresh market order acks `status="accepted"`, `filled_qty="0"`,
-   `filled_avg_price=null` (NOT filled). (BUG B / async.)
+   `filled_avg_price=null` (*not* filled). (BUG B / async.)
 3. **Async full fill** — after `tick()`/poll, `get_order_by_client_order_id` reports
    `status="filled"`, `filled_qty==qty`, `filled_avg_price` set.
 4. **Partial fill** — `status="partially_filled"`, `0 < filled_qty < qty`; shape + recorder

--- a/docs/superpowers/specs/2026-08-17-vm-migration-design.md
+++ b/docs/superpowers/specs/2026-08-17-vm-migration-design.md
@@ -199,7 +199,7 @@ group.
 holding only `SLACK_BOT_TOKEN` and the channel — never `/etc/fund/env`. If the
 alert shared the main env file, then the single most likely fresh-VM failure
 (a missing or unreadable env file) would break the job *and* its alert
-identically, and the coverage claim below would be false.
+identically, and the coverage claim that follows would be false.
 
 **Redact before posting** (review A4). The journal tail is filtered for
 `sk-ant-`, `xoxb-`, `xapp-`, and `PK` prefixes before it reaches Slack. A
@@ -276,9 +276,9 @@ belongs immediately **before** the final transfer.
 |---|---|---|---|
 | 0 — prep | delete orphan `fund-2026-08-17-rerun.sqlite-{wal,shm}`; `sqlite3 .backup` → snapshot | — | nothing changes |
 | 1 — build | still authoritative, timer loaded | provision, TZ, user, packages, clone, `make deps`, `make test`, install `/etc/fund/env` (with `FUND_DB` absolute) and `/etc/fund/alert-env`, journald persistence, pre-warm uv cache, units installed **disabled** | VM does no writes |
-| 2 — validate | untouched | the seven checks below | all read-only or market-closed early-exit |
+| 2 — validate | untouched | the seven checks in "Validation checks" | all read-only or market-closed early-exit |
 | 3 — cutover | **unload, move plist out of `~/Library/LaunchAgents`, rename `.env`** | final `.backup` transfer + journals rsync; restore assertions; `systemctl enable --now` all three timers | one host holds an enabled timer at every instant |
-| 4 — watch | — | first 09:35 run; digest lands; first-ever 16:35 P&L run | see below |
+| 4 — watch | — | first 09:35 run; digest lands; first-ever 16:35 P&L run | see "De-risk the P&L job" |
 
 ### Two independent barriers on the Mac (reviews T1, A2)
 
@@ -286,7 +286,7 @@ belongs immediately **before** the final transfer.
 in `~/Library/LaunchAgents/`, which is launchd's per-user auto-load directory —
 launchd loads its contents at every login. Unloading alone means the fund
 **resurrects on the Mac at the next reboot or login**, days later, with no
-human action, while the VM is also live. That is trap 2 firing automatically,
+human action, while the VM is also live. That is two hosts holding a live schedule at once,
 and `client_order_id` idempotency does not catch it.
 
 So cutover does both:
@@ -358,7 +358,7 @@ so prove it manually after a close before it ever sits on a timer. Its first
 execution should be supervised, not scheduled.
 
 **Never schedule `make eval`.** It spends real money — measured $0.81 and ~7
-minutes per run. Only the three timers above get enabled.
+minutes per run. Only the three timers in §4 get enabled.
 
 ---
 
@@ -411,7 +411,7 @@ minutes per run. Only the three timers above get enabled.
   into enforced. Needs tests.
 - **Pin the MCP server version** in `agents/seats.py:49`, if the provision-time
   pin attempt proves insufficient.
-- **Dead-man's-switch**, if the accepted risk above stops feeling acceptable.
+- **Dead-man's-switch**, if the accepted risk in §8 stops feeling acceptable.
 
 ## 10. Out of scope
 

--- a/gate/risk.py
+++ b/gate/risk.py
@@ -58,10 +58,11 @@ def _corr_mult(corr: float) -> float:
     return 1.10
 
 def size(inputs, mode: Mode):
-    """inputs: GateInputs OR anything else (dict, garbage). frozen=True blocks
-    plain attribute assignment, but pydantic v2's model_copy(update=...) and
-    model_construct(...) both skip field validators and can still produce an
-    isinstance-valid GateInputs carrying NaN. So size() does not trust
+    """Approved(max_qty, pre_sector_qty, side) or Rejected(reason).
+    inputs is a GateInputs or anything else (a dict, garbage). frozen=True
+    blocks plain attribute assignment, but pydantic v2's model_copy(update=...)
+    and model_construct(...) both skip field validators and can still produce
+    an isinstance-valid GateInputs carrying NaN. So size() does not trust
     isinstance() to mean "already validated" — it re-checks finiteness on
     every call, on any GateInputs it receives, regardless of how it was
     built. Anything that isn't already a GateInputs is validated here via

--- a/gate/tickets.py
+++ b/gate/tickets.py
@@ -65,7 +65,7 @@ def expire_open_tickets(conn: sqlite3.Connection, now_iso: str) -> list[str]:
 def _as_share_count(qty):
     """Whole-share count from an int or a digit-string; None otherwise. The
     Alpaca MCP place tool sends qty as a STRING ("1"); tickets store max_qty as
-    an int. Accept the string form of a whole number; reject bool, float, and
+    an int. Accepts the string form of a whole number; rejects bool, float, and
     non-digit strings — no fractional shares, no guessing (invariant 4)."""
     if isinstance(qty, bool):
         return None
@@ -84,10 +84,11 @@ _STOP_LEG_KEYS = ("stop_loss_stop_price", "stop_loss_limit_price",
 
 
 def _as_price(value):
-    """Price from a float/int or a numeric STRING; None otherwise. The Alpaca
+    """Price from a float, int, or a numeric STRING; None otherwise. The Alpaca
     MCP place tool sends every numeric as a string ("210.0"), so the string
     form is the normal case here, not the edge case. Rejects bool and
-    unparseable input — a stop we cannot read is a stop we cannot verify."""
+    unparseable input — a stop the gate cannot read is a stop the gate
+    cannot verify."""
     if isinstance(value, bool):
         return None
     if isinstance(value, (int, float)):
@@ -163,11 +164,11 @@ def validate_order(conn: sqlite3.Connection, tool_input,
                 f" != ticket stop_price {t['stop_price']} — the order must"
                 " carry the ticket's stop")
         # A stop exit places at Alpaca as order_class 'oto' carrying the single
-        # stop leg — NOT 'bracket' (bracket 422s: it requires a take_profit leg
-        # the ticket has no field for). Fail-fast on the unplaceable class
-        # rather than let the broker reject it (invariant 4). The plain path
-        # (stop_price NULL) stays order_class-agnostic — no false-deny on a
-        # legitimate simple order.
+        # stop leg — NOT 'bracket'. Alpaca rejects a bracket order with a 422
+        # because it requires a take_profit leg the ticket has no field for.
+        # Fail-fast on the unplaceable class rather than let the broker reject
+        # it (invariant 4). The plain path (stop_price NULL) stays
+        # order_class-agnostic — no false-deny on a legitimate simple order.
         if tool_input.get("order_class") != "oto":
             return False, (f"order_class {tool_input.get('order_class')!r} must "
                            "be 'oto' for a stop exit — bracket is unplaceable")

--- a/orchestrator/clock.py
+++ b/orchestrator/clock.py
@@ -26,8 +26,8 @@ def et_run_date(now: datetime) -> str:
     """YYYY-MM-DD in America/New_York — schema.sql documents run_date as ET,
     not UTC. Pure: takes a datetime, never reads the clock itself, so callers
     keep the injected-Clock discipline and this stays purity-lint clean.
-    Naive datetimes are rejected (all fund datetimes are tz-aware, see iso()
-    above) rather than silently assumed to be UTC."""
+    Naive datetimes are rejected (all fund datetimes are tz-aware, see
+    iso()) rather than silently assumed to be UTC."""
     if now.tzinfo is None:
         raise ValueError("naive datetime — all fund datetimes are tz-aware")
     return now.astimezone(_ET).date().isoformat()
@@ -37,7 +37,7 @@ def et_hhmm(now: datetime) -> str:
     """HH:MM in America/New_York — the twin of et_run_date for a gate
     ticket's expiry. Every other time posted to #risk is ET; a bare UTC
     HH:MM there misreads as a much longer TTL than it is. Pure and naive-
-    datetime-rejecting for the same reasons as et_run_date above."""
+    datetime-rejecting for the same reasons as et_run_date."""
     if now.tzinfo is None:
         raise ValueError("naive datetime — all fund datetimes are tz-aware")
     return now.astimezone(_ET).strftime("%H:%M")

--- a/orchestrator/daily.py
+++ b/orchestrator/daily.py
@@ -115,7 +115,7 @@ def run_pre_gate(ctx: StageCtx) -> list[str]:
 
 
 def _pre_gate_stage(ctx: StageCtx) -> list[str]:
-    """The pre_gate stage BODY: run_pre_gate's pure computation, plus one
+    """The pre_gate stage body: run_pre_gate's pure computation, plus one
     alert per ticker dropped because BOTH shapes came back gate_error — a
     malformed/NaN feed, not the legitimate no_headroom/nothing_held skip,
     which must stay silent (review Important 5). Only called from inside
@@ -175,7 +175,7 @@ def run_decision(ctx: StageCtx, active: list[str]) -> None:
         if decided is not None:
             continue
         # Event BEFORE the row commit (review Minor 7): if a crash lands
-        # between the two, the resume guard above only ever sees the
+        # between the two, the resume guard in this loop only ever sees the
         # decisions table, so once that INSERT commits the ticker is
         # skipped forever. Committing the alert first means the only
         # crash window left re-runs both (a harmless duplicate alert),
@@ -264,7 +264,7 @@ def run_gate(ctx: StageCtx) -> None:
     an already-minted ticket is reused (and reconciled) rather than
     duplicated. Each decision is isolated (review Important 4): a raise
     handling one ticker rejects only that ticker with 'gate_error' and the
-    rest of the stage still runs — matching the fail-closed posture size()
+    rest of the stage still runs. That matches the fail-closed posture size()
     already has, so one bad row can never sink the whole day's execution,
     reconciliation, and digest."""
     now_dt = ctx.clock.now()
@@ -305,7 +305,7 @@ def run_execution(ctx: StageCtx, run_trader_turn: Callable[[], None] | None) -> 
     """Trader stage. Zero open tickets -> no turn at all (no LLM spend on a
     hold day); the stage still drains and still checkpoints done."""
     now = iso(ctx.clock.now())
-    expire_open_tickets(ctx.conn, now)   # gate expiry is clock-injected (§0)
+    expire_open_tickets(ctx.conn, now)   # clock-injected expiry (acceptance §0)
 
     def body() -> None:
         if run_trader_turn is not None and open_tickets(ctx.conn, iso(ctx.clock.now())):
@@ -318,7 +318,7 @@ def run_execution(ctx: StageCtx, run_trader_turn: Callable[[], None] | None) -> 
 
 def _decision_rows(conn: sqlite3.Connection, run_date: str) -> list[dict]:
     """The digest's decisions as fields, not prose. slackkit/render.py lays
-    the digest out from these: it may not parse them back out of the text
+    the digest out from these: it must not parse them back out of the text
     (free text is never parsed) nor read the DB itself (invariant 6)."""
     return [{"ticker": r["ticker"], "action": r["action"], "qty": r["qty"],
              "status": r["status"]}
@@ -384,7 +384,7 @@ def run_close(ctx: StageCtx) -> None:
     """EOD digest to #pnl + one journal line per participating seat. Posts
     even on a full-HOLD day. Idempotent per-piece (review Minor 6): the
     digest-exists check only guards the digest post, and each journal write
-    is independently guarded by _append_entry_once, so a kill between the
+    is independently guarded by _append_entry_once, so an exit between the
     digest commit and the journal writes still gets the journals written on
     resume instead of losing them forever."""
     conn, run_date = ctx.conn, ctx.run_date

--- a/orchestrator/pnl.py
+++ b/orchestrator/pnl.py
@@ -17,7 +17,7 @@ from orchestrator.clock import et_run_date
 
 
 class PnlUnavailable(RuntimeError):
-    """Today's P&L cannot be computed from data we trust, so there is no
+    """Today's P&L cannot be computed from data the fund trusts, so there is no
     number to post. Never a guess and never a zero (invariant 4) — a flat day
     and an unmeasurable one look identical in a digest and mean opposite
     things."""
@@ -30,7 +30,9 @@ def eod_pnl(source, clock) -> dict:
     MUST run after the close has settled — 16:35 ET is the scheduled time.
     close_frame shifts its end back SIP_DELAY (16 min), so an earlier call asks
     for a bar the session has not finished writing; the same-session guard
-    below is what turns that into no post rather than a wrong one.
+    on the bar date is what turns that into no post rather than a wrong one.
+    Raises PnlUnavailable when the broker equity or the SPY closes cannot
+    support a number.
     """
     now = clock.now()
     run_date = et_run_date(now)
@@ -76,8 +78,9 @@ def _spy_closes(source, end) -> tuple[float, float, str]:
     """SPY's last two daily closes, and the ET date of the last one.
 
     Routed through close_frame, never a hand-rolled bars request: close_frame
-    owns the SIP_DELAY shift Alpaca's free plan 403s without, and applies it to
-    the `end` passed in rather than to a wall-clock read of its own.
+    owns the SIP_DELAY shift that the free Alpaca plan rejects with a 403 when
+    it is missing, and applies it to the `end` passed in rather than to a
+    wall-clock read of its own.
     """
     frame = source.close_frame(["SPY"], end=end)
     if "SPY" not in frame.columns or len(frame.index) < 2:

--- a/orchestrator/reconcile.py
+++ b/orchestrator/reconcile.py
@@ -103,7 +103,7 @@ _CONFIRMED_DEAD = {"canceled": "canceled", "expired": "canceled",
 def _dead_fill(o) -> tuple[int, float] | None:
     """Fill numbers on a broker-confirmed-dead order. None means "no shares
     changed hands" — the plain no-fill cancel, where filled_qty is absent,
-    null or 0 and filled_avg_price is null. Anything else goes through
+    null, or 0, and filled_avg_price is null. Anything else goes through
     _parse_fill and raises if malformed: a dead order that claims shares must
     say how many and at what price, or we record nothing at all."""
     raw_qty = o.get("filled_qty")
@@ -115,19 +115,19 @@ def _dead_fill(o) -> tuple[int, float] | None:
 def _timeout_close(conn, row, broker, now, max_wait_s) -> bool:
     """Close out ONE order the broker last confirmed still working, past the
     cap: request the cancel, re-query ONCE, record the TRUE terminal state.
-    Returns True iff the order filled in the race (keeps the caller's fill
-    counter honest).
+    Returns True if the order filled in the race; False otherwise, which
+    keeps the caller's fill counter honest.
 
-    The order may be 'submitted' OR 'partially_filled' in the DB (accepted ->
+    The order can be 'submitted' OR 'partially_filled' in the DB (accepted ->
     partially_filled -> canceled happens inside one run), so the CAS starts
     from whatever the row actually holds. The re-queried fill numbers decide
     the decision's fate, because the DB must tell the truth about what's held:
     filled_qty > 0 is a REAL position, so the decision is 'executed' with a
     fill event for the partial qty; only a zero fill is 'failed'.
 
-    Fail closed everywhere the broker leaves us guessing — a cancel that
+    Fail closed everywhere the broker's answer is ambiguous — a cancel that
     errored while the order still works, a re-query that errored or returned
-    nothing, a status that is not confirmed-dead, fill numbers that will not
+    nothing, a status that is not confirmed-dead, fill numbers that do not
     parse, a dead status with no legal edge from the row's current status:
     leave the row as-is for the next run and alert. Requesting a cancel twice
     is harmless (idempotent by client_order_id); recording a cancel that did
@@ -215,6 +215,11 @@ def _timeout_close(conn, row, broker, now, max_wait_s) -> bool:
 def reconcile_orders(conn: sqlite3.Connection, *, clock: Clock, broker,
                      sleep: Callable[[float], None],
                      poll_s: float = 3.0, max_wait_s: float = 90.0) -> int:
+    """Poll every submitted order to a terminal state, then close out at the
+    cap whatever the broker still confirms as working. Returns the number of
+    orders this call moved to 'filled'. poll_s is the polling cadence and
+    max_wait_s the total budget before the timeout path runs; raises
+    ValueError on a non-positive poll_s."""
     if poll_s <= 0:
         raise ValueError(f"poll_s must be positive, got {poll_s!r}")
     filled, waited = 0, 0.0
@@ -236,8 +241,9 @@ def reconcile_orders(conn: sqlite3.Connection, *, clock: Clock, broker,
                     filled += 1
             except Exception as e:
                 # Fail closed: broker unreachable, or a payload we couldn't
-                # parse (e.g. _apply's coercion raised). Either way leave the
-                # order 'submitted' for the next poll and surface it loudly.
+                # parse (for example, _apply's coercion raised). Either way
+                # leave the order 'submitted' for the next poll and surface it
+                # loudly.
                 problem[coid] = type(e).__name__
                 confirmed_open.pop(coid, None)
                 continue

--- a/slackkit/outbox.py
+++ b/slackkit/outbox.py
@@ -1,8 +1,8 @@
-"""events outbox: SQLite truth -> Slack projection (contracts §2, §5.3).
-DB write and Slack post are decoupled; a crash between post and mark, or a
-post that raises after Slack accepted it, may duplicate a Slack message —
-acceptable (a duplicate projection is recoverable, a lost one is not); never
-retry into a second DB write."""
+"""Events outbox: SQLite truth -> Slack projection (contracts §2, §5.3).
+DB write and Slack post are decoupled. A crash between post and mark, or a
+post that raises after Slack accepted it, might duplicate a Slack message.
+A duplicate projection is recoverable and a lost one is not, so duplicates
+are acceptable. Never retry into a second DB write."""
 
 from __future__ import annotations
 
@@ -28,7 +28,7 @@ def append_event(conn: sqlite3.Connection, kind: str, payload: dict,
 def _dead_letter(conn: sqlite3.Connection, row, now_iso: str,
                  exc: Exception) -> None:
     """Mark one undeliverable row posted, never retried, not counted, and
-    append a projection_error naming it so scripts/audit_day.py reddens the
+    append a projection_error naming it so scripts/audit_day.py fails the
     day (its dead-letter check counts projection_error rows). A
     projection_error that itself dead-letters appends nothing — that is what
     stops the loop when the dead channel is #risk."""
@@ -44,22 +44,22 @@ def _dead_letter(conn: sqlite3.Connection, row, now_iso: str,
 
 def drain(conn: sqlite3.Connection, slack, now_iso: str) -> int:
     """Post unposted events, oldest first. Returns the count of events
-    genuinely posted to Slack (via slack.post()) during THIS call — not the
+    genuinely posted to Slack (through slack.post()) during THIS call — not the
     count of rows marked drained, and not a promise that the queue is now
     empty. A short count means work is left for the next drain; the audit's
     global "undrained outbox events" check is what surfaces a queue that
     never clears.
 
-    Two failure modes, two outcomes:
+    The two failure modes have two outcomes:
 
     * render() raises -> PERMANENT (an unknown kind, a malformed payload; it
-      will raise identically forever). The row is dead-lettered — marked
+      raises identically forever). The row is dead-lettered — marked
       posted, never retried, not counted — and a projection_error event
       describing it is appended and drained in the same call, so a bad event
       dead-letters itself instead of jamming the queue (MVF review C2).
 
     * slack.post() raises PermanentPostError -> PERMANENT (the bot is not in
-      that channel, the channel is archived/gone, the token is invalid; see
+      that channel, the channel is archived or gone, the token is invalid; see
       slackkit.real.PERMANENT_ERRORS). Retrying cannot help, so the row is
       dead-lettered exactly like a render failure and the drain CONTINUES to
       the next event. Ordering only has to hold WITHIN a channel, and a dead
@@ -74,8 +74,8 @@ def drain(conn: sqlite3.Connection, slack, now_iso: str) -> int:
       recoverable only by reading the DB.
 
     Terminates: each pass either returns early or marks every row it fetched,
-    and the only rows a pass can add are the projection_errors it appended,
-    which never append further projection_errors."""
+    and the only rows a pass can add are the projection_error rows it appended,
+    which never append further projection_error rows."""
     posted = 0
     while True:
         rows = conn.execute(

--- a/slackkit/port.py
+++ b/slackkit/port.py
@@ -1,3 +1,6 @@
+"""The Slack seam: the SlackPort protocol and PermanentPostError, both
+importable without slack_sdk."""
+
 from __future__ import annotations
 
 from typing import Protocol
@@ -19,8 +22,8 @@ class SlackPort(Protocol):
 
 
 class PermanentPostError(Exception):
-    """A post that will fail identically forever (the bot is not in the
-    channel, the channel is gone/archived, the token is invalid). drain()
+    """A post that fails identically forever (the bot is not in the
+    channel, the channel is gone or archived, the token is invalid). drain()
     dead-letters that one event and keeps going; every other post failure
     stays transient and stops the drain for retry.
 

--- a/slackkit/real.py
+++ b/slackkit/real.py
@@ -1,4 +1,4 @@
-"""Real Slack port (live-paper + @live smoke only). Import via
+"""Real Slack port (live-paper + @live smoke only). Import from
 slackkit.real explicitly — slackkit/__init__.py must stay empty so the
 purity-linted orchestrator can import slackkit.outbox."""
 
@@ -11,7 +11,7 @@ from .port import PermanentPostError
 
 # Slack error codes that no retry can fix: the bot was never invited, the
 # channel is gone or archived, the token is bad, the Block Kit payload is
-# malformed/oversized, or the token may not set a sender identity — Slack
+# malformed or oversized, or the token cannot set a sender identity — Slack
 # rejects that message identically forever, so it must dead-letter rather
 # than stop the drain for a retry that cannot help. Everything else (rate
 # limits, 5xx, network) is transient and must keep its retry semantics.
@@ -19,8 +19,8 @@ from .port import PermanentPostError
 #
 # missing_scope / not_allowed_token_type are the persona pair: they answer a
 # username/icon_emoji the token is not allowed to set, and stay refused until
-# a human changes the app's scopes. Left transient they would stop the drain
-# on the day's FIRST signal — the analyst's — and queue every gate post, fill
+# a human changes the app's scopes. Left transient, they would stop the drain
+# on the day's first signal — the analyst's — and queue every gate post, fill
 # and digest behind it for the rest of the day.
 PERMANENT_ERRORS = frozenset({"not_in_channel", "channel_not_found",
                               "invalid_auth", "is_archived",

--- a/slackkit/render.py
+++ b/slackkit/render.py
@@ -1,5 +1,5 @@
 """Event kind -> (channel, Slack mrkdwn text) per contracts.md §8. Unknown
-kind = raise: an unrenderable event is a bug, not something to guess at
+kind raises: an unrenderable event is a bug, not something to guess at
 (invariant 4 is about trading defaults; projection failures must fail fast).
 
 Rendering is a projection and nothing more (invariant 6): every word below
@@ -17,9 +17,9 @@ class Post(NamedTuple):
     without text arrive blank there. `blocks` is None for kinds whose text is
     already prose composed elsewhere.
 
-    `username`/`icon_emoji` override the sender Slack shows (needs the token's
-    chat:write.customize scope). Both None — every kind but `signal` and
-    `decision` — posts under the app's own identity."""
+    `username`/`icon_emoji` override the sender Slack shows. Setting them
+    needs the token's chat:write.customize scope. Both None — every kind but
+    `signal` and `decision` — posts under the app's own identity."""
     channel: str
     text: str
     blocks: list[dict] | None = None
@@ -53,7 +53,7 @@ def _context(*parts: str) -> dict:
 
 # The seat that emitted the post, in the words a human uses for it: a name so
 # a channel reads as people talking, the role in parentheses so nobody has to
-# memorise the mapping and a second analyst stays unambiguous. One dict, used
+# memorize the mapping and a second analyst stays unambiguous. One dict, used
 # both as the Slack sender name and as the in-message label — two spellings of
 # one seat is worse than seeing the name twice, and the label is what survives
 # if chat:write.customize is ever revoked. An unmapped seat falls back to its
@@ -96,7 +96,7 @@ def _persona(agent: str) -> tuple[str, str | None]:
 
 
 def _order(side: str, qty: int) -> str:
-    """'buy 80 shares' / 'hold' — a hold has no share count to claim."""
+    """`buy 80 shares` or `hold` — a hold has no share count to claim."""
     return "hold" if side == "hold" else f"{side} {qty} shares"
 
 
@@ -220,7 +220,7 @@ def _render_pnl(payload: dict) -> Post:
 
 
 def _render_alert(payload: dict) -> Post:
-    """Labelled so an alert is not mistaken for a gate post: #risk carries
+    """Labeled so an alert is not mistaken for a gate post: #risk carries
     both, and they demand different reactions."""
     text = f"⚠️ *Alert* · {payload['text']}"
     return Post("#risk", text, [_section(text)])
@@ -246,7 +246,7 @@ RENDERERS: dict[str, Callable[[dict], Post]] = {
 
 
 def render(kind: str, payload: dict) -> Post:
-    """unknown kind raises here; drain() dead-letters it so one bad event
+    """An unknown kind raises here; drain() dead-letters it so one bad event
     cannot jam the queue (MVF review C2)."""
     renderer = RENDERERS.get(kind)
     if renderer is None:

--- a/state/critiques.py
+++ b/state/critiques.py
@@ -1,8 +1,8 @@
 """Default critique rows. MVF has no Critic seat, so the orchestrator opens
 the decision stage by inserting one `clear` critique per active ticker —
-otherwise submit_decision's critique-row guard (contracts §4) refuses every
-PM call. Lives in state/ (not agents/) because orchestrator/ must not import
-from agents/ (CLAUDE.md); agents.tools.fund_server re-exports it."""
+otherwise the critique-row guard in submit_decision (contracts §4) refuses
+every PM call. Lives in state/ (not agents/) because orchestrator/ must not
+import from agents/ (CLAUDE.md); agents.tools.fund_server re-exports it."""
 
 from __future__ import annotations
 

--- a/state/db.py
+++ b/state/db.py
@@ -9,6 +9,7 @@ _SCHEMA = Path(__file__).with_name("schema.sql")
 
 
 def connect(db_path: str | Path) -> sqlite3.Connection:
+    """Open the fund DB at `db_path`, creating the schema when absent."""
     conn = sqlite3.connect(str(db_path))
     conn.row_factory = sqlite3.Row
     conn.execute("PRAGMA journal_mode=WAL")

--- a/state/models.py
+++ b/state/models.py
@@ -35,7 +35,7 @@ class Decision(BaseModel):
     @model_validator(mode="after")
     def hold_means_zero(self):
         assert (self.action == "hold") == (self.qty == 0)
-        assert self.stop_price is None or self.action == "buy"   # stops guard new/added longs only
+        assert self.stop_price is None or self.action == "buy"   # stops guard new or added longs only
         return self
 
 

--- a/state/transition.py
+++ b/state/transition.py
@@ -31,13 +31,14 @@ class IllegalTransition(Exception):
 
 
 class StaleTransition(Exception):
-    """Legal edge, but the row is not currently in from_status (CAS failed)."""
+    """Legal edge, but the row is not in from_status (CAS failed)."""
 
 
 def try_transition(conn: sqlite3.Connection, table: str, key: dict,
                    from_status: str, to_status: str, now_iso: str) -> bool:
-    """CAS the row from from_status to to_status. False if the row is not in
-    from_status (lets idempotent handlers no-op on re-run, contracts §5.2)."""
+    """CAS the row from from_status to to_status. True if the row moved; false
+    if the row is not in from_status (lets idempotent handlers no-op on
+    re-run, contracts §5.2)."""
     if table not in EDGES:
         raise IllegalTransition(f"no state machine for table {table!r}")
     if (from_status, to_status) not in EDGES[table]:


### PR DESCRIPTION
A Google developer-documentation style review of the reader-facing docs and runtime docstrings, with the findings applied. **Wording only — no behavior change.** `make test` green at 789 passed, purity lint clean.

## What landed

| Commit | Content |
|---|---|
| `9f94167` | 104 fixes — 2 blocking, 27 accessibility, 75 Python docstrings across 20 files |
| `284f36e` | 125 markdown prose fixes across 7 files |

229 of 338 verified findings.

**The two blocking ones:**
- `gate/risk.py` — `size()`'s docstring opened with a parameter note, so any generator truncating at the first period told a caller nothing about the return value.
- `2026-08-17-vm-migration-design.md` — referenced a "trap 2" defined nowhere in the document, at the most dangerous point of the cutover.

**Accessibility** — directional "above"/"below" replaced with named sections or the repo's own `§N` pointers, ALL-CAPS emphasis replaced with italics, `# PART B`/`# PART C` demoted from h1, table and list lead-ins made complete sentences.

**Style** — serial commas, American spelling, abbreviations spelled out on first use, slashes replaced with "or", code font on bare identifiers. Four bolded pseudo-headings became real headings so they can be linked; three high-consequence runbook warnings became typed Warning/Caution notices.

## What was deliberately not changed

**Safety emphasis is preserved at HEAD counts** — `STOP` 3/3, `NOT` 2/2, `ONLY` 3/3, `BEFORE` 2/2, `REAL` 1/1, `AND` 2/2 in `HANDOFF-LIVE.md`. All 24 `§N` pointers and all 10 numbered headings unchanged. Every cost figure intact.

**8 findings skipped for cause:**
- `422-reject` is house jargon used across `specs/design.md`, `specs/contracts.md`, `charters/exec.md`, and the runbook — changing it in one place only fragments the term.
- `may` → `must` on "exactly one host **may** hold a live schedule" would invert a permission statement into a requirement. That's the invariant preventing duplicate orders.
- `ONE host` caps in README, `REAL` in the runbook, and the `AUDIT CLEAN` note whose proposed rewrite de-emphasized it twice.

**`docs/superpowers/` is untouched** in the second commit. The first commit does contain 12 lines across three of those files from the accessibility tier; happy to strip those if you'd rather.

## Still open — 21 house conventions

These are consistent enough to read as deliberate choices, so they're presented as decisions rather than applied:

- **Spaced em dashes** — 367 spaced, 0 unspaced across 12 files. Google says no spaces.
- **Numbered headings with `§N` cross-references** — 83 pointers, several crossing file boundaries. Google says don't number headings; renumbering here would break all of them.
- **ALL-CAPS for prohibitions** — ~40 uses, every one marking a prohibition, abort, or irreversible step, and absent entirely from the four files that state no stop-conditions.
- **Free-prose docstrings** — 103 of 103, zero `Args:`/`Returns:`/`Raises:`. No structured sections were introduced.

Full review with all 338 findings, 223 left-alone entries, and the convention evidence: https://claude.ai/code/artifact/387ab8ce-6d51-4adf-b9eb-604cfd614d67