### PR TITLE
docs: the regression ratchet, and a runbook that stopped being true

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,10 @@ Issues live as GitHub issues on `benjaminematton/fund`, via the `gh` CLI. See `d
 
 The domain docs are single-context: `CONTEXT.md` and `docs/adr/`, both at the repo root. See `docs/agents/domain.md`.
 
+### Regression ratchet
+
+A real failure becomes a permanent eval case, written by a human, once. Eligibility and the procedure: `docs/agents/regression-ratchet.md`.
+
 ## Compact instructions
 
 When compacting, preserve verbatim: the test invariants in the Test invariants section; which plan tasks are complete with commit SHAs; any deviation from `plans/phase-1a.md` / `plans/phase-1b.md` and why. Discard file reads, test output, and exploration traces.

--- a/docs/agents/regression-ratchet.md
+++ b/docs/agents/regression-ratchet.md
@@ -1,0 +1,96 @@
+# Promoting a live failure to a permanent eval case
+
+A failure the fund has already had, and can have again, is worth more than a
+failure someone imagined. The ratchet is the rule that a real one becomes a
+permanent case: it happens once, and after that it is graded on every run
+forever.
+
+Promotion is a **human writing a case**. It is not automated and it is not an
+agent's job, because deciding what class a failure belongs to *is* building
+the failure taxonomy — and a taxonomy an agent invents from its own traces is
+one nobody has checked against reality. A human reads the trace first.
+
+## Which failures are eligible
+
+**Only failures fully determined by their recorded inputs.**
+
+`evals/grade.py` reads a `Trace` and a `Case` and runs nothing — no SDK, no
+network, no DB. That is what makes a new invariant retroactively cover every
+trace ever recorded, and it is also the constraint: a case whose failure
+depends on state nobody wrote down cannot be graded honestly. If reproducing
+the failure would need a broker reply, a clock position, or a Slack thread
+that is not in the trace, it is not eligible. Write an issue instead.
+
+**One instance is enough.** There is deliberately no "must recur twice" rule.
+A recurrence bar sounds prudent and is not: it lets the first instance of
+every failure class through by design, which is precisely the instance you
+had the evidence for.
+
+**Do not promote permitted behaviour.** Check the charter before deciding a
+turn was wrong. `evals/metrics.py` exists for exactly this: a single vague
+invalidation breaks no rule, because `charters/pm.md` §"Output contract"
+permits leaving invalidation unset for non-price conditions. What is worth
+watching there is the *rate*, and a rate is a metric, never an invariant.
+Promoting a permitted behaviour to a hard case does not tighten the fund, it
+writes a rule the charter does not contain.
+
+## Where the failures come from
+
+Two corpora, and they are not equally strong evidence.
+
+- **Live traces** — `$FUND_TRACES` on the droplet, one JSON per seat turn,
+  written by `evals/live.py` from a real trading day. These are the real
+  thing: a live failure has already cost something.
+- **Eval-suite traces** — `evals/traces/<run>/<sha>/<case>/<trial>.json`,
+  from `make eval`. Real model turns against real charters, so a failure here
+  is real too — but the run may be a deliberate charter ablation, in which
+  case the "failure" is the experiment working. Check what the run was before
+  promoting from it.
+
+`evals/traces/recorded/` is neither. It is a hand-built fixture for testing
+the grader (`report_cli.NOT_A_RUN` excludes it), and its I1 `oversize` verdict
+is a planted one. Never promote from it.
+
+## Doing it
+
+1. **Read the trace.** Find one turn whose wrong output is fully determined by
+   its recorded snapshot and prompt. Write down in one sentence what the seat
+   should have done instead. If that sentence needs a fact the trace does not
+   contain, stop — it is not eligible.
+
+2. **Write the case.** `evals/cases/pm/r<nn>-<slug>.yaml`, in the shape
+   `evals/cases.py:load_case` expects: `id`, `seat`, `clock` (timezone-aware),
+   `tickers`, `snapshot`, `signals`, `journal`, `expect`, `notes`. Put the
+   trace's snapshot in **verbatim** — paraphrasing it is how a case stops
+   testing the failure it came from. `notes` must name the date and run of the
+   live failure, so a future reader can find the original.
+
+3. **Verify it fails against the trace that motivated it.** Grade the
+   originating trace against the new case and confirm the invariant that
+   describes the failure reports FAIL. A case that does not fail on the
+   evidence it was written from is testing something else.
+
+4. **Then either it is a guard or it is a task.** If the fix is already in,
+   the case passes and is now a permanent guard. If it is not, the case stays
+   red and the fix is its own piece of work. **Do not weaken the case to make
+   it green** — `CLAUDE.md`'s red-test rule applies here exactly as it does in
+   `make test`.
+
+5. **Commit the case and the reasoning together.** The `notes` field and the
+   commit message are the only record of why this case exists; a case whose
+   motivation is lost is one a future reader will eventually delete as
+   redundant.
+
+## Grading the corpus
+
+Free and offline — it re-scores recorded traces and never runs a turn:
+
+```bash
+make eval-report                       # every run
+make eval-report RUN=<run>             # one run
+make eval-report RUN=<run> BASELINE=<sha>   # diffed against a baseline
+```
+
+There is deliberately no "latest": runs are labelled by hand as well as by git
+sha, and a merge rewrites every directory's mtime, so neither name order nor
+mtime identifies the run you meant.

--- a/ops/README.md
+++ b/ops/README.md
@@ -120,6 +120,15 @@ here fails silently. Both units that need it read this file
 (`fund-daily.service` writes the traces, `fund-backup.service` archives them),
 so one line covers both. A day that recorded nothing is visible in the log:
 `run_day` prints `recording seat traces under <path>` when the sink is live.
+
+**Adding this line before the code that reads it is deployed arms a change
+that fires later.** It is inert until a pull brings the reading code, and then
+recording starts on the next day with no deploy step that mentions it — the
+env file changed hours or days earlier and nothing surfaces it at pull time.
+That happened on 2026-08-19: the line was staged at 16:45 EDT, 45 minutes
+after a deploy, and the next pull would have started recording by inheritance
+rather than by choice. If you stage an env line ahead of its code, say so to
+whoever deploys next; `/etc/fund/env` is not in git and no diff will show it.
 Traces cannot be reconstructed afterwards, so the cost of forgetting is the
 corpus itself.
 
@@ -379,10 +388,27 @@ write it:
 su - fund -c 'cd /opt/fund && .venv/bin/python3 scripts/sync_deps.py'
 ```
 
