### PR TITLE
Three hosts resolved dependencies three ways; now they install one lock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,14 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      # Read from pyproject rather than restating the list here: a second copy
-      # of a version range is a drift vector, and an unreviewed range is what
-      # put mcp 2.0.0 in a fresh venv while the pinned one stayed on 1.x.
-      - name: Install deps (from pyproject — single source of truth)
-        run: |
-          python3 -c "import tomllib; p = tomllib.load(open('pyproject.toml','rb'))['project']; print('\n'.join(p['dependencies'] + p['optional-dependencies']['dev']))" > /tmp/requirements.txt
-          cat /tmp/requirements.txt
-          pip install -r /tmp/requirements.txt
+      # Install the lock, not pyproject's ranges. Resolving ranges here made CI
+      # a third environment that re-resolved on every run — green against a set
+      # no other host had, which is how mcp 2.0.0 reached a fresh venv while
+      # the pinned one stayed on 1.x. pyproject stays the source of truth for
+      # what is *allowed*; the lock records what is *run*, and
+      # tests/test_deps_lock.py checks the lock back against pyproject's ranges.
+      - name: Install deps (from requirements.lock — one resolution per host)
+        run: pip install -r requirements.lock
       - name: Purity lint (no LLM imports, no wall clock — CLAUDE.md invariant 3)
         run: python3 scripts/check_purity.py
       - name: Full test suite (no network, no keys; includes frozen golden numbers)

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ build/
 # WAL mode (state/db.py sets journal_mode=WAL) writes these alongside the db
 # run_day's flock handle (scripts/run_day.py acquire_lock)
 *.lock
+# ...but the dependency lock is the one file every host must receive.
+!requirements.lock
 *.sqlite-wal
 *.sqlite-shm
 *.sqlite-journal

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,13 @@
 
 # Bootstrap: plain `make test` works from a clean checkout or a fresh git
 # worktree — .venv is created on first run, and deps re-sync whenever
-# pyproject.toml changes (the only steps that touch the network). The sync is
-# content-hash gated in scripts/sync_deps.py, NOT mtime-gated: Apple's GNU
-# make 3.81 treats equal 1-second timestamps as up-to-date, which silently
-# skips same-second pyproject edits. BOOT_PY picks a >=3.12 interpreter
-# explicitly; macOS /usr/bin/python3 (3.9) won't do.
+# requirements.lock or pyproject.toml changes (the only steps that touch the
+# network). Every host installs the lock, never the ranges, so local, the
+# droplet and CI hold the same 52 versions. The sync is content-hash gated in
+# scripts/sync_deps.py, NOT mtime-gated: Apple's GNU make 3.81 treats equal
+# 1-second timestamps as up-to-date, which silently skips same-second edits.
+# BOOT_PY picks a >=3.12 interpreter explicitly; macOS /usr/bin/python3 (3.9)
+# won't do.
 PYTHON := .venv/bin/python3
 BOOT_PY := $(shell command -v python3.14 || command -v python3.13 || command -v python3.12 || command -v python3)
 
@@ -22,6 +24,14 @@ deps:
 	    $(BOOT_PY) -m venv .venv && $(PYTHON) -m pip install --quiet --upgrade pip; \
 	}
 	@$(PYTHON) scripts/sync_deps.py
+
+# Re-resolve pyproject.toml's ranges in a throwaway venv and rewrite the lock.
+# The only supported way to change a pinned version — hand-editing the lock
+# skips the resolver and can pin a set that does not install together. Run
+# `make test` afterwards, then commit pyproject.toml and the lock together.
+.PHONY: deps-relock
+deps-relock:
+	@$(BOOT_PY) scripts/relock.py
 
 # Full offline suite: no network, no API keys. Must pass before every commit.
 test: lint

--- a/ops/README.md
+++ b/ops/README.md
@@ -380,13 +380,19 @@ nowhere else and makes the next pull conflict. If it refuses to fast-forward,
 someone edited the tree in place — find out what before forcing anything.
 
 **3. Check the two files that a pull alone does not handle.** If
-`pyproject.toml` changed, the venv is stale — resync it **as the `fund` user**,
-never as root, or the venv ends up owned by root and the units can no longer
-write it:
+`requirements.lock` or `pyproject.toml` changed, the venv is stale — resync it
+**as the `fund` user**, never as root, or the venv ends up owned by root and
+the units can no longer write it:
 
 ```bash
 su - fund -c 'cd /opt/fund && .venv/bin/python3 scripts/sync_deps.py'
 ```
