### PR TITLE
fix: an empty news result is unmeasured, not measured-as-nothing

### DIFF
--- a/charters/news.md
+++ b/charters/news.md
@@ -1,4 +1,4 @@
-# News/Sentiment Analyst — v1
+# News/Sentiment Analyst — v2
 
 ## Identity
 You are **Marcus Ellery**, news and sentiment analyst. Ten years on a macro
@@ -38,6 +38,12 @@ to guess.
 - Alpaca read-only (`news`, `stock-data`): headlines for the ticker, plus enough
   price context (latest quote, ≤10 daily bars) to judge whether a story is
   already in the tape. Budget your calls: aim for ≤4 tool calls per ticker.
+- `get_news` — call it with **`symbols` only**. Its default window is the start
+  of the current day, which is exactly the window you want. **NEVER pass `start`
+  and `end` as the same date.** Both resolve to midnight, so the interval is
+  zero-width, and Alpaca returns an empty list with a clean success and no error
+  — indistinguishable from a genuinely quiet day. On 2026-08-19 that returned
+  nothing on a day carrying 30 articles across the watchlist.
 - `submit_signal` — REQUIRED, once per ticker: direction bullish/bearish/neutral,
   confidence 0–100, summary ≤500 chars citing the 2–3 specific headlines that
   drove it, each with its recency. With `get_stage_brief` these are the only two
@@ -54,10 +60,19 @@ Per ticker: one Slack-visible line `<TICKER>: <direction> (<confidence>/100) —
   is context, not a signal — say which you are looking at.
 - One outlet repeating another is ONE source. Count distinct reporting, not
   distinct URLs.
-- Absence of news is information: a big move with no story is usually noise, and
-  saying so plainly beats manufacturing a narrative.
-- If tools error or the feed is empty, submit neutral with low confidence and
-  say why. Never guess a headline you did not read.
+- Absence of news is information **only once you have established it**. A big
+  move with no story is usually noise — but you may say that only after a call
+  that actually returned stories for the period and none of them bear on the
+  move. **An empty result is not evidence of absence; it is evidence you did not
+  measure.** Saying "no news published" when the tool returned nothing is a
+  claim about the world made from a fact about your query.
+- If tools error, or a call returns nothing at all, **you have not measured**.
+  Submit neutral with low confidence and say the data was **unavailable** —
+  never that there was no news, and never reason onward from the silence.
+  A confident false negative reads as diligence and is harder to catch than an
+  invented headline, so it is the more dangerous of the two.
+- Never guess a headline you did not read, and never assert a silence you did
+  not verify.
 
 ---
-changelog: v1 initial (second Phase 2 analyst seat; see docs/adr/0001)
+changelog: v1 initial (second Phase 2 analyst seat; see docs/adr/0001); v2 get_news is called with symbols only — start==end is a zero-width interval that returns empty with no error — and an empty result is unmeasured, never measured-as-nothing (2026-08-19: the seat asserted "No news published" on a day carrying 30 articles; issue #6)

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -210,7 +210,7 @@ def test_charter_version_comes_from_the_header():
     from agents.seats import charter_version_for
 
     assert charter_version_for({"seat": "pm"}) == "v6"
-    assert charter_version_for({"seat": "news"}) == "v1"
+    assert charter_version_for({"seat": "news"}) == "v2"
 
 
 def test_an_unparseable_header_is_unknown_not_a_crash():


### PR DESCRIPTION
The news seat has never produced a usable signal. It reported "No news published" on days carrying real headlines — 30 articles across the watchlist on 08-19, four directly on NVDA — while the analyst seat, same run and same minute, cited five.

**Two defects. Fixing either alone leaves the seat broken.**

**The query.** `get_news` was called with `start == end`, both date-only, so both resolve to midnight and the interval is zero-width. Alpaca returns an empty list with a clean success and no error. The charter now specifies `symbols` only — the tool's default window is already the current day.

**The instructions.** `charters/news.md` said *"if the feed is **empty**"* where `charters/analyst.md` says *"if data is **missing**"*, and elevated "absence of news is information" to a principle. One describes a measured state, the other an unmeasured one; the seat behaved exactly as written. It may now call a move unexplained only after a call that returned stories, and must report an empty or errored call as data **unavailable**.

The charter also now records *why*: a confident false negative reads as diligence and is harder to catch than an invented headline. The original line was aimed at hallucination — the visible failure — and traded it for the invisible one.

Header bumped to **v2** so `signals.charter_version` records which instructions produced a signal. The version assertion in `test_migrations.py` tracks that bump; **1106 passed, 1 skipped**.

**Not deployed.** The 09:35 run uses whatever is on the droplet, so this does not change tomorrow's behaviour until someone ships it.

Closes half of #6. The eval gap that would catch a regression is #18 — nothing tests this seat.