### PR TITLE
feat: alert when the fund's orders account for shares the broker no longer holds

### DIFF
--- a/orchestrator/daily.py
+++ b/orchestrator/daily.py
@@ -20,7 +20,8 @@ from typing import Callable
 from gate.risk import Approved, Rejected, size
 from gate.tickets import create_ticket, expire_open_tickets, open_tickets
 from orchestrator.clock import Clock, et_hhmm, iso
-from orchestrator.protection import assert_positions_protected
+from orchestrator.protection import (assert_positions_accounted,
+                                     assert_positions_protected)
 from orchestrator.reconcile import reconcile_orders
 from slackkit.outbox import append_event, drain
 from state.critiques import insert_default_critiques
@@ -481,7 +482,15 @@ def run_day(ctx: StageCtx, *, execution_turn: Callable[[], None] | None = None,
     # run. `sleep` is threaded through for the one short re-read a
     # just-created OTO leg needs to become visible.
     now = iso(ctx.clock.now())
-    if assert_positions_protected(ctx.conn, broker=broker, now_iso=now,
-                                  sleep=sleep):
+    # Two directions, deliberately separate calls: protection asks whether what
+    # the broker holds is covered, accounting asks whether what the fund's own
+    # orders claim is still held. A position that CLOSED produces no broker
+    # position, so the first is structurally silent on exactly the case the
+    # second exists to catch.
+    findings = assert_positions_protected(ctx.conn, broker=broker,
+                                          now_iso=now, sleep=sleep)
+    findings += assert_positions_accounted(ctx.conn, broker=broker,
+                                           now_iso=now, sleep=sleep)
+    if findings:
         drain(ctx.conn, ctx.slack, now)
     run_stage(ctx, "close", lambda: run_close(ctx))

--- a/orchestrator/protection.py
+++ b/orchestrator/protection.py
@@ -23,6 +23,7 @@ quietly, because a check that can pass while lying is worse than no check at
 all (invariant 4)."""
 from __future__ import annotations
 
+import json
 import sqlite3
 from typing import Callable
 
@@ -249,3 +250,172 @@ def assert_positions_protected(conn: sqlite3.Connection, *, broker,
     for text in problems:
         alert(text)
     return len(problems)
+
+
+# --- the mirror: shares the records account for that the broker does not hold -
+
+
+def _recorded_holdings(conn: sqlite3.Connection) -> dict[str, int]:
+    """Net shares per symbol the fund's OWN order records account for.
+
+    THE SEAM. The fund stores no position — `state/schema.sql` has no positions
+    table — so what it holds is *implied* by its filled orders. If a later
+    design stores that fact directly, swap this one read; nothing above it
+    changes.
+
+    `filled_qty > 0` rather than `status = 'filled'`, for the same reason
+    _promised_stop does it: reconcile.py records a timed-out partial as
+    CANCELED with shares genuinely held."""
+    net: dict[str, int] = {}
+    for r in conn.execute("SELECT symbol, side, filled_qty FROM orders"
+                          " WHERE filled_qty > 0"):
+        signed = r["filled_qty"] if r["side"] == "buy" else -r["filled_qty"]
+        net[r["symbol"]] = net.get(r["symbol"], 0) + signed
+    return net
+
+
+def _held_by_symbol(positions: list) -> dict[str, int] | None:
+    """Whole shares per symbol at the broker. None if ANY line is unreadable —
+    the unreadable one could be exactly the position that explains a gap, so a
+    partial answer here would license a false accusation."""
+    out: dict[str, int] = {}
+    for raw in positions:
+        p = raw if isinstance(raw, dict) else {}
+        symbol, qty = p.get("symbol"), _qty(p.get("qty"))
+        if not symbol or qty is None:
+            return None
+        out[str(symbol)] = out.get(str(symbol), 0) + qty
+    return out
+
+
+def _shortfall_text(symbol: str, recorded: int, held: int) -> str:
+    return (f"{symbol}: the fund's own orders account for {recorded} shares"
+            f" but the broker holds {held} — no recorded order explains the"
+            " difference, so something the fund never recorded closed it (a"
+            " stop leg, or an exit placed by hand). Record the exit or"
+            " reconcile by hand; until then the fund's trade history is"
+            " incomplete")
+
+
+def _last_accounting(conn: sqlite3.Connection, symbol: str) -> dict | None:
+    """The most recent thing this guard said about `symbol`, or None.
+
+    A READ of past findings, not a write, so the module's append-nothing
+    discipline and its retraction-safety both survive: a read cannot create
+    anything to retract.
+
+    Most-recent rather than ever-said, and this is the whole design. Matching
+    "have I alerted about NVDA before" would suppress a discrepancy that
+    cleared and then RECURRED — the old event is still in the table, so the
+    second occurrence would stay silent forever. That trades a noise problem
+    for a silence problem, which is the worse of the two and the one this repo
+    keeps being bitten by. A cleared finding is recorded as cleared, which
+    re-arms the alert."""
+    row = conn.execute(
+        "SELECT json_extract(payload, '$.accounting') AS a FROM events"
+        " WHERE kind = 'alert' AND json_extract(payload, '$.accounting.symbol')"
+        " = ? ORDER BY id DESC LIMIT 1", (symbol,)).fetchone()
+    return json.loads(row["a"]) if row and row["a"] else None
+
+
+def assert_positions_accounted(conn: sqlite3.Connection, *, broker,
+                               now_iso: str,
+                               sleep: Callable[[float], None] | None = None
+                               ) -> int:
+    """Alert when the fund's records account for shares the broker does not
+    hold. Returns the number of alerts appended.
+
+    assert_positions_protected iterates BROKER positions, so a position that
+    has CLOSED produces no iteration and no alert. That is right for
+    protection — a closed position needs none — and it is exactly why nothing
+    notices when a stop fires. An OTO stop leg has no `orders` row by
+    construction (agents/runtime.py:151 writes one row per place_* response,
+    keyed on the parent), so the exit that closed the position is recorded
+    nowhere and the fund's account of its own trading is silently wrong.
+
+    Direction matters here as it does above, and it is the opposite one. The
+    BROKER is the authority on what is held; the fund's records are the
+    authority on what the fund DID. This asks only whether the fund's own
+    trades can account for what the broker shows, never the converse — that
+    would alert on every hand-placed intervention these alerts ask for, and
+    assert_positions_protected already covers that direction via _UNKNOWN.
+
+    Reported once per distinct discrepancy, and again if it clears and
+    recurs. The condition is permanent until a human reconciles it, and
+    repeating it every run would redden the audit forever — a permanently red
+    audit is what masks the next new failure. That is a narrower argument than
+    crying wolf: the sanctioned stopless position above is a correct state,
+    while this is a fault that is still a fault on day two. Worth saying once,
+    not worth saying daily."""
+    nap = sleep or (lambda _s: None)
+
+    def alert(text: str, accounting: dict) -> None:
+        append_event(conn, "alert",
+                     {"text": text, "accounting": accounting}, now_iso)
+
+    def why(e: Exception) -> str:
+        return f"{type(e).__name__}: {str(e)[:120]}"
+
+    def unverified(text: str) -> int:
+        append_event(conn, "alert", {"text": text}, now_iso)
+        return 1
+
+    recorded = {s: q for s, q in _recorded_holdings(conn).items() if q > 0}
+    if not recorded:
+        return 0
+
+    if broker is None:
+        return unverified(
+            "position accounting UNVERIFIED — no broker wired into the run;"
+            f" the fund's records account for {len(recorded)} holding(s) and"
+            " nothing can confirm the broker still has them")
+
+    def read() -> dict[str, int] | None:
+        return _held_by_symbol(list(broker.open_positions()))
+
+    def unread(how: str, e: Exception) -> str:
+        return (f"position accounting UNVERIFIED — could not {how} positions"
+                f" ({why(e)}); a holding the fund believes it opened may"
+                " already be gone and nothing would say so")
+
+    try:
+        held = read()
+    except Exception as e:
+        return unverified(unread("read", e))
+
+    if held is None or any(held.get(s, 0) < q for s, q in recorded.items()):
+        # A buy that just filled is recorded before the broker lists the
+        # position, and this runs right after reconciliation — exactly when a
+        # fill has just happened. Without one short wait the fund would alert
+        # on every day it actually trades. Once per run, never once per symbol.
+        nap(_RETRY_S)
+        try:
+            held = read()
+        except Exception as e:
+            return unverified(unread("re-read", e))
+    if held is None:
+        return unverified(
+            "position accounting UNVERIFIED — a position line could not be"
+            " read, so whether the fund's records are accounted for is unknown")
+
+    appended = 0
+    for symbol in sorted(recorded):
+        have, want = held.get(symbol, 0), recorded[symbol]
+        last = _last_accounting(conn, symbol) or {}
+        if have >= want:
+            # Clearing is recorded, not merely observed: without this the next
+            # occurrence would match the stale open finding and stay silent.
+            if not last.get("cleared", True):
+                alert(f"{symbol}: the fund's orders and the broker agree again"
+                      f" at {have} shares — the earlier accounting gap is"
+                      " closed",
+                      {"symbol": symbol, "cleared": True})
+                appended += 1
+            continue
+        if (last.get("recorded"), last.get("held")) == (want, have):
+            continue                      # same finding, already standing
+        alert(_shortfall_text(symbol, want, have),
+              {"symbol": symbol, "recorded": want, "held": have,
+               "cleared": False})
+        appended += 1
+    return appended

--- a/tests/test_protection.py
+++ b/tests/test_protection.py
@@ -4,7 +4,8 @@ failure of all three incidents, so 'fails closed' is a test, not a comment."""
 
 import json
 
-from orchestrator.protection import assert_positions_protected
+from orchestrator.protection import (assert_positions_accounted,
+                                     assert_positions_protected)
 
 NOW = "2026-08-19T20:05:00+00:00"
 
@@ -427,3 +428,178 @@ def test_the_re_read_waits_once_per_run_not_once_per_position(fund_db):
         now_iso=NOW, sleep=naps.append)
     assert n == 3
     assert naps == [3.0]