+
+The resync installs `requirements.lock` and then re-reads installed metadata,
+exiting non-zero if the venv still disagrees with it. A clean exit is the
+evidence that this host runs the locked set — check the exit code, never
+`pyproject.toml`, which is a range and matched all along while the hosts
+differed on 20 packages.
 
 If `state/schema.sql` changed, read `state/migrations.py` before pulling.
 

--- a/requirements.lock
+++ b/requirements.lock
@@ -1,0 +1,69 @@
+# requirements.lock — the one resolution every host installs.
+#
+# pyproject.toml declares what the fund is COMPATIBLE with; this file records
+# what it actually RUNS. Ranges alone let local, the droplet and CI resolve
+# differently on three different days: on 2026-08-20 they differed on 20
+# packages, including mcp (the transport every tool call rides) and the SDK
+# that had never been tested at the version placing real orders.
+#
+# Installed by scripts/sync_deps.py, which then verifies installed metadata
+# against these pins and fails if they disagree. Do not hand-edit a version.
+#
+# REGENERATE (after any pyproject.toml dependency change):
+#     make deps-relock
+# then run `make test` and commit pyproject.toml and this file together.
+#
+# Seeded 2026-08-20 from the droplet's live resolution at 09a7a7c — the
+# versions already trading — so adopting it changed no production package.
+alpaca-py==0.44.0
+annotated-types==0.8.0
+anyio==4.14.2
+attrs==26.1.0
+certifi==2026.7.22
+cffi==2.1.1
+charset-normalizer==3.5.1
+claude-agent-sdk==0.2.139
+click==8.4.2
+cryptography==50.0.0
+h11==0.16.0
+httpcore==1.0.9
+httpx-sse==0.4.3
+httpx==0.28.1
+idna==3.18
+iniconfig==2.3.0
+jsonschema-specifications==2025.9.1
+jsonschema==4.26.0
+mcp==1.29.0
+msgpack==1.2.1
+numpy==2.5.2
+packaging==26.3
+pandas==2.3.3
+pluggy==1.6.0
+pycparser==3.0
+pydantic-settings==2.15.0
+pydantic==2.13.4
+pydantic_core==2.46.4
+Pygments==2.21.0
+PyJWT==2.13.0
+pytest==9.1.1
+python-dateutil==2.9.0.post0
+python-dotenv==1.2.3
+python-multipart==0.0.32
+pytz==2026.3.post1
+PyYAML==6.0.3
+referencing==0.37.0
+requests==2.34.2
+rpds-py==2026.6.3
+six==1.17.0
+slack_bolt==1.30.0
+slack_sdk==3.43.0
+sniffio==1.3.1
+sse-starlette==3.4.8
+sseclient-py==1.9.0
+starlette==1.6.0
+typing-inspection==0.4.4
+typing_extensions==4.16.0
+tzdata==2026.3
+urllib3==2.7.0
+uvicorn==0.52.3
+websockets==17.0.1

