### PR TITLE
The watchdog could not tell a dead box from a failed run

### DIFF
--- a/docs/agents/devops.md
+++ b/docs/agents/devops.md
@@ -35,7 +35,7 @@ checker that can disagree with the first.
 |---|---|
 | In-run assertions, and the day's exit code | `scripts/audit_day.py::audit()` |
 | Failure alerting | `OnFailure=fund-alert@%n.service` → `ops/notify_failure.sh` |
-| Liveness — the run that never started | `ExecStartPost` heartbeat to an off-box watchdog (`HC_PING_URL`) |
+| Liveness — the run that never started | `ExecStopPost` heartbeat to an off-box watchdog (`HC_PING_URL/${EXIT_STATUS}`), fired pass or fail so silence means only "never ran" |
 | Pre-trade control | `gate/` |
 
 **Alert on what happened; watchdog what didn't.** A signal that stops arriving is invisible to any

--- a/ops/README.md
+++ b/ops/README.md
@@ -166,12 +166,20 @@ continues a comment across a trailing backslash where a shell would not.
 
 ### The heartbeat check
 
-`fund-daily.service` pings `HC_PING_URL` from `ExecStartPost`, so a ping means
-the day completed. The watchdog alerts on the **absence** of one — the single
-failure mode `OnFailure` cannot see, because a timer that never fires produces
-nothing for systemd to react to. Provisioning a fresh host is not finished
-until this exists; without it the host is silent in exactly the case that
-matters, and silence reads as a quiet day.
+`fund-daily.service` pings `HC_PING_URL/${EXIT_STATUS}` from `ExecStopPost`, so
+a ping means the day **ran**, and the exit status says whether it passed — 0 is
+a success to healthchecks.io, nonzero a failure. The watchdog alerts on the
+**absence** of one — the single failure mode `OnFailure` cannot see, because a
+timer that never fires produces nothing for systemd to react to. Provisioning a
+fresh host is not finished until this exists; without it the host is silent in
+exactly the case that matters, and silence reads as a quiet day.
+
+**It was `ExecStartPost` until 2026-08-24**, which fires only on success. A
+failed run therefore sent nothing and the watchdog fired — but `OnFailure` had
+already alerted on that same run, so silence meant "the box is dead" *or* "the
+run failed", ambiguous precisely where the watchdog is the only thing that can
+speak. If you are deploying a version at or before that date, the old form is
+what you will find on the host.
 
 On healthchecks.io, the check must be in **cron** mode:
 

--- a/ops/fund-daily.service
+++ b/ops/fund-daily.service
@@ -23,8 +23,8 @@ EnvironmentFile=/etc/fund/env
 # missed it.
 Environment=PATH=/home/fund/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
 ExecStart=/opt/fund/.venv/bin/python3 /opt/fund/scripts/run_day.py
-# Heartbeat to an off-box watchdog. ExecStartPost runs only when ExecStart
-# succeeded, so a ping means "the day completed".
+# Heartbeat to an off-box watchdog. ExecStopPost runs whether ExecStart
+# succeeded or failed, and ${EXIT_STATUS} carries which it was.
 #
 # This covers the one failure mode OnFailure structurally cannot: a unit that
 # never runs at all. Timer disabled by a daemon-reload, Persistent=false plus a
@@ -33,12 +33,28 @@ ExecStart=/opt/fund/.venv/bin/python3 /opt/fund/scripts/run_day.py
 # silence is indistinguishable from a quiet day. A watchdog expecting a daily
 # ping alerts on the absence instead.
 #
+# NOT ExecStartPost, which runs only on success. Under that form a failed run
+# sent no ping and the watchdog fired — but OnFailure had already alerted on
+# that same run. Silence therefore meant "the box is dead" OR "the run failed",
+# ambiguous in exactly the case where the watchdog is the only thing that can
+# speak. Firing unconditionally makes silence mean only "it never ran", and
+# lets the exit status carry pass/fail separately.
+#
+# Healthchecks.io reads a /<exit-status> suffix: 0 registers a success, nonzero
+# registers a failure. So an unconditional ping does not launder a failed day
+# into a healthy one — it reports the failure to the watchdog too.
+#
+# Known edge: on a TimeoutStartSec kill, systemd sets EXIT_STATUS to a signal
+# NAME (e.g. TERM), not a number. Healthchecks rejects that, curl -f errors,
+# the `-` swallows it, and the day reads as silence — which the watchdog alerts
+# on anyway, and OnFailure fires on timeout kills as well. Covered twice.
+#
 # The `-` prefix is deliberate and fail-safe in the right direction: a failed
 # ping cannot fail the trading day it is reporting on, and a ping that silently
 # never lands makes the watchdog alert. Errors here can only cause a false
 # alarm, never silence. Unset HC_PING_URL expands to empty, curl errors, and
 # the `-` swallows it — so this is inert until the URL is in /etc/fund/env.
-ExecStartPost=-/usr/bin/curl -fsS -m 10 --retry 3 ${HC_PING_URL}
+ExecStopPost=-/usr/bin/curl -fsS -m 10 --retry 3 ${HC_PING_URL}/${EXIT_STATUS}
 # Bound a hung LLM call. On kill the kernel releases the flock and checkpoint
 # CAS makes the next run resume rather than repeat.
 TimeoutStartSec=30min

