### PR TITLE
docs: state the firm's end goal, and the research behind it

### DIFF
--- a/VISION.md
+++ b/VISION.md
@@ -1,0 +1,133 @@
+# Vision — the firm at steady state
+
+What we are shooting for. Not a plan and not a spec — a picture of the finished
+thing, to remember what all the plumbing is in service of.
+
+*(`fund`, this repo, is the proving ground and stays paper-only. The firm below
+trades real capital, and getting there is its own deliberate project.)*
+
+---
+
+## The end state
+
+A working investment firm, staffed by long-lived AI agents, run by one person.
+
+It researches its own ideas, argues them properly, sizes them, trades them, and
+grades itself on what actually happened. It runs every day whether or not
+anyone is watching. It trades real money — ours. And the agents inside it get
+better over months, because the firm keeps score honestly enough to know which
+of its own opinions were worth anything.
+
+It stays small on purpose. What edge is left at this horizon lives in the
+corners that large institutions can't fit into, so size is the thing most likely
+to destroy the advantage. The firm is trying to be right, not big.
+
+The interesting part isn't that the agents are smart. It's that the firm knows
+what it doesn't know, and acts that way.
+
+## The floors
+
+**The research floor.** Analyst desks, each with its own beat — the tape and
+market structure, news and sentiment, macro and rates, company fundamentals.
+Each one shows up every morning with a view, from its own data, in its own
+voice. They disagree with each other, and that's the point.
+
+**The lab.** A standing research operation inventing, testing, and killing
+systematic strategies. Most of what it proposes dies, which is how you know the
+testing is real. What survives earns capital and keeps it only while it works.
+The lab never stops running, because an edge that isn't being replaced is an
+edge quietly expiring.
+
+**The debate.** Seats whose whole job is attacking the firm's own conclusions —
+the bull, the bear, and a critic who goes after the reasoning rather than the
+position. Every serious multi-agent system ever built keeps a seat like this,
+and the ones that dropped it regretted it.
+
+**The portfolio manager.** One seat that sees all of it — the desks, the
+argument, the lab's strategies, the current book — and decides what the firm
+does today. It listens to each analyst in proportion to how right that analyst
+has actually been, not how good today's pitch sounded.
+
+**The trader.** Places the orders. Has no opinions.
+
+**The gate.** The deterministic layer between every decision and every order.
+It sizes from volatility and correlation, holds the firm's limits, and either
+approves or refuses. No judgment, no language model, no talking it around. This
+is the thing that makes the rest of it safe to run, and it behaves identically
+on the day the account is real as it did on every paper day before it.
+
+**The scorecard.** Every seat graded continuously on whether it was right and
+whether its confidence meant anything. Desks that turn out to have no edge get
+narrowed or retired. Nobody grades themselves.
+
+**Operations and the books.** The morning standup, the watch on open positions,
+the end-of-day digest, P&L attributed by desk and by strategy, and the running
+cost of the firm's own thinking.
+
+**The data.** The firm buys its own eyes — real-time market data rather than a
+partial free feed, a real news wire with history, corporate actions, and enough
+monitoring to know when a feed has gone stale before it acts on it.
+
+**The human.** One, and it stays one. Allocates the capital, sets the limits,
+decides which desks exist, and carries what can't be handed to a process.
+Everything else, the firm does itself.
+
+## A day, once it's all running
+
+The desks report before the open, each on its own beat. Where they disagree, the
+bull and bear take it apart and the critic goes after the reasoning. The PM
+reads all of it, weighs each voice by its record, and decides. The gate sizes
+what it approves and refuses what it won't. The trader executes. The book is
+reconciled, the day is written down, and that night the calls that came due get
+scored against what the market actually did — which is what the desks read
+tomorrow morning before they open their mouths.
+
+Most days it makes one or two small decisions. Some days the right answer is to
+do nothing at all, and it does nothing, without anyone having to intervene.
+
+## Counting forward
+
+There's one way a firm like this fools itself that no amount of care in the
+trading fixes. An agent asked how a stock did in some past quarter may simply
+remember — the period it's being tested on was in its training data. Tested that
+way, these systems look brilliant and then lose half their edge the moment
+they're asked about a future nobody has seen. It's the failure mode that makes
+most published results in this field worth very little.
+
+So the firm's record is built forward, out of calls made before the outcome
+existed, on days that hadn't happened yet. Slow, and the only kind that counts.
+It also means the years of paper trading aren't a rehearsal to be endured —
+they're the measurement, and the only clean one available.
+
+## What success looks like
+
+The firm's confidence means something — when a desk says seventy percent, it
+happens about seventy percent of the time. It runs a handful of modest,
+uncorrelated strategies that survived honest testing, none of them spectacular,
+which against the base rates for this activity is a genuinely good outcome. The
+cost of running the whole thing is known and unremarkable. When something breaks
+or a feed goes quiet, the firm stops on its own rather than guessing. And it
+learns fast enough that this year's agents are measurably better than last
+year's — measurably, because anything less is a story.
+
+Returns matter too, but they're the last thing to become readable and the
+easiest to fool yourself about.
+
+If it turns out the agents simply can't do this — enough graded calls, no skill,
+no improvement — then the firm says so out loud and stops. That possibility is
+what makes the rest of it worth taking seriously.
+
+## Where we are
+
+As of August 2026: a paper account, two analyst desks, a portfolio manager, a
+trader, and the gate — running a real market day end to end and unattended,
+from the pre-gate through research, decision, the gate, execution,
+reconciliation, and the close. A nightly job resolves decisions once they reach
+their horizon, which is what will eventually give the grading something to work
+with.
+
+No debate — the decision stage records a default clearance, because there is no
+critic seat in it yet. No bull, no bear, no macro, no operations seat. The lab
+is built and tested but nothing routes to it. Most of what this document
+describes is still ahead of us; the path is in
+[`specs/design.md`](specs/design.md) §7.

