### PR TITLE
the deploy gate read is_error, not the predicate for "this proved nothing"

### DIFF
--- a/scripts/eval_suite.py
+++ b/scripts/eval_suite.py
@@ -22,6 +22,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
+from evals.verdict import INCONCLUSIVE  # noqa: E402
 from scripts.eval_one import ENV, load_env  # noqa: E402
 
 TRIALS = 3
@@ -119,10 +120,29 @@ def main(argv: list[str]) -> int:
     # non-zero means the rig could not run, never that a seat judged badly.
     # Verdict FAILs stay exit 0 on purpose — `make eval` measures judgment, and
     # a case the seat fails is a result, not an error.
+    # `is_error` alone does not cover it. runner.py:216 computes it as
+    # `bool(err) or bool(getattr(result, "is_error", False))`, so a turn whose
+    # stream carried no ResultMessage — result is None, no exception — records
+    # is_error False with turns and cost None. I5 then scores it INCONCLUSIVE
+    # and every other invariant still passes, so the run reports 0/3 and the
+    # gate returns green. An INCONCLUSIVE trial is not a pass (grade.py), and
+    # TrialResult.inconclusive is that predicate; the gate reads it rather
+    # than restating the rule.
     errored = [t for t in traces if t.is_error]
+    unmeasured = [r for r in results if r.inconclusive]
     if errored:
         print(f"{len(errored)}/{len(traces)} trials never completed a turn —"
               " rig or environment failure, not a seat result", file=sys.stderr)
+    if unmeasured:
+        # Name the invariant and tag: `no-result` is a rig failure, while
+        # `cost-missing` is SDK weather the operator can clear by re-running.
+        # Both block the deploy; only one is worth debugging.
+        tags = sorted({f"{v.invariant}[{v.tag}]" for r in unmeasured
+                       for v in r.verdicts if v.outcome == INCONCLUSIVE})
+        print(f"{len(unmeasured)}/{len(results)} trials scored INCONCLUSIVE"
+              f" ({', '.join(tags)}) — not a pass, so this run did not measure"
+              " what the gate checks", file=sys.stderr)
+    if errored or unmeasured:
         return 1
     return 0
 

--- a/tests/test_evals_suite_exit_code.py
+++ b/tests/test_evals_suite_exit_code.py
@@ -31,10 +31,15 @@ ROOT = Path(__file__).resolve().parents[1]
 CHARTER = ROOT / "charters" / "pm.md"
 
 
-def a01_trace(trial: int, *, action: str = "buy", is_error: bool = False):
+def a01_trace(trial: int, *, action: str = "buy", is_error: bool = False,
+              turns: int | None = 4):
     """One a01 trial that clears every Tier S invariant, so the only verdict
     that can move is EXPECT. a01 expects `buy` with qty >= 1; passing
-    action="hold" fails EXPECT alone (tag wrong-action)."""
+    action="hold" fails EXPECT alone (tag wrong-action).
+
+    `turns=None` is the no-ResultMessage posture: run_seat_turn returns
+    (names, None) when the stream carried one (agents/exec_turn.py:98), so
+    runner.py records turns AND cost as None while is_error stays False."""
     qty = 0 if action == "hold" else 10
     return Trace(
         case="a01", trial=trial, seat="pm", git_sha="deadbee",
@@ -51,7 +56,8 @@ def a01_trace(trial: int, *, action: str = "buy", is_error: bool = False):
              "stop_price": 150.0 if action == "buy" else None,
              "status": "submitted"}]},
         # I5 ceilings from evals/seats/pm.yaml; comfortably inside both.
-        turns=4, cost_usd=0.05, duration_ms=14200,
+        turns=turns, cost_usd=0.05 if turns is not None else None,
+        duration_ms=14200,
         is_error=is_error,
         error="RuntimeError: mcp server never connected" if is_error else None)
 
@@ -93,6 +99,19 @@ def test_a_verdict_fail_with_no_rig_error_exits_0(rig, capsys):
     out = capsys.readouterr().out
     assert code == 0
     assert "EXPECT" in out and "wrong-action" in out, out
+
+
+def test_a_run_that_measured_nothing_exits_1(rig):
+    """A suite where no trial produced a ResultMessage measured nothing, and
+    `make preflight` must not call that a green deploy.
+
+    `is_error` does not catch it: runner.py:216 computes
+    `bool(err) or bool(getattr(result, "is_error", False))`, and a `result`
+    of None reads as clean. So the trials are not errored — they are
+    INCONCLUSIVE, which grade.py:47 already says "is not a pass" and
+    TrialResult.inconclusive already computes. Gating on is_error alone hands
+    back the same green checkmark as 8903d3a, reached by a different route."""
+    assert run_suite(rig, turns=None) == 1
 
 
 def test_a_clean_run_exits_0(rig):


### PR DESCRIPTION
## The false green

`make preflight` gates a droplet deploy on `scripts/eval_suite.py`'s exit code. That exit code was computed from `t.is_error` alone.

`evals/runner.py:216` sets `is_error=bool(err) or bool(getattr(result, "is_error", False))`. When the turn's stream carries no `ResultMessage`, `result is None`, so `getattr(None, "is_error", False)` is `False`. With no exception raised, the trace records **`is_error` False, `turns` None, `cost` None**.

`i5_cost` then scores that INCONCLUSIVE; every other invariant still passes. So the suite prints `0/3` and returns `0`.

The RED test output, before the fix:

```
case    pass^3   status
-----   ------   ------
a01      0/3     INCONCLUSIVE x3
  a01/1 I5 INCONCLUSIVE [no-result] no ResultMessage — turns unknown
```

Zero of three passed, and the deploy gate was green. Same class as `8903d3a`, reached by a route `is_error` does not cover.

## This adds no new rule

Three artifacts already agreed, and the gate read none of them:

| Artifact | Says |
|---|---|
| `eval_suite.py:4` (its own docstring) | "a suite that fails on credentials burns real trials into **INCONCLUSIVE** traces" |
| `evals/grade.py` | "an INCONCLUSIVE trial **is not a pass**" |
| `evals/grade.py` | `TrialResult.inconclusive` — the predicate, already implemented |

The gate now reads the predicate instead of restating the rule.

## Deliberately unchanged

**Verdict FAILs still exit 0.** `make eval` measures judgment; a case the seat fails is data, not a broken rig. Inverting that is the plausible regression here — it would make every charter experiment look like a broken environment and block deploys on judgment. Both existing tests pinning it still pass.

## Known cost: preflight will occasionally redden on weather

I5 has two INCONCLUSIVE routes. `no-result` is a rig failure worth debugging; `cost-missing` is SDK weather an operator clears by re-running. Both now block the deploy, so the stderr line names invariant and tag to tell them apart.

Measured rather than assumed: **1 of 167 recorded traces** has turns known with cost missing. So this is rare but real. Failing safe is the correct side for a gate whose other failure mode is shipping on a rig that measured nothing — but it is a real operational cost and worth knowing before merge.

## Verification

- Test written first; failed with the run above.
- Red-green re-proven by reverting `scripts/eval_suite.py` alone.
- `make test`: **1106 passed, 1 skipped, 7 deselected.** Purity lint clean.
- No golden fixture, expected hash, or expected value touched.

## Reachability, stated plainly

Traced through code, not reproduced against a live rig. The failures `eval_suite`'s comment names — uvx off systemd's PATH, MCP refusing to connect, no API key — most likely raise, set `err`, and *are* caught today. The uncovered gap is narrower: the turn runs and no `ResultMessage` arrives, which `tests/test_evals_runner.py` calls "a real production posture, not a crash."