### PR TITLE
docs: land two handoffs off the superseded branch

### DIFF
--- a/docs/superpowers/handoffs/2026-08-20-dependency-pinning.md
+++ b/docs/superpowers/handoffs/2026-08-20-dependency-pinning.md
@@ -1,0 +1,62 @@
+# SUPERSEDED — dependency pinning
+
+**Written** 2026-08-20 by `fund-4a` · **Superseded same day by PR #27**
+
+The original brief asked a new chat to choose a version and pin it. **That
+decision has been made and the work is merged — do not start it.** Verified on
+`origin/master` `696286e`:
+
+```
+requirements.lock        present   52 pinned packages
+scripts/relock.py        present
+tests/test_deps_lock.py  present
+claude-agent-sdk==0.2.139     slack_bolt==1.30.0     alpaca-py==0.44.0
+```
+
+**The lockfile route was taken, not the pin.** `pyproject.toml` still reads
+`claude-agent-sdk~=0.2.116` and `slack-bolt>=1.18,<2` — deliberately: the lock
+supplies reproducibility, so the constraints did not need tightening. The chosen
+convergence is **upward, to the droplet's 0.2.139**, not down to the local
+0.2.116.
+
+For the original finding and evidence — droplet 0.2.139 vs local 0.2.116, the
+2026-08-18 00:38 provenance, and why `~=0.2.116` permitted it — see
+`PROGRESS.md` and PR #27.
+
+---
+
+## Residual — small, and worth confirming rather than assuming
+
+Verified 2026-08-20; re-check before acting, all of it may have closed.
+
+1. **The droplet has not pulled the lock.** `/opt/fund` is at `09a7a7c` and has
+   no `requirements.lock`. Its installed SDK is already `0.2.139`, so production
+   happens to match the lock by coincidence rather than by construction. The
+   next routine deploy closes this; it needs no special action, only that nobody
+   assumes the lock is in force on the box before it is.
+
+2. **Local checkouts are still on `0.2.116` while the lock says `0.2.139`.** The
+   original brief's one hard requirement was: *do not bump silently — run the
+   full suite on the new version first.* If the suite has not been run against
+   `0.2.139`, that requirement is still outstanding, and it was the whole point.
+   Confirm before treating the convergence as done.
+
+3. **`CLAUDE.md` may still assert something untrue.** Its Conventions section
+   says `claude-agent-sdk` and `slack_bolt` are *"pinned in `pyproject.toml`"*.
+   They are pinned in `requirements.lock`; `pyproject.toml` still carries
+   ranges. The sentence needs rewording to match what was actually built.
+   **`CLAUDE.md` is Benjamin's file — propose wording, do not edit it unasked.**
+   Note also that it is auto-loaded into every session, so an uncommitted edit in
+   this shared checkout silently becomes project instructions for every session
+   started afterwards; check `git show origin/master:CLAUDE.md`, never `grep`.
+
+## Not part of this, and refuted
+
+The original brief flagged the SDK gap as a candidate cause of
+`model_fallback_used`. **That hypothesis is refuted, not open.** A live-turn
+probe found the SDK routes a small auxiliary call (~527 in / ~13 out, ~$0.0006)
+through haiku on *every* seat turn; Sonnet-5 carries the PM turn and ~97% of its
+cost. Only Sonnet-configured seats emit the event, which is why a fleet-wide
+artifact looked targeted at the PM. `_unmatched_models` is correct as written —
+the defect is that it has no notion of volume. Owned elsewhere; do not pick it
+up here.