+
+
+# --- the mirror case: records account for shares the broker does not hold ----
+#
+# assert_positions_protected iterates BROKER positions, so a position that has
+# closed produces no iteration and no alert. That is correct for protection —
+# a closed position needs none — and it is exactly why nothing notices when a
+# stop fires. An OTO stop leg has no `orders` row by construction (one row per
+# place_* response, keyed on the parent), so the fund never records that its
+# own stop closed the position.
+
+
+def _recorded_sell(conn, *, symbol="NVDA", qty=80, filled_qty=None,
+                   tid="b7c90000-0000-4000-8000-000000000001",
+                   submitted_at="2026-08-18T19:59:00+00:00", status="filled"):
+    """A filled SELL the fund placed through the gate — the thing whose absence
+    makes a broker-side exit unexplainable."""
+    cur = conn.execute(
+        "INSERT INTO decisions (run_date, ticker, action, qty, thesis,"
+        " invalidation, stop_price, status, created_at) VALUES"
+        " (?, ?, 'sell', ?, 't', 'i', NULL, 'executed', ?)",
+        (submitted_at[:10], symbol, qty, submitted_at))
+    conn.execute(
+        "INSERT INTO tickets (id, decision_id, ticker, side, max_qty,"
+        " stop_price, expires_at, status, created_at)"
+        " VALUES (?, ?, ?, 'sell', ?, NULL, ?, 'consumed', ?)",
+        (tid, cur.lastrowid, symbol, qty, submitted_at, submitted_at))
+    conn.execute(
+        "INSERT INTO orders (client_order_id, symbol, side, qty, status,"
+        " filled_qty, submitted_at) VALUES (?, ?, 'sell', ?, ?, ?, ?)",
+        (tid, symbol, qty, status, qty if filled_qty is None else filled_qty,
+         submitted_at))
+    conn.commit()
+
+
+def test_a_holding_the_broker_confirms_is_silent(fund_db):
+    _promised(fund_db)
+    n = assert_positions_accounted(
+        fund_db, broker=Broker([_long("NVDA", "80")], []), now_iso=NOW)
+    assert n == 0
+    assert _alerts(fund_db) == []
+
+
+def test_a_recorded_buy_the_broker_no_longer_holds_alerts(fund_db):
+    """The issue-5 case. The stop fired, the broker is flat, and no `orders`
+    row explains it."""
+    _promised(fund_db)
+    n = assert_positions_accounted(fund_db, broker=Broker([], []), now_iso=NOW)
+    assert n == 1
+    text = _alerts(fund_db)[0]
+    assert "NVDA" in text and "80" in text
+    assert "0" in text
+
+
+def test_a_partial_disappearance_names_the_shortfall(fund_db):
+    _promised(fund_db)
+    n = assert_positions_accounted(
+        fund_db, broker=Broker([_long("NVDA", "30")], []), now_iso=NOW)
+    assert n == 1
+    assert "30" in _alerts(fund_db)[0]
+
+
+def test_a_recorded_sell_explains_the_absence(fund_db):
+    """Bought 80 and sold 80, both through the gate. Nothing is unexplained."""
+    _promised(fund_db)
+    _recorded_sell(fund_db)
+    n = assert_positions_accounted(fund_db, broker=Broker([], []), now_iso=NOW)
+    assert n == 0
+    assert _alerts(fund_db) == []
+
+
+def test_a_position_with_no_record_is_not_this_guards_business(fund_db):
+    """The other direction — the broker holds something the fund never opened.
+    assert_positions_protected already alerts on that via _UNKNOWN; two alerts
+    for one condition would be noise."""
+    n = assert_positions_accounted(
+        fund_db, broker=Broker([_long("MSFT", "40")], []), now_iso=NOW)
+    assert n == 0
+    assert _alerts(fund_db) == []
+
+
+def test_an_unchanged_discrepancy_alerts_once_not_every_run(fund_db):
+    """The condition is permanent until a human reconciles it. Repeating it
+    daily would redden the audit forever, and a permanently red audit is what
+    masks the next new failure."""
+    _promised(fund_db)
+    broker = Broker([], [])
+    first = assert_positions_accounted(fund_db, broker=broker, now_iso=NOW)
+    second = assert_positions_accounted(fund_db, broker=broker, now_iso=NOW)
+    assert (first, second) == (1, 0)
+    assert len(_alerts(fund_db)) == 1
+
+
+def test_a_discrepancy_that_changes_shape_alerts_again(fund_db):
+    """30 of 80 missing and then all 80 missing are different facts. Dedup must
+    not swallow the second."""
+    _promised(fund_db)
+    assert_positions_accounted(
+        fund_db, broker=Broker([_long("NVDA", "30")], []), now_iso=NOW)
+    n = assert_positions_accounted(
+        fund_db, broker=Broker([], []), now_iso=NOW)
+    assert n == 1
+    assert len(_alerts(fund_db)) == 2
+
+
+def test_unreadable_positions_fail_closed(fund_db):
+    """Same rule as the rest of the module: a check that can pass while lying
+    is worse than no check at all."""
+    class Broken:
+        def open_positions(self): raise ConnectionError("401 unauthorized")
+        def open_orders(self): return []
+
+    _promised(fund_db)
+    n = assert_positions_accounted(fund_db, broker=Broken(), now_iso=NOW)
+    assert n == 1
+    assert "UNVERIFIED" in _alerts(fund_db)[0]
+
+
+def test_no_broker_fails_closed(fund_db):
+    _promised(fund_db)
+    n = assert_positions_accounted(fund_db, broker=None, now_iso=NOW)
+    assert n == 1
+    assert "UNVERIFIED" in _alerts(fund_db)[0]
+
+
+def test_a_position_that_is_merely_slow_to_appear_is_not_a_discrepancy(fund_db):
+    """A buy that just filled is recorded before the broker lists the position.
+    Without one short wait the fund would alert on every day it actually
+    trades — the same lag assert_positions_protected naps for."""
+    class SlowPosition(Broker):
+        def __init__(self, positions):
+            super().__init__(positions, [])
+            self.reads = 0
+
+        def open_positions(self):
+            self.reads += 1
+            return self._positions if self.reads > 1 else []
+
+    _promised(fund_db)
+    broker = SlowPosition([_long("NVDA", "80")])
+    naps = []
+    n = assert_positions_accounted(fund_db, broker=broker, now_iso=NOW,
+                                   sleep=naps.append)
+    assert n == 0, "alerted on a position the broker had not listed yet"
+    assert broker.reads == 2, "positions were not re-read after the wait"
+    assert naps == [3.0]
+
+
+def test_a_discrepancy_that_clears_and_recurs_alerts_again(fund_db):
+    """The failure dedup-by-history would introduce. Matching "have I ever
+    alerted about NVDA" leaves the old event in the table forever, so the
+    SECOND occurrence stays silent — trading a noise problem for a silence
+    problem, which is the worse one."""
+    _promised(fund_db)
+    assert assert_positions_accounted(
+        fund_db, broker=Broker([], []), now_iso=NOW) == 1
+    # the gap closes: the broker shows the shares again
+    assert assert_positions_accounted(
+        fund_db, broker=Broker([_long("NVDA", "80")], []), now_iso=NOW) == 1
+    # ...and the identical gap returns. It must be reported, not swallowed.
+    n = assert_positions_accounted(fund_db, broker=Broker([], []), now_iso=NOW)
+    assert n == 1, "a recurrence of a cleared discrepancy was swallowed"
+    texts = _alerts(fund_db)
+    assert len(texts) == 3
+    assert "closed" in texts[1]
+
+
+def test_a_standing_discrepancy_is_not_reported_as_cleared(fund_db):
+    """The clear must fire on a real transition, not on every quiet run."""
+    _promised(fund_db)
+    _recorded_sell(fund_db)                 # nets to zero: nothing to account
+    for _ in range(3):
+        assert assert_positions_accounted(
+            fund_db, broker=Broker([], []), now_iso=NOW) == 0
+    assert _alerts(fund_db) == []