--- a/VISION.md
+++ b/VISION.md
@@ -3,8 +3,9 @@
 What we are shooting for. Not a plan and not a spec — a picture of the finished
 thing, to remember what all the plumbing is in service of.
 
-*(`fund`, this repo, is the proving ground and stays paper-only. The firm below
-trades real capital, and getting there is its own deliberate project.)*
+*(The account is paper today, and stays paper for a long time — that's the
+measurement, not a holding pattern. Real capital is where this ends up: the last
+step of this project, not a different one.)*
 
 ---
 
@@ -28,9 +29,11 @@ what it doesn't know, and acts that way.
 ## The floors
 
 **The research floor.** Analyst desks, each with its own beat — the tape and
-market structure, news and sentiment, macro and rates, company fundamentals.
-Each one shows up every morning with a view, from its own data, in its own
-voice. They disagree with each other, and that's the point.
+market structure, news and sentiment, macro and rates. Each shows up every
+morning with a view, from its own data, in its own voice. They disagree with
+each other, and that's the point. Fundamentals is the desk that doesn't fit
+this rhythm: it needs evidence that arrives quarterly and a source the firm
+doesn't have yet, so it earns a seat only once there's a slower stage to sit in.
 
 **The lab.** A standing research operation inventing, testing, and killing
 systematic strategies. Most of what it proposes dies, which is how you know the
@@ -67,6 +70,12 @@ cost of the firm's own thinking.
 **The data.** The firm buys its own eyes — real-time market data rather than a
 partial free feed, a real news wire with history, corporate actions, and enough
 monitoring to know when a feed has gone stale before it acts on it.
+
+**Slack.** Where the firm is visible. Every report, argument, gate verdict, fill
+and digest lands in a channel as it happens, so a day can be read after the fact
+or watched while it runs, and any seat can be asked a question and will answer
+from its own record. It's the firm's face and its running log — never the place
+decisions actually come from.
 
 **The human.** One, and it stays one. Allocates the capital, sets the limits,
 decides which desks exist, and carries what can't be handed to a process.