--- a/scripts/relock.py
+++ b/scripts/relock.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Regenerate requirements.lock from pyproject.toml's ranges (`make deps-relock`).
+
+Resolves the ranges in a throwaway venv and freezes the result, so relocking
+never depends on — or disturbs — whatever .venv happens to hold. The committed
+header is carried across, because it is where the regeneration instructions
+live. Run `make test` afterwards: the lock is only as good as the suite that
+ran against it.
+"""
+
+import re
+import subprocess
+import sys
+import tempfile
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT = ROOT / "pyproject.toml"
+LOCK = ROOT / "requirements.lock"
+
+# The installer, not dependencies of the fund: freezing them pins the tool
+# doing the pinning, and a fresh venv gets its own anyway.
+INSTALLER = {"pip", "setuptools", "wheel", "distribute", "pkg-resources", "uv"}
+
+PIN = re.compile(r"^([A-Za-z0-9][A-Za-z0-9._-]*)==([^\s;]+)$")
+
+
+def existing_header(lock: Path = LOCK) -> str:
+    """The committed comment block at the top of the lock, or '' if absent."""
+    if not lock.exists():
+        return ""
+    header = []
+    for line in lock.read_text().splitlines():
+        if not line.startswith("#"):
+            break
+        header.append(line)
+    return "".join(f"{line}\n" for line in header)
+
+
+def render_lock(header: str, freeze: str) -> str:
+    """Header plus every exact pin from `pip freeze`, sorted, installer dropped."""
+    pins = []
+    for raw in freeze.splitlines():
+        m = PIN.match(raw.strip())
+        if m and m.group(1).lower() not in INSTALLER:
+            pins.append(m.group(0))
+    pins.sort(key=str.lower)
+    return header + "".join(f"{pin}\n" for pin in pins)
+
+
+def main() -> int:
+    project = tomllib.load(PYPROJECT.open("rb"))["project"]
+    deps = project["dependencies"] + project["optional-dependencies"]["dev"]
+
+    with tempfile.TemporaryDirectory() as tmp:
+        venv = Path(tmp) / "venv"
+        subprocess.check_call([sys.executable, "-m", "venv", str(venv)])
+        python = venv / "bin" / "python3"
+        subprocess.check_call(
+            [str(python), "-m", "pip", "install", "--quiet", "--upgrade", "pip"])
+        subprocess.check_call([str(python), "-m", "pip", "install", "--quiet", *deps])
+        freeze = subprocess.check_output([str(python), "-m", "pip", "freeze"], text=True)
+
+    LOCK.write_text(render_lock(existing_header(), freeze))
+    print(f"relock: wrote {LOCK.relative_to(ROOT)} "
+          f"({sum(1 for line in LOCK.read_text().splitlines() if '==' in line)} pins)")
+    print("relock: run `make test`, then commit pyproject.toml and the lock together.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sync_deps.py
+++ b/scripts/sync_deps.py
@@ -1,35 +1,100 @@
 #!/usr/bin/env python3
-"""Sync .venv deps from pyproject.toml, content-hash gated (called by make).
+"""Sync .venv to requirements.lock, content-hash gated (called by make).
+
+Installs the lock, not pyproject.toml's ranges: ranges resolve to whatever is
+newest on the day a venv is built, which is how local, the droplet and CI came
+to differ on 20 packages. pyproject.toml still gates the stamp because its
+ranges are what tests/test_deps_lock.py checks the lock against.
 
 mtime-based stamp files are unreliable here: Apple's GNU make 3.81 compares
 timestamps at 1-second granularity and treats equal mtimes as up-to-date, so
-a pyproject.toml edit landing in the same second as the previous sync is
-silently skipped. The stamp therefore stores a sha256 of pyproject.toml and
-this script compares content, not time. Runs under the venv python.
+an edit landing in the same second as the previous sync is silently skipped.
+The stamp therefore stores a sha256 of both files' content, not time. Runs
+under the venv python.
 """
 
 import hashlib
+import importlib
+import importlib.metadata as md
+import re
 import subprocess
 import sys
-import tomllib
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 STAMP = ROOT / ".venv" / ".deps-synced"
 PYPROJECT = ROOT / "pyproject.toml"
