### PR TITLE
fix: the snapshot hash identified the platform, not the data

### DIFF
--- a/fixtures/golden-strategy.md
+++ b/fixtures/golden-strategy.md
@@ -13,8 +13,8 @@ Synthetic, seeded (`tests/synthetic.py`, seed=42): 20 names, 2,520 daily bars
 edge — after a 5-day drop of ≥5%, next-day expected return gets a +50 bps kick.
 We planted the edge, so we know the ground truth the gate should find.
 
-Data snapshot hash: `dat_a4d2ee4153d5df6d` (recorded under numpy≥2; numpy 1.x
-serializes the synthetic market with ~1e-11 bit-level differences)
+Data snapshot hash: `dat_adfbd511dae060bd` (hashed at 6 significant digits, so
+it is identical on macOS and Linux — see `snapshot_hash`)
 
 ## G1 — the spec
 
@@ -31,7 +31,7 @@ search_budget:    20 configs
 
 ## The PASS path — params {dip_days: 5, dip_pct: 0.05, trend_days: 200}
 
-`config_hash cfg_2ad6bd632a066999 · run_key run_549f306118a70c4e`
+`config_hash cfg_2ad6bd632a066999 · run_key run_7b4a168abfd09ced`
 
 `run_backtest` (holdout = last 18 months quarantined; 8.448 visible years):
 

--- a/fundbt/run_backtest.py
+++ b/fundbt/run_backtest.py
@@ -45,8 +45,13 @@ def register_rule(name: str):
 
 
 def snapshot_hash(close: pd.DataFrame) -> str:
-    """SHA256 of the pinned data slice. Recorded with every trial."""
-    payload = close.round(10).to_csv().encode()
+    """SHA256 of the pinned data slice. Recorded with every trial.
+
+    Six significant digits, not raw float text: numpy's macOS and manylinux
+    wheels disagree by ~1 ULP on FMA-contracted multiply-adds, so hashing the
+    exact decimals would identify the platform rather than the data.
+    """
+    payload = close.to_csv(float_format="%.6g").encode()
     return "dat_" + hashlib.sha256(payload).hexdigest()[:16]
 
 

--- a/tests/test_golden.py
+++ b/tests/test_golden.py
@@ -17,9 +17,9 @@ def test_golden_pass_path():
     r = run_backtest(spec=spec, params=GOLDEN_PARAMS, close=close,
                      registry=reg, seat="quant", now_iso=NOW)
 
-    assert r["data_snapshot_hash"] == "dat_a4d2ee4153d5df6d"
+    assert r["data_snapshot_hash"] == "dat_adfbd511dae060bd"
     assert r["config_hash"] == "cfg_2ad6bd632a066999"
-    assert r["run_key"] == "run_549f306118a70c4e"
+    assert r["run_key"] == "run_7b4a168abfd09ced"
     assert r["n_trades"] == 740
     assert r["span_years"] == 8.448
     assert round(r["net_sharpe"], 6) == 1.827113

--- a/tests/test_run_backtest.py
+++ b/tests/test_run_backtest.py
@@ -5,7 +5,8 @@ import numpy as np
 
 import fundbt.rules  # noqa: F401  (registers dip_buyer)
 from fundbt.registry import TrialRegistry
-from fundbt.run_backtest import BacktestError, evaluate_holdout, run_backtest
+from fundbt.run_backtest import (BacktestError, evaluate_holdout, run_backtest,
+                                 snapshot_hash)
 from tests.synthetic import GOLDEN_PARAMS, make_market, make_spec
 
 NOW = "2026-07-09T00:00:00Z"
@@ -25,6 +26,26 @@ def test_deterministic_and_cached():
     assert r1["run_key"] == r2["run_key"]
     assert r1["net_sharpe"] == r2["net_sharpe"]
     assert reg.family_n("F1") == 1          # cache hit did NOT increment N
+
+
+def test_snapshot_hash_ignores_platform_float_noise():
+    """numpy's macOS wheel FMA-contracts the multiply-add inside
+    Generator.uniform; the manylinux wheel rounds twice. That 1-ULP split at
+    the first draw grows to ~5e-15 relative across the market, so hashing raw
+    float text identifies the platform rather than the data. Perturb by an
+    order of magnitude more than the observed drift: the hash must not move."""
+    close = make_market()
+    noise = 1.0 + 1e-14 * np.random.default_rng(0).standard_normal(close.shape)
+    assert snapshot_hash(close * noise) == snapshot_hash(close)
+
+
+def test_snapshot_hash_detects_a_real_data_change():
+    """The tolerance above must not be so wide that a changed snapshot slips
+    through — a pinned slice that moved is exactly what this hash is for."""
+    close = make_market()
+    changed = close.copy()
+    changed.iloc[0, 0] *= 1.001
+    assert snapshot_hash(changed) != snapshot_hash(close)
 
 
 def test_param_range_enforced():