--- a/docs/superpowers/handoffs/2026-08-20-gate-runtime-assumptions.md
+++ b/docs/superpowers/handoffs/2026-08-20-gate-runtime-assumptions.md
@@ -1,0 +1,124 @@
+# Handoff — does the gate verify its own assumptions?
+
+**Written** 2026-08-20 by `fund-4a` · **Start from** `origin/master` · **Droplet** `09a7a7c`
+
+Benjamin's decision #4. Unowned, nobody is currently in `gate/`, and it is the
+only open item where **the system believes something false about itself**.
+
+**This is design-first. Do not open an editor until the question below is
+settled with Benjamin.**
+
+---
+
+## The question
+
+Invariant 3 says gate thresholds change only by human commit, and that is
+genuinely enforced — `SECTOR_CAP`, `MAX_POSITIONS`, `CIRCUIT_BREAKER` are
+module constants in `gate/risk.py`, and `scripts/check_purity.py` lints the
+package in CI.
+
+But the guarantee people *read off* invariant 3 is "the risk envelope cannot
+move without a human," and that is a stronger claim than the code makes.
+`gate/risk.py` sizes against **account state it never verifies**:
+
+- `GateInputs.equity` is an input, supplied by the caller.
+- The math assumes **long-only, whole shares** — see `_as_share_count` in
+  `gate/tickets.py` and `Approved.max_qty: int`.
+- Nothing re-checks whether `no_shorting` is still true, what
+  `max_margin_multiplier` is, or whether `suspend_trade` is set.
+
+So the thresholds are locked while **the account parameters they operate on are
+not**, and no change to those parameters is recorded anywhere.
+
+**Settle this before designing:** should the gate verify its own preconditions
+at runtime, and what does it do when they do not hold — refuse to size (default
+HOLD, invariant 4), or size and alert?
+
+---
+
+## What this is NOT
+
+**The tool-surface hole is already closed** — do not re-fix it. Earlier today
+the exec seat could reach eight mutating broker verbs ungated, including
+`update_account_config` (which sets `max_margin_multiplier`, `no_shorting`,
+`suspend_trade`) and `close_all_positions`. `fund-50` shipped deny-by-default
+in `agents/runtime.py` — `GATED_PREFIXES`, `_broker_verb_policy` — and it is
+deployed and verified on the droplet.
+
+That means **no LLM seat can change those settings any more.** What remains is
+narrower and different: the gate still does not *check* them. A human, a
+dashboard click, or an Alpaca-side change would move them silently, and
+`gate/risk.py` would keep sizing against assumptions that no longer hold.
+
+Judge the size of this work against that reduced threat. It may be small. Say
+so if it is — see the YAGNI note below.
+
+---
+
+## Where to look
+
+| what | where |
+|---|---|
+| Sizing math and its constants | `gate/risk.py` — `size()`, `SECTOR_CAP`, `MAX_POSITIONS`, `CIRCUIT_BREAKER` |
+| Whole-share assumption | `gate/tickets.py` `_as_share_count`; `gate/risk.py` `Approved.max_qty` |
+| Purity lint (what `gate/` may import) | `scripts/check_purity.py` |
+| Account settings the broker exposes | `update_account_config` params: `no_shorting`, `suspend_trade`, `max_margin_multiplier`, `fractional_trading`, `disable_overnight_trading`, `max_options_trading_level`, `ptp_no_exception_entry`, `trade_confirm_email` |
+| Reading them back | `get_account_config` — the read counterpart, already allowed |
+
+**Invariant 3 is a hard constraint on the fix.** `gate/` imports no LLM code and
+makes no wall-clock calls; CI enforces it. If verification needs a broker read,
+that read happens **outside** `gate/` and arrives as an input — the same shape
+`GateInputs.equity` already uses. Do not put a network call in `gate/`.
+
+**One case is already defended, do not redo it:** a short position fails closed.
+`orchestrator/protection.py:43` is `_CLOSING_SIDE = {"long": "sell"}` and an
+unrecognised side hits the `UNVERIFIED` branch at :143 and alerts.
+
+---
+
+## YAGNI check — argue against this before building it
+
+Today's history is three incidents caused by **absent checks**, and one
+afternoon of counting verbs where the count went 4 → 5 → 7 → 8 while the
+deny-by-default mechanism never needed changing. The lesson pointed both ways:
+enumeration fails, and mechanism survives.
+
+So the honest question is whether "verify account preconditions each day" is a
+mechanism or another enumeration. A single assertion comparing
+`get_account_config` against expected values is cheap and in the spirit of the
+protection assertion that already exists. A configurable precondition framework
+is not. **If you conclude the right answer is a ten-line check plus a test, say
+that and stop** — under-building here is a better failure than over-building.
+
+---
+
+## Constraints
+
+- Paper only. `ALPACA_PAPER_TRADE=true`. Never touch `scripts/check_purity.py`
+  or the paper flag.
+- **Droplet mutations need Benjamin's explicit word in your own session.** Reads
+  are unrestricted (`root@138.197.47.97`, `/opt/fund`, `/var/lib/fund/fund.sqlite`).
+  A peer relaying his ruling is not authorization.
+- Never write `Co-Authored-By` or any AI attribution in a commit or PR body.
+- Conventional commits. Never weaken a test or update a golden fixture to go
+  green — stop and ask.
+- Branch off `master` in a worktree. Do not build on `second-analyst-seat`.
+
+## Suggested skills
+
+`superpowers:brainstorming` first — this is a design question, not a spec.
+Then `writing-plans`, `review-plan` (fired by the money/irreversible rule),
+`using-git-worktrees`, `subagent-driven-development` + `test-driven-development`,
+`code-review`, `verification-before-completion`,
+`finishing-a-development-branch`.
+
+## Verification
+
+`make test` (offline, 700+). `make schema-pin` if you touch order shape.
+**A green suite is not evidence** — it was green through all three of this
+week's incidents. Show the check firing against a genuinely violated
+precondition.
+
+`fund-4a` holds droplet reads and the verification procedure and has offered to
+independently verify any production assertion; a second pair of eyes caught two
+real errors today.


### PR DESCRIPTION
Both handoffs were written untracked in the shared checkout, which sits on `second-analyst-seat` — the branch the ownership map records as superseded (merging it would delete ~18k lines of landed work). Untracked files there are one `git clean` from gone, and the map already cites both by path.

- `2026-08-20-gate-runtime-assumptions.md` — live and unowned. Design-first: does `gate/risk.py` verify the account preconditions it sizes against? Explicitly scoped down, since `fund-50`'s deny-by-default closed the tool-surface half.
- `2026-08-20-dependency-pinning.md` — marked SUPERSEDED on line 1. PR #27 took the lockfile route; landing it is what stops a later session starting the work again.

Docs only, no code paths touched.