### PR TITLE
a case id names a case only within a seat, and grade_traces assumed otherwise

### DIFF
--- a/evals/grade.py
+++ b/evals/grade.py
@@ -98,7 +98,16 @@ def grade_traces(traces_root: Path | str, cases: dict[str, Case],
 
     `invariants=None` grades each trace against ITS seat's registry — the
     right default for a traces root holding more than one seat. An explicit
-    dict is honored verbatim, which is what lets a caller grade a subset."""
+    dict is honored verbatim, which is what lets a caller grade a subset.
+
+    A case id identifies a case only WITHIN a seat — evals/cases/<seat>/ is
+    per-seat, so an `a02` exists once per seat and they are different cases.
+    A mapping that spans seats therefore collides on the id. That matters
+    most for exactly the multi-seat root the line above is written for: the
+    invariants would be selected from the TRACE's seat while the
+    expectations came from another seat's case, which reads as a plausible
+    verdict rather than an error. Both sides carry `seat`, so the pair is
+    checked rather than assumed."""
     results = []
     for path in sorted(Path(traces_root).rglob("*.json")):
         trace = Trace.read(path)
@@ -107,6 +116,12 @@ def grade_traces(traces_root: Path | str, cases: dict[str, Case],
             raise ValueError(
                 f"{path}: no case file for {trace.case!r} — a trace cannot be"
                 " graded against expectations that no longer exist")
+        if trace.seat != case.seat:
+            raise ValueError(
+                f"{path}: trace is seat {trace.seat!r} but case"
+                f" {trace.case!r} in this mapping is seat {case.seat!r} —"
+                " case ids repeat across seats, so this pair would score one"
+                " seat against another seat's expectations")
         results.append(grade_trace(
             trace, case,
             invariants if invariants is not None else seat_registry(trace.seat)))

--- a/tests/test_evals_runner.py
+++ b/tests/test_evals_runner.py
@@ -8,6 +8,7 @@ missing, session crash, rows captured, alerts captured — is exercised for $0.
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -297,6 +298,22 @@ def test_grade_applies_the_seats_invariant_registry(case, tmp_path):
                            invariants={"I9": i_always_fails})
     assert calls == ["a01"]
     assert results[0].verdicts[0].outcome == "FAIL"
+
+
+def test_grade_refuses_a_trace_whose_seat_is_not_the_cases_seat(case,
+                                                                tmp_path):
+    """Case ids repeat across seats — a pm a02 and a critic a02 are different
+    cases sharing an id — so a lookup keyed on id alone grades a PM trace
+    against another seat's expectations and reports the verdict as real.
+    Both Trace and Case already carry `seat`, so this is a comparison rather
+    than new plumbing. Preventive: evals/cases/ is pm-only today, and the
+    collision arrives with the second seat's cases."""
+    run_trial("pm", case, 1, session=decide(), workdir=tmp_path,
+              traces_root=tmp_path / "traces")
+    with pytest.raises(ValueError, match="seat"):
+        grade_traces(tmp_path / "traces",
+                     cases={case.id: replace(case, seat="critic")},
+                     invariants={})
 
 
 def test_grade_of_an_errored_trace_is_inconclusive_not_failed(case, tmp_path):


### PR DESCRIPTION
## What

`evals/cases/` is per-seat, so an `a02` exists once per seat and they are different cases. `grade_traces` looked the case up on `trace.case` alone, so a `cases` mapping spanning seats collides on the id and grades a trace against **another seat's expectations** — then reports that verdict as the trial's own.

Both `Trace` and `Case` already carry `seat`, so this is a comparison rather than new plumbing.

## Why now — preventive, not corrective

`evals/cases/` is `pm`-only on master today (`git ls-tree -r origin/master -- evals/cases/critic/` → 0 files), so **nothing collides yet**. Both preconditions — a second seat's cases, and a caller that merges seats into one mapping — arrive together with the Critic work. Closing it before they land is cheaper than after.

## Coordination

`feat/g1-alignment-gate` reshapes this same function (new signature, `seat_registry()` helper, per-trace fallback). That branch's owner released `evals/grade.py`, asked that the check be written to survive the signature changing underneath, and will resolve the rebase conflict keeping both. This change deliberately stays clear of the `invariants` argument for that reason.

Note for anyone reasoning across the two: on master, `invariants` is a **required positional with no `| None = None` fallback**. Branch-side reasoning does not transfer.

## Verification

- Test written first; failed with `DID NOT RAISE ValueError` — feature missing, not a typo.
- Full red-green cycle: reverting `evals/grade.py` alone reddens it; restoring greens it.
- `tests/test_evals_runner.py` 21 → 22 tests.
- `make test`: **956 passed, 1 skipped, 6 deselected**. Purity lint clean.
- No golden fixture, expected hash, or expected value touched.