### PR DESCRIPTION
`ci` has failed on every run it has ever made — 50 runs, zero successes, all on `tests/test_golden.py::test_golden_pass_path`. This fixes it, and the cause is not what the previous investigation concluded.

## Root cause

`snapshot_hash` hashed the decimal text of the float matrix, so it asserted bit-identical floats across machines — something numpy does not provide.

numpy's macOS wheel FMA-contracts the multiply-add inside `Generator.uniform` (`low + (high-low)*u`, one rounding); the manylinux wheel rounds twice. Proven by exact rational arithmetic — macOS matches the fused result bit-for-bit, Linux the unfused one:

```
fused (FMA)    0x1.6974569e58a45p-6   <- macOS numpy
unfused        0x1.6974569e58a44p-6   <- Linux numpy
```

The PCG64 bit stream itself is identical everywhere (`random_raw` and `random()` match exactly) — numpy's cross-platform guarantee covers the *stream*, not float math layered on top.

That 1-ULP split at the very first draw (`vol[0]` in `tests/synthetic.py`) propagates through 2520 days of `rng.normal` + `cumprod` into **30,151 of 50,400 cells** differing at ~5.4e-15 relative, which survives `round(10)` and changes the CSV bytes.

## What the previous diagnosis got wrong

| Prior claim | Evidence |
|---|---|
| Dependency drift from unpinned numpy/pandas | CI resolves **numpy 2.5.2 / pandas 2.3.3** — the same pair that produces the *correct* hash on a Mac. Pinning fixes nothing. |
| Python version or CPU architecture | Python 3.12 on arm64 macOS → correct hash. linux/amd64 and linux/arm64 are **byte-identical at every layer**. Both ruled out. |
| Regression since a green baseline on `990a9ae` | That "success" was a dependency-graph workflow, not `ci`; both ran on `990a9ae` in the same second. `ci` has never passed. |
| `db738d7` fixed numpy 1.26 → 2.x drift | Its message is wrong. numpy 2.5.2 on Linux still produces its "numpy 1.26" value today. The old constant was simply the *Linux* value — re-recording it from a Mac is what made CI red. |

## The fix

Hash at 6 significant digits. Measured margin to the nearest rounding boundary is **1289x** the maximum drift. `%.6f` would have been **1.6x** — the same bug with a longer fuse:

| format | min margin | ratio to max drift |
|---|---|---|
| `%.8f` | 1.2e-13 | 0.0 — already straddles |
| `%.6f` | 4.7e-12 | 1.6 |
| **`%.6g`** | **3.7e-09** | **1289** |

Magnitude-relative precision suits prices spanning 26..2030, and is the right invariant for real pinned data too.

## Blast radius

Nil. `trial_registry` exists in no database on disk (`state/fund.sqlite`, the droplet backup) — `TrialRegistry` is only ever constructed `:memory:` in tests. Nothing has ever been logged, so there is no cache to invalidate. `family_n`, `spec_trial_count` and `consume_holdout` key on `family` / `spec_id` / `spec_id` — not `run_key` — so the deflated-Sharpe N was never at risk.

`data_snapshot_hash` and `run_key` change once, deliberately, with authorization under the CLAUDE.md STOP-and-ask invariant. Only 2 of 19 frozen golden values move; all 17 economic metrics were already platform-stable.

## Verification

| Check | Result |
|---|---|
| `tests/run_tests.py` — macOS arm64 | 36 pass, 0 fail |
| `tests/run_tests.py` — linux/amd64, CI's exact install line | 36 pass, 0 fail |
| `tests/run_tests.py` — linux/arm64 | 36 pass, 0 fail |
| Purity lint, both platforms | clean |
| Red-green-restore on the new regression test | pass → **fail** without the fix → pass |
| New constants across platforms | identical |

The new test asserts *stability under perturbation*, not a new magic number, so this cannot recur silently. A second test pins the tolerance from widening so far that a real data change slips through (it fails at `%.2g`).

## Not addressed

`pytest tests/` has 5 pre-existing failures in `tests/test_fund_tools.py` — `mcp` 2.0.0 removed `Server.request_handlers`. Reproduced on clean master with this change stashed. CI does not run them. Pinning `claude-agent-sdk` reaches the droplet, so that is a separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