-If `state/schema.sql` changed, **stop.** There is no migration framework — only
-a DDL file applied at creation. An existing `fund.sqlite` will not pick up the
-change, and the source of truth silently disagrees with the code. Plan that
-change deliberately; it is not a deploy step.
+If `state/schema.sql` changed, read `state/migrations.py` before pulling.
+
+There is now a migration framework, added 2026-08-19: `state/db.py:connect()`
+applies every pending migration, so an existing `fund.sqlite` does pick up the
+change. Before that, `schema.sql` was applied only at creation and an existing
+DB silently disagreed with the code — which is why this step used to say
+**stop** outright.
+
+It is still the only step in a deploy that **writes to the live database**, so
+it is the one to slow down on:
+
+```bash
+cd /opt/fund && git diff <old-sha>..origin/master -- state/migrations.py
+```
+
+Read what it does before you run it. Additive `ALTER TABLE ADD COLUMN` with a
+default is safe and idempotent; anything that drops, renames, rewrites or
+backfills a column is not a deploy step and needs planning on its own.
+Take a fresh backup immediately before the pull rather than trusting the
+night's timer — the migration runs on the first `connect()` after it, which is
+usually `make preflight`, not a moment you choose.
 
 **4. Finish with `make preflight`, not with a green `git pull`.** A pull that
 succeeded proves files moved. Preflight proves the seats still start under


### PR DESCRIPTION
Two docs-only commits. No code, no tests changed, no runtime effect.

- `14d2d6e` — `docs/agents/regression-ratchet.md`: how a real failure becomes a permanent eval case, who may decide that (a human, not an agent), and the eligibility rule that stops permitted behaviour being promoted to a hard case.
- `edc3c54` — `ops/README.md`: the `state/schema.sql` → **STOP** rule went obsolete the moment `state/migrations.py` landed in #7, and a stop sign that no longer means anything is worse than none. Rewritten to point at the migration and keep the caution where it belongs — this is still the only deploy step that writes to the live DB. Plus a new paragraph on staged env lines: adding one before its code deploys arms a change that fires later, invisible to every pull-time diff because `/etc/fund/env` is not in git. It names the 2026-08-19 instance, which was mine.

Merging before tonight's deploy so the runbook on the droplet is correct for whoever reads it next.

`make test` — 906 passed, 1 skipped.