--- a/research/field-brief-autonomous-agent-firms.md
+++ b/research/field-brief-autonomous-agent-firms.md
@@ -1,0 +1,158 @@
+# Field brief: autonomous multi-agent trading firms
+
+**Date:** 2026-08-20 · **Prepared for:** writing an end-goal vision doc for `fund` — what a one-human, N-agent firm realistically becomes · **Depth:** normal-to-deep, ~16 searches/fetches
+
+## State of the field *(prose)*
+
+Two years of multi-agent trading papers have produced a large, architecturally
+inventive, and empirically thin literature, and 2026 is the year the field
+started saying so about itself. The two most useful papers of the year are both
+critiques rather than systems: a taxonomy-and-evaluation survey that argues
+**coordination design dominates agent count**, and a systematic audit of 77
+LLM-trading studies through March 2026 that found almost none of them met basic
+empirical standards — one paper in the whole corpus modeled transaction costs,
+one handled survivorship, none hit the top reproducibility tier. Meanwhile the
+one clean real-money experiment anyone has run, nof1's Alpha Arena, gave six
+frontier models $10k each and watched four of them lose money, with the
+organizers attributing the damage to over-trading whose fees erased small
+gains. On the commercial side, 2026 produced the field's first genuinely
+agentic funds — Lumenai and YC's Standard Signal — but both landed on the same
+structural answer: agents decide *inside constraints that infrastructure
+enforces*, with a human holding ultimate responsibility. Against that, the
+Mercer survey of 131 asset managers found only ~6% let AI make decisions at
+all. The practical summary: architecture is a solved-enough problem, evaluation
+is not, and the frontier position is not "more agents" but "agents inside an
+envelope, with the books to prove what happened."
+
+## Core concepts and vocabulary
+
+- **Coordination primacy** — the finding that *how* agents interact (debate,
+  hierarchy, structured handoff) determines outcome quality far more than how
+  many agents there are; naive agent addition can degrade performance.
+- **Envelope / defined constraints** — the industry's converged phrasing for a
+  deterministic layer the model cannot argue past. Lumenai: "decision-makers
+  within defined constraints." Standard Signal: "hard risk limits are enforced
+  by our infrastructure rather than by the model."
+- **Closed-loop evaluation** — an evaluation where the agent's action feeds back
+  into the state it next observes; the audit's minimum bar, and one most papers
+  fail.
+- **Time-consistent split protocol** — train/test separation that respects
+  chronology, so the agent cannot see the future. 2 of 19 qualifying studies had
+  an extractable one.
+- **Survivorship handling** — correcting for delisted/dead names in the universe;
+  documented in exactly one of 77 studies.
+- **Transaction-cost model** — an explicit fee/slippage model in the evaluation;
+  present in one of 77 studies, and the single factor that decided Alpha Arena.
+- **Darwinian org chart** — continuously scoring agents on realized outcomes and
+  adopting only top-ranked output (ContestTrade); the scaling path beyond fixed
+  rosters.
+- **Regulatory AUM** — the assets-under-*management* figure that triggers adviser
+  registration ($100M SEC, $25M in NY); keyed to managing *others'* money.
+- **Exempt reporting adviser** — the private-fund adviser exemption below $150M:
+  files, but does not fully register.
+- **Agent memory tiers** — in-context / semantic / episodic, the 2026 production
+  split; the field is moving from bigger windows toward hierarchical memory.
+
+## Live debates and open questions *(prose)*
+
+**Does multi-agent structure actually beat a single well-prompted model?** The
+2026 evaluation survey (arXiv 2603.27539) takes the middle position and makes it
+sharp: well-coordinated 3–5 agent teams beat single agents *and* beat larger
+poorly-coordinated ones, hierarchical structures with a designated
+decision-maker beat flat consensus on risk tasks, and simple agent addition
+sometimes makes things worse through token waste and conflicting
+recommendations. Against the maximalist reading stands the Xia et al. audit
+(arXiv 2605.19337), which implies the whole comparison is currently unsettleable
+— if only 19 of 77 studies meet minimum empirical standards and none are
+reproducible, the performance claims on both sides are not yet evidence. The
+honest position in August 2026 is that coordination quality is the live variable
+and nobody has demonstrated it cleanly.
+
+**How much autonomy is defensible with real money?** Standard Signal (YC Spring
+2026, a team of one) is the frontier position: AI researches and executes
+end-to-end, with risk limits in infrastructure rather than in the model, and a
+claimed live Sharpe above 3 that no third party has audited. Lumenai, launching
+into the same window with an institutional structure, keeps human portfolio
+managers ultimately responsible. Mercer's 131-manager survey puts the industry
+at ~6% using AI for decision-making at all. So there is a real spread — but note
+that the two aggressive players and the conservative majority agree on the same
+mechanism: the constraint layer is infrastructure, not prompt.
+
+**Is the bottleneck intelligence or execution discipline?** Alpha Arena is the
+sharpest datum here. Six frontier models, identical prompts, real capital, and
+the losses were not primarily bad directional calls — win rates clustered at
+25–30% for everyone, and the organizers attribute the drawdowns to over-trading
+where fees erased quick small gains (Qwen3 Max paid $1,654 in fees while
+finishing best). That points at position sizing, trade frequency, and cost
+modeling as the binding constraints rather than market insight — which is a
+claim about *plumbing*, and it is the single most encouraging result in the
+field for a design whose default is HOLD.
+
+## Key claims log
+
+| Claim | Status | Source(s) |
+|---|---|---|
+| Coordination design dominates agent count; well-coordinated 3–5 agent teams beat single agents and larger poorly-coordinated groups; naive agent addition can degrade performance | single-source | [arXiv 2603.27539](https://arxiv.org/pdf/2603.27539) (read) |
+| Hierarchical structures with a designated decision-maker beat flat consensus on risk-management tasks | single-source | [arXiv 2603.27539](https://arxiv.org/pdf/2603.27539) (read) |
+| Financial MAS papers rarely report token/API cost; cost scales non-linearly with agent complexity; debate coordination substantially raises inference cost | single-source | [arXiv 2603.27539](https://arxiv.org/pdf/2603.27539) (read) |
+| Audit of 77 LLM-trading studies through Mar 2026: 19 met minimum empirical standards; 2/19 had extractable time-consistent splits; 1 modeled transaction costs; 1 handled survivorship; 0 met top reproducibility tier | single-source | [arXiv 2605.19337](https://arxiv.org/abs/2605.19337) (read, **abstract only**) |
+| Alpha Arena S1 (Oct 18–Nov 3 2025): 6 LLMs × $10k real capital; 4 of 6 lost (ChatGPT −$6,267, Gemini −$5,671, Grok −$4,531, Claude Sonnet −$3,081); DeepSeek +$489, Qwen3 Max +$2,232; win rates 25–30%; losses attributed to over-trading, fees erasing gains | single-source | [protos](https://protos.com/llm-crypto-trading-contest-finds-llms-cant-trade-crypto/) (read) |
+| Mercer 2026 AI in Asset Management Survey (131 managers, Feb–Mar 2026): ~74% automation/efficiency, ~69% insight/analysis, ~6% decision-making | single-source (one origin); relay discrepancy — InvestmentNews reports 73/68/5 for the same survey | [Mercer](https://www.mercer.com/insights/investments/market-outlook-and-trends/asset-managers-use-of-ai/) (read); [InvestmentNews](https://www.investmentnews.com/transformation/most-asset-managers-are-using-ai-but-few-let-it-call-the-shots/266712) (read, inherits Mercer origin) |
+| Barriers to adoption: 69% data quality/access, ~59% regulatory/compliance; 57% of managers have only 1–5 FTEs on AI | single-source | [Mercer](https://www.mercer.com/insights/investments/market-outlook-and-trends/asset-managers-use-of-ai/) (read) |
+| Lumenai Innovation Fund (global equity L/S, ops ~2026-06-01): agentic from the ground up, agents "decision-makers within defined constraints," human PMs retain ultimate responsibility | single-source | [Hedgeweek](https://www.hedgeweek.com/lumenai-plans-launch-of-fully-agentic-ai-hedge-fund/) (read) |
+| Standard Signal (YC Spring 2026, team of 1): AI researches + executes end-to-end; risk limits enforced by infrastructure not the model; every decision logged and auditable; claims live Sharpe >3 | single-source (company origin, unaudited) | [Y Combinator](https://www.ycombinator.com/companies/standard-signal) (read) |
+| Alpaca data: free = IEX only, 15-min delayed API (real-time websocket), 30 symbols, 200 calls/min; Algo Trader Plus $99/mo = all US exchanges, unlimited symbols, real-time OPRA options | single-source (vendor origin) | [Alpaca](https://alpaca.markets/data) (read) |
+| Polygon Stocks Advanced ≈$199/mo; Databento ≈$199/mo or metered | **search-level — not established** | vendor-comparison blog (search-level) |
+| Adviser registration keys off regulatory AUM ($100M SEC / $25M NY) and client type; private-fund exemption below $150M | single-source | [Proskauer](https://www.proskauer.com/pub/proskauer-hedge-start-when-is-sec-registration-necessary) (read) |
+| Trading only one's own capital, with no clients, falls outside the Advisers Act and needs no registration | **inference / prior-knowledge** — Proskauer explicitly did not address the own-capital case; derived from registration keying on clients and assets under *management* | derived from [Proskauer](https://www.proskauer.com/pub/proskauer-hedge-start-when-is-sec-registration-necessary) (read) + training |
+| Production agent memory in 2026 splits into in-context / semantic / episodic tiers; field shifting from bigger windows to hierarchical memory | search-level only | ICLR MemAgents workshop, 2026 memory preprints (search-level) |
+
+No claim in this brief reached **verified** — no load-bearing claim was
+corroborated by two independently-read origins. Treat every row above as one
+source's account.
+
+## Practitioner heuristics *(prose)*
+
+The people doing this credibly converge on a few habits. They put the risk layer
+in infrastructure and say so out loud, because a limit that lives in a prompt is
+a suggestion — both aggressive real-money entrants of 2026 lead with exactly
+this claim, and it is now closer to table stakes than differentiation. They
+count trials, because the field's dominant failure is not a bad model but a good
+backtest; the audit's one-in-seventy-seven numbers on cost models and
+survivorship are what that failure looks like at scale. They report cost per
+decision, which the evaluation survey singles out as near-universally missing
+and which becomes load-bearing the moment debate-style coordination enters the
+design, since that is the pattern whose token cost grows fastest. They keep
+rosters small and coordination sharp rather than staffing every role a paper
+mentions — 3–5 well-coordinated agents is the size the evidence supports, and
+"add another analyst" is the move insiders roll their eyes at. And they treat
+over-trading as the first-order risk: Alpha Arena's damage came from frequency
+and fees, not from being wrong more often than anyone else.
+
+## Source shelf
+
+- [arXiv 2603.27539 — Toward Reliable Evaluation of LLM-Based Financial Multi-Agent Systems](https://arxiv.org/pdf/2603.27539) — best 2026 survey; source of coordination primacy and the cost-awareness critique. **(read)**
+- [arXiv 2605.19337 — Agentic Trading: When LLM Agents Meet Financial Markets](https://arxiv.org/abs/2605.19337) — Xia et al., audit of 77 studies; the field's harshest self-assessment. **(read, abstract only)**
+- [protos — LLM crypto trading contest finds LLMs can't trade crypto](https://protos.com/llm-crypto-trading-contest-finds-llms-cant-trade-crypto/) — Alpha Arena S1 numbers; the only clean real-money datum. **(read)**
+- [Mercer — Moving Beyond the AI Pitch: Asset Managers' use of AI](https://www.mercer.com/insights/investments/market-outlook-and-trends/asset-managers-use-of-ai/) — 131-manager survey; the industry baseline. **(read)**
+- [Hedgeweek — Lumenai plans launch of fully agentic AI hedge fund](https://www.hedgeweek.com/lumenai-plans-launch-of-fully-agentic-ai-hedge-fund/) — institutional agentic fund, human PM responsibility retained. **(read)**
+- [Y Combinator — Standard Signal](https://www.ycombinator.com/companies/standard-signal) — the frontier autonomy position; company copy, unaudited. **(read)**
+- [Alpaca — Market data plans](https://alpaca.markets/data) — free IEX vs $99/mo full-exchange tier. **(read)**
+- [Proskauer — Hedge Start: When Is SEC Registration Necessary?](https://www.proskauer.com/pub/proskauer-hedge-start-when-is-sec-registration-necessary) — registration thresholds and exemptions. **(read)**
+- [InvestmentNews — Most asset managers are using AI, but few let it call the shots](https://www.investmentnews.com/transformation/most-asset-managers-are-using-ai-but-few-let-it-call-the-shots/266712) — relays Mercer; same origin, context only. **(read)**
+- euclideanai.com Alpha Arena analysis — **(search-level; fetch returned 404, never read)**
+- ICLR 2026 MemAgents workshop; 2026 agent-memory preprints — **(search-level)**
+
+## Coverage edges *(prose)*
+
+Nothing here is verified to the two-independent-origin bar, so every claim is
+one account. The Alpha Arena figures rest on a single trade-press read after the
+intended second source 404'd, and the Mercer percentages differ by a point
+between the survey page and its relay — the direction is solid, the decimals are
+not. Market-data vendor pricing beyond Alpaca (Polygon, Databento, and news
+vendors specifically) was never fetched from the vendors themselves and stays
+search-level; anyone budgeting a data stack should re-derive it from vendor
+pages. The regulatory picture covers registration thresholds but not the
+own-capital case, tax treatment, or the vacated-and-relitigated state of the
+SEC's expanded dealer rule. Agent-memory research for long-lived operation was
+mapped but not read, and would be the first place to spend a follow-up pass.


### PR DESCRIPTION
Adds `VISION.md` — a high-level description of the desired steady state, so scope decisions have something to be checked against. Nothing implementational; the invariants stay where they are in `CLAUDE.md` and the phasing stays in `specs/design.md` §7.

Also adds `research/field-brief-autonomous-agent-firms.md`, the 2026 research the vision is grounded in — every claim carries its evidence status, and **none reached two independent sources**, so the brief says so rather than implying more confidence than it earned.

Two findings from the existing `research/` files shaped the doc:

- **Contamination.** "Profit Mirage" found the flagship LLM trading agents decay 51–62% in Sharpe once tested past the model's knowledge cutoff (`research/strategy-research-report.md` §3.3). The doc's "Counting forward" section exists because of this, and reframes the paper years as the measurement rather than a rehearsal.
- **Stay small.** The residual edge lives in capacity-constrained names precisely because institutions can't scale there (§2, §3.6), so the vision says the firm is trying to be right rather than big.

The "Where we are" section is written against this tree, not against README's Status section, which is stale — it claims 556 tests (actual: 1105) and lists the resolutions loop and second analyst seat as "next" when both have landed. Not fixed here; separate call.

Note `agents/config/critic.yaml` and `charters/critic.md` both exist, but `orchestrator/daily.py:195` inserts default critiques with reason `no_critic_seat` — the seat is configured and not in the decision loop. The doc says that rather than inferring a critic from the config.

Docs only, no code. Suite green on this branch: 1105 passed, 1 skipped.