### PR DESCRIPTION
Closes #5 — but not with the fix it asked for. Its premise does not hold, and the detector its title describes would be dead on arrival.

## Why the issue as written could not be built

- **There is no positions table.** `state/schema.sql` has signals, critiques, decisions, tickets, orders, resolutions, checkpoints, events, costs. The DB stores no position, so there is no stored belief to desync.
- **Positions come from the broker.** `market/source_alpaca.py:161-170` builds the seats' brief and the gate's inputs from `get_all_positions()`, read fresh each day.
- **No production consumer derives a held quantity from `orders`.** All call sites are order-lifecycle, idempotency, promised-stop lookup (buys only), or reporting.
- **`resolve.py` is immune by design** — it measures from price frames, and says so: an early exit must not shorten the window.

So "the fund's database will go on believing it holds NVDA 80 while the broker is flat" cannot happen as stated.

Separately, the **order-keyed** detector in the title — flag broker orders with no `orders` row — would fire on **every legitimately stopped position**, because an OTO stop leg has no `orders` row by construction (`agents/runtime.py:151` writes one row per `place_*` response, keyed on the parent). Credit to `fund-29` for that observation.

## What is actually broken

The mirror of the case `protection.py` already covers.

`assert_positions_protected` iterates **broker** positions, so a position that has **closed** produces no iteration and no alert. That is correct for protection — a closed position needs none — and it is exactly why nothing notices when a stop fires. The fund's own account of its trading goes silently wrong: the leg fills, the position is gone, and no `orders` row records the exit.