--- a/tests/test_ops_units.py
+++ b/tests/test_ops_units.py
@@ -10,15 +10,32 @@ def test_heartbeat_cannot_fail_the_trading_day():
     a monitoring ping marks the unit failed AFTER a successful day — converting
     an observability addition into a trading-day failure, and firing OnFailure
     for a day that actually completed."""
-    line = next(l for l in DAILY.splitlines() if l.startswith("ExecStartPost="))
-    assert line.startswith("ExecStartPost=-"), f"lost the fail-safe prefix: {line}"
+    line = next(l for l in DAILY.splitlines() if l.startswith("ExecStopPost="))
+    assert line.startswith("ExecStopPost=-"), f"lost the fail-safe prefix: {line}"
 
 
 def test_heartbeat_runs_after_the_day_not_before():
-    """ExecStartPost, not ExecStartPre: a ping must mean the day COMPLETED. Pinging
-    before the run would report liveness for a day that then failed."""
-    assert "ExecStartPost=-/usr/bin/curl" in DAILY
+    """Never ExecStartPre: pinging before the run would report liveness for a
+    day that then failed."""
+    assert "ExecStopPost=-/usr/bin/curl" in DAILY
     assert "ExecStartPre=/usr/bin/curl" not in DAILY
+
+
+def test_heartbeat_fires_whether_the_day_passed_or_failed():
+    """ExecStopPost, not ExecStartPost. ExecStartPost runs ONLY on success, so a
+    failed run sent no ping and the watchdog fired — but OnFailure had already
+    alerted on that same run. Silence therefore meant "the box is dead" OR "the
+    run failed", ambiguous exactly where the watchdog is the only thing that can
+    speak. Firing unconditionally makes silence mean only "it never ran"."""
+    assert "ExecStartPost=" not in DAILY, "ExecStartPost only fires on success"
+
+
+def test_heartbeat_carries_the_exit_status():
+    """The ping must say whether the day passed. Healthchecks.io reads a
+    /<exit-status> suffix — 0 is a success, nonzero is a failure — so an
+    unconditional ping does not launder a failed day into a healthy one."""
+    line = next(l for l in DAILY.splitlines() if l.startswith("ExecStopPost="))
+    assert "${HC_PING_URL}/${EXIT_STATUS}" in line, line
 
 
 def test_no_restart_directive():


### PR DESCRIPTION
## The problem

`fund-daily.service` pinged its off-box watchdog from `ExecStartPost`, which systemd runs **only when `ExecStart` succeeded**. So a failed run sent no ping and the watchdog fired — but `OnFailure=fund-alert@%n.service` had already alerted on that same run.

Watchdog silence therefore meant either:

- the box is dead / the unit never started — **the case only the watchdog can catch**, or
- the run happened and failed — **already covered by `OnFailure`**

Ambiguous in exactly the case where the watchdog is the only thing that can speak.

This is not theoretical here: `fund-daily.service` has now failed on two consecutive trading days (2026-08-21 and 2026-08-24), so the watchdog has been firing on the covered branch.

## The change

```
-ExecStartPost=-/usr/bin/curl -fsS -m 10 --retry 3 ${HC_PING_URL}
+ExecStopPost=-/usr/bin/curl -fsS -m 10 --retry 3 ${HC_PING_URL}/${EXIT_STATUS}
```

`ExecStopPost` fires whether the day passed or failed, so **silence now means only "it never ran."** `HC_PING_URL` is healthchecks.io, which reads a `/<exit-status>` suffix — `0` registers a success, nonzero a failure — so the unconditional ping does not launder a failed day into a healthy one.

The `-` prefix is unchanged and still load-bearing: a failed monitoring ping must never fail the trading day it reports on.

## Known edge, documented in the unit file

On a `TimeoutStartSec` kill, systemd sets `EXIT_STATUS` to a signal *name* (e.g. `TERM`), not a number. healthchecks rejects that, `curl -f` errors, the `-` swallows it, and the day reads as silence — which the watchdog alerts on anyway, and `OnFailure` fires on timeout kills too. Covered twice.

## Tests

`tests/test_ops_units.py`: 5 passed. Full suite `1135 passed, 1 skipped, 7 deselected`.

Two existing tests changed, deliberately and not to make anything pass:

- `test_heartbeat_cannot_fail_the_trading_day` — the `-` prefix argument is unchanged; only the directive name moved.
- `test_heartbeat_runs_after_the_day_not_before` — this pinned "a ping must mean the day COMPLETED", which is the decision being changed. It is **re-pinned, not deleted**: two new tests assert the ping fires pass-or-fail and that it carries `${EXIT_STATUS}`, so the original concern (never report liveness for a day that then failed) is preserved by a different mechanism.

## Deploying

**Not deployable by merge.** This needs a droplet deploy plus `systemctl daemon-reload`, and the droplet is currently 25 commits behind `origin/master`. `ops/README.md` and `docs/agents/devops.md` are updated in this PR — read the runbook from the version you deploy, not the one on the host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)