### PR TITLE
fix(tests): the renderer guard scanned sibling worktrees, not just this branch

### DIFF
--- a/tests/test_slackkit.py
+++ b/tests/test_slackkit.py
@@ -698,8 +698,8 @@ def test_real_slack_leaves_every_other_slack_error_transient():
     assert not isinstance(exc.value, PermanentPostError)
 
 
-def test_every_written_kind_has_a_renderer():
-    """Static guard: every append_event kind literal in the codebase renders.
+def _written_kinds(root: Path) -> set[str]:
+    """Every append_event kind literal under `root`.
 
     AST-based (not regex): finds every append_event call, requires its kind
     argument to be a string literal (2nd positional or kind= kwarg), and
@@ -708,10 +708,13 @@ def test_every_written_kind_has_a_renderer():
     """
     import ast
 
-    root = Path(__file__).resolve().parents[1]
     kinds = set()
     for py in root.rglob("*.py"):
-        if ".venv" in py.parts or "tests" in py.parts:
+        # Relative to root, never the absolute path: the checkout itself may sit
+        # under a dot-directory (a worktree lives in `.claude/worktrees/`), and
+        # matching absolute components would skip every file and pass vacuously.
+        rel = py.relative_to(root)
+        if any(part.startswith(".") for part in rel.parts) or "tests" in rel.parts:
             continue
         tree = ast.parse(py.read_text(), filename=str(py))
         for node in ast.walk(tree):
@@ -736,5 +739,35 @@ def test_every_written_kind_has_a_renderer():
             assert isinstance(kind_arg, ast.Constant) and isinstance(kind_arg.value, str), (
                 f"{loc}: append_event kinds must be string literals")
             kinds.add(kind_arg.value)
-    missing = kinds - set(RENDERERS)
+    return kinds
+
+
+def test_every_written_kind_has_a_renderer():
+    """Static guard: every append_event kind literal in the codebase renders."""
+    missing = _written_kinds(Path(__file__).resolve().parents[1]) - set(RENDERERS)
     assert not missing, f"event kinds without renderer: {missing}"
+
+
+def test_the_kind_scan_ignores_nested_checkouts_but_keeps_its_teeth(tmp_path):
+    """`.claude/worktrees/` holds sibling checkouts of OTHER branches, and the
+    scan walked into them — so the guard failed on whatever branch you were
+    standing on, naming kinds belonging to code that branch does not contain.
+
+    Both directions are pinned here on purpose. Skipping the nested checkout is
+    only half the requirement; a filter that skips too much (say, one matching
+    dot-components of the absolute path, which contains `.claude` whenever the
+    checkout itself lives under a worktree dir) would empty the scan and leave
+    the guard passing vacuously forever.
+    """
+    (tmp_path / "pkg").mkdir()
+    (tmp_path / "pkg" / "real.py").write_text(
+        "append_event(conn, 'kind_in_this_checkout', {})\n")
+    nested = tmp_path / ".claude" / "worktrees" / "other-branch" / "pkg"
+    nested.mkdir(parents=True)
+    (nested / "stray.py").write_text(
+        "append_event(conn, 'kind_from_another_branch', {})\n")
+
+    kinds = _written_kinds(tmp_path)
+
+    assert "kind_in_this_checkout" in kinds          # teeth: still scans
+    assert "kind_from_another_branch" not in kinds   # ignores the sibling


### PR DESCRIPTION
`test_every_written_kind_has_a_renderer` walked `root.rglob("*.py")` skipping only `.venv` and `tests`, so it descended into `.claude/worktrees/` — where checkouts of **other branches** live — and reported their `append_event` kinds as unrendered against whatever branch you were standing on.

On `second-analyst-seat` it named `scorecard`, `model_fallback_used` and `spec_critique`. None of the three exist in that branch:

```
scorecard           -> .claude/worktrees/{critic-seat,missing-stop-fix}/scripts/score_day.py
model_fallback_used -> .claude/worktrees/{critic-seat,missing-stop-fix}/agents/runtime.py
spec_critique       -> .claude/worktrees/critic-seat/agents/tools/fund_server.py
```

`spec_critique` is the Critic seat work sitting in a sibling worktree. The guard was reporting one branch's code as a defect in another.

## Why it stayed invisible

CI never saw it — `actions/checkout` produces a tree with no nested worktrees — so it landed entirely on developers. And `CLAUDE.md` requires `make test` to pass before every commit, so it quietly made that gate unpassable for anyone with a worktree open.

## The fix, and the trap in the obvious version

Skip dot-directories wholesale, which subsumes the old `.venv` case.

Matched against the path **relative to root, never the absolute one**. A worktree checkout itself lives under `.claude/worktrees/`, so a filter matching absolute path components would skip *every* file, collect nothing, and leave the guard passing vacuously — a silent hole strictly worse than the false positive it replaces. That was the first version I wrote.

## Both directions are pinned

The scan is extracted to `_written_kinds(root)` so the regression test builds its own tree instead of depending on whether the machine running the tests happens to have worktrees:

```python
assert "kind_in_this_checkout" in kinds          # teeth: still scans
assert "kind_from_another_branch" not in kinds   # ignores the sibling
```

The first assertion is what catches the vacuous-pass version. Verified RED before the fix, failing on the second assertion with the first already holding.

## Verification

- Fixed scan against the **real main checkout** with 4 nested worktrees present (`critic-seat`, `missing-stop-fix`, `resolutions-producer`, and this one): **9 kinds, 0 missing renderers** — previously 3 false positives.
- Purity lint clean.
- `909 passed` under both `mcp` 1.28.1 / SDK 0.2.116 and `mcp` 2.0.0 / SDK 0.2.141.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