| direction | covered? |
|---|---|
| broker holds a position the fund has no record of | yes — `_promised_stop` → `_UNKNOWN` → alert |
| the fund's records imply a holding the broker lacks | **nothing saw it** |

## The design

`assert_positions_accounted` is additive and read-only: it does not change `assert_positions_protected`'s contract.

`_recorded_holdings` is **the seam**. The fund stores no position, so what it holds is implied by filled orders. If a later design stores that fact directly, swap that one read and nothing above it changes.

It reports **once per distinct discrepancy, and again if the discrepancy clears and recurs.** Repeating every run would redden the audit forever, and a permanently red audit is what masks the next new failure. That is a narrower argument than crying wolf: the sanctioned stopless position `protection.py` deliberately stays quiet about is a *correct state*, while this is a fault that is still a fault on day two.

**The re-arm is the load-bearing part.** Matching "have I ever alerted about NVDA" leaves the old event in the table forever, so a discrepancy that cleared and recurred would stay silent — trading a noise problem for a **silence** problem, which is the worse one. A cleared finding is recorded as cleared. `fund-29` caught this; it would have shipped otherwise.

Reading past findings is a read, not a write, so the module's "appends nothing" discipline and its retraction-safety both survive intact.

## Verification

- **967 passed**, purity lint clean.
- 12 new tests, including both directions of the dedup and the fail-closed paths.
- **The re-arm test has teeth, proven not assumed**: simulating the naive dedup (match the last non-cleared finding) makes it fail `assert 0 == 1` — the recurrence swallowed, exactly the predicted silence bug.
- A just-filled buy is recorded before the broker lists the position, so without one short wait this would alert on every day the fund trades. Same lag `assert_positions_protected` naps for; pinned by its own test.

## Note for the issue

The title should be amended — it describes the order-keyed detector, which cannot work, and a consequence that does not exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
