### PR TITLE
docs: wiring a live Critic needs the JSON decode too, not just the scan

### DIFF
--- a/evals/live.py
+++ b/evals/live.py
@@ -64,6 +64,14 @@ def rows_written(conn, seat: str, run_date: str) -> dict:
     bug: whoever adds that stage must give this function the seat-scoped scan
     the table actually needs (`WHERE seat = ?`, ordered by `spec_id`), and
     should not discover the requirement from a traceback on the trading path.
+
+    TWO halves are needed there, not one. The scan is the obvious half; the
+    other is JSON decoding. `strategy_critiques.objections` is stored as JSON
+    text, so a scan alone hands every grader a raw string where the model
+    declares a list — `evals/runner.py:JSON_COLUMNS` already does this for the
+    rig, and a live trace that skipped it would grade differently from an eval
+    trace of the same turn. That divergence is exactly what moving ROW_COLUMNS
+    into evals/trace.py exists to prevent.
     """
     out = {}
     for table in WRITE_TABLES.get(seat, ()):


### PR DESCRIPTION
Comment-only, one docstring paragraph in `evals/live.py`.

The `DAILY_TABLES` skip guard merged in #21 tells whoever wires a Critic stage what to supply — the seat-scoped scan `strategy_critiques` actually needs — and stopped there. That is half the requirement.

`strategy_critiques.objections` is stored as JSON text. A scan alone hands every grader a raw string where the pydantic model declares a list, so a **live** trace would grade differently from an **eval** trace of the same turn. That is precisely the divergence moving `ROW_COLUMNS` into `evals/trace.py` exists to prevent. `evals/runner.py:JSON_COLUMNS` already does the decode for the rig.

Not a defect today — nothing schedules a Critic turn. Recorded here rather than on a session's map because maps die with their session and the docstring is where the person doing the wiring will actually be standing.

Found by `fund-50` reviewing the merged guard in its own region.

1,105 passing.