+LOCK = ROOT / "requirements.lock"
+
+PIN = re.compile(r"^([A-Za-z0-9][A-Za-z0-9._-]*)==([^\s;]+)$")
+
+
+def _canon(name: str) -> str:
+    """PEP 503 normalization: slack_bolt and slack-bolt are one name."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def read_lock(lock: Path = LOCK) -> dict[str, str]:
+    """Parse requirements.lock into {canonical name: exact version}."""
+    pins = {}
+    for raw in lock.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        m = PIN.match(line)
+        if not m:
+            raise ValueError(f"{lock}: {line!r} is not an exact name==version pin")
+        pins[_canon(m.group(1))] = m.group(2)
+    return pins
+
+
+def stamp_value(lock: Path = LOCK, pyproject: Path = PYPROJECT) -> str:
+    """Content hash gating the sync — changes if either file changes."""
+    h = hashlib.sha256()
+    h.update(lock.read_bytes())
+    h.update(pyproject.read_bytes())
+    return h.hexdigest()
+
+
+def drift(lock: Path = LOCK) -> list[str]:
+    """Lines describing where installed metadata disagrees with the lock.
+
+    Reads what is installed, never what was requested — a satisfied range is
+    exactly what hid the original drift. Empty list means the env matches.
+    """
+    importlib.invalidate_caches()
+    installed = {}
+    for dist in md.distributions():
+        name = dist.metadata["Name"]
+        if name:
+            installed[_canon(name)] = dist.version
+    report = []
+    for name, want in sorted(read_lock(lock).items()):
+        have = installed.get(name)
+        if have is None:
+            report.append(f"{name}: locked at {want}, not installed")
+        elif have != want:
+            report.append(f"{name}: locked at {want}, installed {have}")
+    return report
 
 
 def main() -> int:
-    want = hashlib.sha256(PYPROJECT.read_bytes()).hexdigest()
+    want = stamp_value()
     if STAMP.exists() and STAMP.read_text() == want:
         return 0
-    project = tomllib.load(PYPROJECT.open("rb"))["project"]
-    deps = project["dependencies"] + project.get(
-        "optional-dependencies", {}).get("dev", [])
-    rc = subprocess.call([sys.executable, "-m", "pip", "install", "--quiet", *deps])
-    if rc == 0:
-        STAMP.write_text(want)
-    return rc
+    rc = subprocess.call(
+        [sys.executable, "-m", "pip", "install", "--quiet", "-r", str(LOCK)])
+    if rc != 0:
+        return rc
+    report = drift()
+    if report:
+        print(
+            "sync_deps: .venv does not match requirements.lock after install:",
+            *(f"  {line}" for line in report),
+            sep="\n", file=sys.stderr)
+        return 1
+    STAMP.write_text(want)
+    return 0
 
 
 if __name__ == "__main__":

--- a/tests/test_deps_lock.py
+++ b/tests/test_deps_lock.py
@@ -1,0 +1,209 @@
+"""requirements.lock is the single resolution every host installs.
+
+Ranges in pyproject.toml let three environments (local, droplet, CI) resolve
+differently on three different days; that is what left `make test` green on
+claude-agent-sdk 0.2.116 while the droplet placed orders on 0.2.139. The lock
+is the answer, so these tests hold it to being complete, exact, and actually
+installed — verified from installed metadata, never from the constraint.
+"""
+
+import importlib.metadata as md
+import re
+import subprocess
+import tomllib
+from pathlib import Path
+
+from packaging.requirements import Requirement
+
+import scripts.relock as relock
+import scripts.sync_deps as sync_deps
+
+ROOT = Path(__file__).resolve().parents[1]
+LOCK = ROOT / "requirements.lock"
+PYPROJECT = ROOT / "pyproject.toml"
+
+PIN = re.compile(r"^([A-Za-z0-9][A-Za-z0-9._-]*)==([^\s;]+)$")
+
+
+def _canon(name: str) -> str:
+    """PEP 503 normalization: slack_bolt, Slack-Bolt and slack.bolt are one name."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def _lock_lines() -> list[str]:
+    return [
+        line.strip()
+        for line in LOCK.read_text().splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+
+
+def _locked() -> dict[str, str]:
+    out = {}
+    for line in _lock_lines():
+        m = PIN.match(line)
+        assert m, f"requirements.lock: {line!r} is not an exact name==version pin"
+        out[_canon(m.group(1))] = m.group(2)
+    return out
+
+
+def _declared() -> list[Requirement]:
+    project = tomllib.load(PYPROJECT.open("rb"))["project"]
+    deps = project["dependencies"] + project["optional-dependencies"]["dev"]
+    return [Requirement(d) for d in deps]
+
+
+def test_lock_is_exact_for_every_line():
+    """A range anywhere in the lock reopens the drift it exists to close."""
+    for line in _lock_lines():
+        assert PIN.match(line), (
+            f"requirements.lock: {line!r} is not an exact pin. Every line must"
+            f" be name==version — a range makes the lock a suggestion.")
+
+
+def test_lock_pins_every_declared_dependency():
+    """A dependency added to pyproject.toml but not locked floats again."""
+    locked = _locked()
+    missing = [r.name for r in _declared() if _canon(r.name) not in locked]
+    assert not missing, (
+        f"declared in pyproject.toml but absent from requirements.lock:"
+        f" {sorted(missing)}. Regenerate the lock — see its header.")
+
+
+def test_lock_versions_satisfy_pyproject_ranges():
+    """The lock is a resolution OF pyproject, not a contradiction of it."""
+    locked = _locked()
+    for req in _declared():
+        pinned = locked[_canon(req.name)]
+        assert req.specifier.contains(pinned, prereleases=True), (
+            f"requirements.lock pins {req.name}=={pinned}, which is outside"
+            f" pyproject.toml's {req.specifier}. One of the two is wrong.")
+
+
+def test_installed_versions_match_the_lock():
+    """The verification that matters: what is imported, not what is requested.
+
+    A matching pyproject.toml is exactly what hid the original drift, so this
+    reads installed metadata. `make deps` (run by `make test`) syncs it.
+    """
+    drift = sync_deps.drift()
+    assert not drift, (
+        "installed packages do not match requirements.lock:\n  "
+        + "\n  ".join(drift)
+        + "\nRun `make deps` to sync this environment to the lock.")
+
+
+def test_stamp_value_changes_when_the_lock_changes(tmp_path):
+    """The sync is content-gated; a lock edit that does not re-gate is a no-op."""
+    lock = tmp_path / "requirements.lock"
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text("[project]\n")
+
+    lock.write_text("pydantic==2.13.4\n")
+    before = sync_deps.stamp_value(lock, pyproject)
+    lock.write_text("pydantic==2.13.5\n")
+    after = sync_deps.stamp_value(lock, pyproject)
+
+    assert before != after, "stamp ignores requirements.lock content"
+
+
+def test_stamp_value_changes_when_pyproject_changes(tmp_path):
+    """pyproject still gates too: its ranges are what the lock is checked against."""
+    lock = tmp_path / "requirements.lock"
+    pyproject = tmp_path / "pyproject.toml"
+    lock.write_text("pydantic==2.13.4\n")
+
+    pyproject.write_text("[project]\n")
+    before = sync_deps.stamp_value(lock, pyproject)
+    pyproject.write_text("[project]\nname = 'x'\n")
+    after = sync_deps.stamp_value(lock, pyproject)
+
+    assert before != after, "stamp ignores pyproject.toml content"
+
+
+def test_drift_reports_a_missing_package(tmp_path):
+    """Descriptive failure, not a bare False — the message is the fix."""
+    lock = tmp_path / "requirements.lock"
+    lock.write_text("definitely-not-installed-xyz==1.0.0\n")
+
+    report = sync_deps.drift(lock)
+
+    assert len(report) == 1
+    assert "definitely-not-installed-xyz" in report[0]
+    assert "1.0.0" in report[0]
+
+
+def test_lock_is_tracked_by_git():
+    """.gitignore carries `*.lock` for run_day's flock handle.
+
+    That rule swallowed requirements.lock on sight — a lock every host is told
+    to install but which never reaches another host is worse than no lock, so
+    the negation is pinned here rather than left to be rediscovered.
+    """
+    tracked = subprocess.run(
+        ["git", "ls-files", "--error-unmatch", "requirements.lock"],
+        cwd=ROOT, capture_output=True, text=True)
+
+    assert tracked.returncode == 0, (
+        "requirements.lock is not tracked by git — check .gitignore's *.lock"
+        f" rule for a missing `!requirements.lock` negation. {tracked.stderr}")
+
+
+def test_relock_keeps_the_header_and_drops_the_installer(tmp_path):
+    """A regenerated lock the next person can still read and trust.
+
+    pip/setuptools/wheel are the installer, not dependencies of the fund;
+    freezing them pins the tool that does the pinning.
+    """
+    rendered = relock.render_lock(
+        header="# header line\n# second line\n",
+        freeze="pytest==9.1.1\npip==26.2.1\nsetuptools==80.0.0\nnumpy==2.5.2\n",
+    )
+
+    assert rendered.startswith("# header line\n# second line\n")
+    assert "pip==" not in rendered
+    assert "setuptools==" not in rendered
+    assert "pytest==9.1.1" in rendered
+    assert "numpy==2.5.2" in rendered
+
+
+def test_relock_sorts_pins_case_insensitively(tmp_path):
+    """Stable order, so a relock diff shows version changes and nothing else."""
+    rendered = relock.render_lock(
+        header="# h\n", freeze="numpy==2.5.2\nPyYAML==6.0.3\nalpaca-py==0.44.0\n")
+
+    assert [line for line in rendered.splitlines() if "==" in line] == [
+        "alpaca-py==0.44.0", "numpy==2.5.2", "PyYAML==6.0.3"]
+
+
+def test_relock_ignores_editable_and_url_entries(tmp_path):
+    """`pip freeze` emits these for local installs; they are not pins."""
+    rendered = relock.render_lock(
+        header="# h\n",
+        freeze="-e git+ssh://x#egg=fund\nnumpy==2.5.2\nfund @ file:///opt/fund\n",
+    )
+
+    assert [line for line in rendered.splitlines() if not line.startswith("#")] == [
+        "numpy==2.5.2"]
+
+
+def test_relock_reuses_the_committed_header(tmp_path):
+    """Regeneration must not silently discard the file's own instructions."""
+    lock = tmp_path / "requirements.lock"
+    lock.write_text("# why this file exists\n#\n# REGENERATE: make deps-relock\nnumpy==1.0.0\n")
+
+    assert relock.existing_header(lock) == (
+        "# why this file exists\n#\n# REGENERATE: make deps-relock\n")
+
+
+def test_drift_reports_a_version_mismatch(tmp_path):
+    """The case that actually happened: present, importable, wrong version."""
+    lock = tmp_path / "requirements.lock"
+    installed = md.version("pydantic")
+    lock.write_text("pydantic==0.0.0-not-a-real-version\n")
+
+    report = sync_deps.drift(lock)
+
+    assert len(report) == 1
+    assert "pydantic" in report[0]
+    assert installed in report[0]


### PR DESCRIPTION
## The finding

`CLAUDE.md` states that `claude-agent-sdk` and `slack_bolt` are "pinned in `pyproject.toml`". Neither is — `~=0.2.116` and `>=1.18,<2` are ranges, so every venv resolved to whatever was newest the day it was built. **No commit bypassed a pin; there was never a pin.**

Local sat on SDK **0.2.116** while the droplet placed real orders on **0.2.139**. `make test` had never run against the version that trades.

The gap was never two packages:

| | local | droplet |
|---|---|---|
| `claude-agent-sdk` | 0.2.116 | 0.2.139 |
| `mcp` | 1.28.1 | 1.29.0 |
| `starlette` | 1.3.1 | **1.6.0** |
| `cryptography` | 49.0.0 | 50.0.0 |
| `slack_bolt` | 1.29.0 | 1.30.0 |
| …plus 15 more | | |

**20 packages differed**, including `mcp` — the transport every tool call rides, order gate included. Pinning only the two names `CLAUDE.md` mentions would have left 18 floating. CI was a *third* environment, re-resolving from scratch on every run.

## Why this is not hypothetical maintenance

A fresh resolve **today**, from the ranges as they stand, pulls:

```
mcp          1.29.0 -> 2.0.0     (+ mcp-types 2.0.0)
httpx        0.28.1 -> httpx2 2.12.0
claude-agent-sdk    -> 0.2.143
             + opentelemetry-api
```

A major version of the tool-call transport, into a system that places orders. **The suite passes on it** — nothing offline exercises a real MCP connection — so green tests would not have caught it. Only a lock does. CI's own comment already memorialized this exact incident ("an unreviewed range is what put mcp 2.0.0 in a fresh venv"); it was still live.

## The change

`requirements.lock` records the resolution instead — **seeded from the droplet's live set at `09a7a7c`**, so production changed nothing and local and CI converge up to what already trades.

- `scripts/sync_deps.py` installs the lock, then re-reads **installed metadata** and exits non-zero if the venv disagrees. Verifying by constraint is exactly what hid this: `pyproject.toml` matched all along.
- `.github/workflows/ci.yml` installs the lock instead of re-resolving.
- `make deps-relock` (`scripts/relock.py`) re-resolves in a throwaway venv and rewrites the lock, preserving its header. The only supported way to change a pinned version.
- `.gitignore`'s `*.lock` rule — there for `run_day`'s flock handle — was **silently swallowing the lockfile**. Negation added, pinned by a test.

`pyproject.toml` is unchanged: it still declares what is *allowed*, the lock records what *runs*, and `tests/test_deps_lock.py` checks the lock back against its ranges.

## Verification

- `make test` — **1118 passed, 1 skipped** on Python 3.14 (both hosts' version)
- Same suite from the lock on Python **3.12** (CI's version) — 1117 passed, 1 skipped
- Droplet matches **all 52 pins**, read from installed metadata. **Zero packages changed on it; no droplet mutation was required.**
- 13 new tests, each written and watched fail before implementation

## Follow-ups, not included here

1. **`CLAUDE.md`'s "pinned" sentence is still false.** It is Benjamin's file, so proposed wording only:
   > Python 3.12+, `pydantic` v2, `pytest`; every dependency is pinned in `requirements.lock`, which every host installs — `pyproject.toml` declares allowed ranges, never the running version. Change a version only via `make deps-relock`, then `make test`.
2. **CI runs Python 3.12; both hosts run 3.14.** A lock is per-interpreter, so this is the same class of drift one level down. Verified working on both, so it is not broken — but it is an open decision.
