### PR TITLE
fix: mcp 2.0 compatibility in tests, and CI that runs the whole suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,15 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - name: Install deps (offline suite needs numpy+pandas only)
-        run: pip install "numpy>=1.23,<3.0" "pandas>=2.0,<3.0"
+      # Read from pyproject rather than restating the list here: a second copy
+      # of a version range is a drift vector, and an unreviewed range is what
+      # put mcp 2.0.0 in a fresh venv while the pinned one stayed on 1.x.
+      - name: Install deps (from pyproject — single source of truth)
+        run: |
+          python3 -c "import tomllib; p = tomllib.load(open('pyproject.toml','rb'))['project']; print('\n'.join(p['dependencies'] + p['optional-dependencies']['dev']))" > /tmp/requirements.txt
+          cat /tmp/requirements.txt
+          pip install -r /tmp/requirements.txt
       - name: Purity lint (no LLM imports, no wall clock — CLAUDE.md invariant 3)
         run: python3 scripts/check_purity.py
-      - name: Offline test suite (no network, no keys; includes frozen golden numbers)
-        run: python3 tests/run_tests.py
+      - name: Full test suite (no network, no keys; includes frozen golden numbers)
+        run: python3 -m pytest tests/

--- a/tests/test_fund_tools.py
+++ b/tests/test_fund_tools.py
@@ -230,14 +230,55 @@ def _server(conn, clock, seat):
     return build_fund_server(lambda: conn, clock, seat)["instance"]
 
 
+def _handlers(server):
+    """(list_tools, call_tool) as plain awaitables, across mcp 1.x and 2.x.
+
+    mcp 2.0 replaced the `request_handlers` dict — keyed by request type, handler
+    taking a whole request and returning a ServerResult wrapper — with
+    `get_request_handler(method)`, whose handler takes (ctx, params) and returns
+    the result directly. These tests pin the registered MCP surface, so they have
+    to reach it whichever way the installed mcp exposes it. Production never
+    touches either: it hands the instance to the SDK.
+    """
+    import mcp.types as mcp
+
+    if hasattr(server, "get_request_handler"):              # mcp >= 2.0
+        listing = server.get_request_handler("tools/list")
+        calling = server.get_request_handler("tools/call")
+
+        async def list_tools():
+            return await listing.handler(None, None)
+
+        async def call_tool(name, args):
+            return await calling.handler(
+                None, calling.params_type(name=name, arguments=args))
+    else:                                                    # mcp 1.x
+        listing = server.request_handlers[mcp.ListToolsRequest]
+        calling = server.request_handlers[mcp.CallToolRequest]
+
+        async def list_tools():
+            req = mcp.ListToolsRequest(method="tools/list")
+            return (await listing(req)).root
+
+        async def call_tool(name, args):
+            req = mcp.CallToolRequest(
+                method="tools/call",
+                params=mcp.CallToolRequestParams(name=name, arguments=args))
+            return (await calling(req)).root
+
+    return list_tools, call_tool
+
+
+def _is_error(result) -> bool:
+    """mcp 2.0 renamed CallToolResult.isError to is_error."""
+    return result.is_error if hasattr(result, "is_error") else result.isError
+
+
 def _tool_names(conn, clock, seat) -> set[str]:
     import asyncio
 
-    import mcp.types as mcp
-
-    handler = _server(conn, clock, seat).request_handlers[mcp.ListToolsRequest]
-    result = asyncio.run(handler(mcp.ListToolsRequest(method="tools/list")))
-    return {t.name for t in result.root.tools}
+    list_tools, _ = _handlers(_server(conn, clock, seat))
+    return {t.name for t in asyncio.run(list_tools()).tools}
 
 
 def _call(conn, clock, seat, name, args):
@@ -245,13 +286,8 @@ def _call(conn, clock, seat, name, args):
     seat's call takes, wrappers included."""
     import asyncio
 
-    import mcp.types as mcp
-
-    handler = _server(conn, clock, seat).request_handlers[mcp.CallToolRequest]
-    request = mcp.CallToolRequest(
-        method="tools/call",
-        params=mcp.CallToolRequestParams(name=name, arguments=args))
-    return asyncio.run(handler(request)).root
+    _, call_tool = _handlers(_server(conn, clock, seat))
+    return asyncio.run(call_tool(name, args))
 
 
 SIGNAL_ARGS = {"ticker": "NVDA", "direction": "bullish", "confidence": 72,
@@ -290,8 +326,6 @@ def test_a_refused_call_comes_back_as_is_error_through_the_wrapper(
     """
     import asyncio
 
-    import mcp.types as mcp
-
     from agents.tools import fund_server
 
     # Build the server while the analyst still HOLDS submit_signal so the tool
@@ -299,16 +333,12 @@ def test_a_refused_call_comes_back_as_is_error_through_the_wrapper(
     # SEAT_CAPS (ADR-0002), so revoking first unregisters the tool and the call
     # dies at the MCP layer ("Tool 'submit_signal' not found") without ever
     # reaching the handler guard this test exists to pin.
-    handler = _server(fund_db, sim_clock,
-                      "analyst").request_handlers[mcp.CallToolRequest]
+    _, call_tool = _handlers(_server(fund_db, sim_clock, "analyst"))
     monkeypatch.setitem(fund_server.SEAT_CAPS, "analyst",
                         frozenset({"get_stage_brief", "read_account"}))
-    result = asyncio.run(handler(mcp.CallToolRequest(
-        method="tools/call",
-        params=mcp.CallToolRequestParams(name="submit_signal",
-                                         arguments=SIGNAL_ARGS)))).root
+    result = asyncio.run(call_tool("submit_signal", SIGNAL_ARGS))
 
-    assert result.isError is True
+    assert _is_error(result) is True
     assert "submit_signal is not granted to seat 'analyst'" in result.content[0].text
     assert result.content[0].text.startswith("error: ")
     assert fund_db.execute("SELECT COUNT(*) c FROM signals").fetchone()["c"] == 0
@@ -320,7 +350,7 @@ def test_a_refused_decision_is_never_reported_as_recorded(fund_db, sim_clock):
     result = _call(fund_db, sim_clock, "pm", "submit_decision",
                    {"ticker": "NVDA", "action": "buy", "qty": 80,
                     "thesis": "t", "invalidation": "i"})
-    assert result.isError is True
+    assert _is_error(result) is True
     assert "no critique row" in result.content[0].text
     assert "decision recorded" not in result.content[0].text
     assert fund_db.execute("SELECT COUNT(*) c FROM decisions").fetchone()["c"] == 0
@@ -333,7 +363,7 @@ def test_the_wrapper_stamps_the_run_date_from_the_injected_clock(fund_db,
     wrapper reading the wall clock would key rows to the wrong day and break
     replay."""
     result = _call(fund_db, sim_clock, "analyst", "submit_signal", SIGNAL_ARGS)
-    assert result.isError is False
+    assert _is_error(result) is False
     assert result.content[0].text == "signal recorded: NVDA"
     assert fund_db.execute("SELECT run_date FROM signals").fetchone()[
         "run_date"] == RUN


### PR DESCRIPTION
Two commits: fix the `mcp` 2.0.0 breakage, then widen CI so that class of breakage cannot hide again.

## The breakage was test-only — no pin needed

`pyproject.toml` declares `claude-agent-sdk~=0.2.116`, which admits `<0.3.0`. A fresh resolve gets **0.2.141**, which widened its own cap from `mcp<2.0.0` to `mcp<3.0.0`, so **mcp 2.0.0** lands. A venv installed months ago stays on 0.2.116 + mcp 1.28.1 — which is why this passed locally and failed in fresh environments.

mcp 2.0 made three changes the tests depended on:

| mcp 1.x | mcp 2.0 |
|---|---|
| `server.request_handlers[CallToolRequest]` | `server.get_request_handler("tools/call") -> HandlerEntry` |
| `handler(request)` → `ServerResult` (unwrap `.root`) | `handler(ctx, params)` → result directly |
| `CallToolResult.isError` | `CallToolResult.is_error` |

**Only the tests broke, because only the tests reached into that internal.** Production hands the server instance to the SDK and never touches it. Verified directly under SDK 0.2.141 + mcp 2.0.0:

- `build_fund_server` builds
- both seats register the correct surface — `analyst`: `get_stage_brief`+`submit_signal`, `pm`: `get_stage_brief`+`submit_decision`
- a real `submit_signal` call round-trips and the row reaches SQLite
- the seat capability guard still refuses a revoked cap

So no dependency pin, and nothing that reaches the droplet. The test helpers now branch on which accessor the installed `mcp` exposes, keeping the suite green on the droplet's 1.x and a fresh venv's 2.x alike.

## CI covered 36 of 908 tests

That gap is why five real failures sat invisible while master read green — and it is the same blind spot that let the golden-hash failure be misread for weeks. A check covering a fraction of the suite still reports one green tick.

`pytest tests/` is a strict superset of `run_tests.py`'s six modules. Dependencies now come from `pyproject.toml` rather than a second hardcoded list, because restating a version range in the workflow is precisely the drift vector that produced this bug: the declared range moved under an unchanged pin and nobody re-read it.

**Verified on this branch's actual CI run** (not just locally): resolved `claude-agent-sdk 0.2.141` + `mcp 2.0.0` — the exact versions that broke — purity lint clean, **908 passed** in 13.7s, ~25s install.

## Consequence worth stating plainly

CI now resolves the SDK and `mcp` on every run, so a future release can break the build. That is the intent — it surfaces where it previously hid. If that turns out to be too noisy, the answer is to pin `claude-agent-sdk` exactly, which is a separate decision because it reaches the droplet.

## Checked and deliberately not changed

`tests/test_eval_env_cannot_trade.py` was flagged as "a skip that reads as green on the guard asserting the eval seat cannot trade". It isn't. The file has four tests and **three run unconditionally**, including the one it calls the load-bearing assertion (`REQUIRED_ENV - EVAL_KEYS ⊇ {FUND_DB, SLACK_BOT_TOKEN}`). Only the fourth skips, and it is a file-contents check that can only run where `.env.eval` exists — which is exactly the host where the scenario it guards against (pasting a real `.env` in) would occur. Making it fail-with-reason would redden the suite on every non-eval host, CI included, since `.env.eval` is secret-bearing and uncommittable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
