### PR TITLE
An alert nobody tracked becomes an issue somebody can see

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,10 @@ test: lint
 	$(PYTHON) -m pytest tests/
 
 # Purity lint: no LLM imports, no wall clock in business logic (CLAUDE.md invariant 3).
+# Alert-code lint: every alert carries a stable code (docs/agents/devops.md).
 lint: deps
 	$(PYTHON) scripts/check_purity.py
+	$(PYTHON) scripts/check_alert_codes.py
 
 # Full simulated trading day: injected clock, FakeSlack, recorded LLM decisions,
 # real tool/gate/DB execution. No network, no API keys, no LLM cost.

--- a/agents/runtime.py
+++ b/agents/runtime.py
@@ -13,7 +13,7 @@ from typing import Callable
 
 from gate.tickets import validate_order
 from orchestrator.clock import Clock, iso
-from slackkit.outbox import append_event
+from slackkit.outbox import append_alert, append_event
 from state.transition import try_transition
 
 log = logging.getLogger(__name__)
@@ -111,7 +111,8 @@ def _deny(conn, clock, reason: str, alert_text: str) -> dict:
         "permissionDecisionReason": reason,
     }}
     try:
-        append_event(conn(), "alert", {"text": alert_text}, iso(clock.now()))
+        append_alert(conn(), "order_gate_denied", alert_text,
+                     now_iso=iso(clock.now()))
     # Logged, never silent: if this path is broken, denies go dark again.
     except Exception as exc:
         log.error("order gate: DENIED %s but could not record the alert —"
@@ -384,10 +385,11 @@ def record_turn_result(conn: sqlite3.Connection, run_date: str, seat: str,
     session_id = str(getattr(result, "session_id", None) or "unknown")
     if isinstance(usd, bool) or not isinstance(usd, (int, float)) \
             or usd != usd or usd in (float("inf"), float("-inf")):
-        append_event(conn, "alert", {
-            "text": f"cost_unavailable {seat} — turn completed with no"
-                    f" total_cost_usd estimate (session {session_id}); the"
-                    " day's est. inference cost understates spend"}, now_iso)
+        append_alert(conn, "cost_unavailable",
+                     f"cost_unavailable {seat} — turn completed with no"
+                     f" total_cost_usd estimate (session {session_id}); the"
+                     " day's est. inference cost understates spend",
+                     now_iso=now_iso)
         return False
     record_cost(conn, run_date, seat, session_id, float(usd), now_iso)
     return True

--- a/docs/superpowers/plans/2026-08-24-alert-issue-filer.md
+++ b/docs/superpowers/plans/2026-08-24-alert-issue-filer.md
@@ -533,6 +533,32 @@ def test_a_non_alert_append_event_is_accepted(tmp_path):
     p = tmp_path / "good.py"
     p.write_text('append_event(conn, "fill", {"text": "x"}, now)\n')
     assert _load().check_file(p) == []
+
+
+def test_a_wrapper_forwarding_its_own_code_is_accepted(tmp_path):
+    """scripts/run_day.py's _alert logs then delegates, so it forwards a
+    variable by construction. That is a forwarder, not a dynamic code."""
+    p = tmp_path / "good.py"
+    p.write_text(
+        "def _alert(conn, clock, code, text, **payload):\n"
+        "    log(text)\n"
+        "    append_alert(conn, code, text, now_iso=n, **payload)\n")
+    assert _load().check_file(p) == []
+
+
+def test_a_wrappers_own_callers_still_owe_a_literal(tmp_path):
+    """The exemption must not leak to the call sites — otherwise routing
+    through a wrapper would launder a dynamic code past the lint."""
+    p = tmp_path / "bad.py"
+    p.write_text('_alert(conn, clock, f"{seat}_turn_failed", "x")\n')
+    errors = _load().check_file(p)
+    assert len(errors) == 1 and "string literal" in errors[0]
+
+
+def test_a_wrapper_call_site_with_a_literal_is_accepted(tmp_path):
+    p = tmp_path / "good.py"
+    p.write_text('_alert(conn, clock, "seat_turn_failed", "x")\n')
+    assert _load().check_file(p) == []
 ```
 
 - [ ] **Step 2: Run to verify it fails**
@@ -553,10 +579,21 @@ forever — absence reading as health, the failure shape this repo keeps hitting
 
 Two checks:
   1. No append_event(..., 'alert', ...) anywhere. Use append_alert().
-  2. append_alert's code is a string literal matching ^[a-z][a-z0-9_]*$.
-     An f-string code is unbounded and would file an issue per run.
+  2. Every alert-raising call passes a string-literal code matching
+     ^[a-z][a-z0-9_]*$. An f-string code is unbounded and would file an issue
+     per run.
 
 Zero dependencies. Exit 1 on any violation.
+
+**The pass-through rule.** scripts/run_day.py keeps a thin `_alert(conn, clock,
+code, text, **payload)` wrapper that logs and delegates, so its one
+`append_alert(conn, code, ...)` call forwards a *variable* by construction.
+Rather than exempt that file, the rule is general: a call sitting inside a
+function that declares its own `code` parameter is a forwarder and is skipped
+— and `_alert` itself is checked as an alert raiser, so its five call sites
+still owe a literal. Known edge, documented rather than hidden: a NEW wrapper
+named something else would have its own callers unchecked until its name is
+added to ALERT_FUNCS.
 """
 from __future__ import annotations
 
@@ -569,6 +606,7 @@ ROOT = Path(__file__).resolve().parents[1]
 PACKAGES = ["orchestrator", "agents", "scripts", "slackkit", "gate", "state",
             "market", "evals"]
 CODE_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+ALERT_FUNCS = ("append_alert", "_alert")
 
 
 def _callee(node: ast.Call) -> str | None:
@@ -578,9 +616,25 @@ def _callee(node: ast.Call) -> str | None:
     return getattr(fn, "id", None)
 
 
+def _forwarded_calls(tree: ast.AST) -> set[int]:
+    """Calls inside a function that declares its own `code` parameter."""
+    forwarded: set[int] = set()
+    for fn in ast.walk(tree):
+        if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        params = [a.arg for a in fn.args.args + fn.args.kwonlyargs]
+        if "code" not in params:
+            continue
+        for inner in ast.walk(fn):
+            if isinstance(inner, ast.Call):
+                forwarded.add(id(inner))
+    return forwarded
+
+
 def check_file(path: Path) -> list[str]:
     errors: list[str] = []
     tree = ast.parse(path.read_text(), filename=str(path))
+    forwarded = _forwarded_calls(tree)
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue
@@ -591,11 +645,16 @@ def check_file(path: Path) -> list[str]:
                 errors.append(
                     f"{path}:{node.lineno}: append_event(..., 'alert', ...) —"
                     " use append_alert() so the alert carries a code")
-        elif name == "append_alert":
-            code = node.args[1] if len(node.args) > 1 else None
+        elif name in ALERT_FUNCS:
+            if id(node) in forwarded:
+                continue                   # a wrapper forwarding its own code
+            # append_alert(conn, code, text, ...)  -> args[1]
+            # _alert(conn, clock, code, text, ...) -> args[2]
+            pos = 1 if name == "append_alert" else 2
+            code = node.args[pos] if len(node.args) > pos else None
             if not isinstance(code, ast.Constant) or not isinstance(code.value, str):
                 errors.append(
-                    f"{path}:{node.lineno}: append_alert code must be a string"
+                    f"{path}:{node.lineno}: {name} code must be a string"
                     " literal, not an expression — a dynamic code files an"
                     " issue per run")
             elif not CODE_RE.match(code.value):

--- a/docs/superpowers/plans/2026-08-24-alert-issue-filer.md
+++ b/docs/superpowers/plans/2026-08-24-alert-issue-filer.md
@@ -243,6 +243,12 @@ git commit -m "feat: reconcile's alerts say which condition they are"
 
 Same rule as Task 2: assert on the existing test that already drives the path.
 
+> **The test→code tables below are a starting guess, not verified fact.** Task 2's equivalent table
+> had three wrong entries: two tests whose broker raises in the main poll loop never reach the code
+> path the table claimed, and one test fires two alerts rather than one. **Trace the actual control
+> flow, assert what really fires, and report every correction** — the site→code mapping by line is
+> authoritative, the which-test-hits-it mapping is not.
+
 **`tests/test_daily_stages.py`** — reuse the `_codes` helper shape from Task 2 (define it locally in
 this file too; the two files do not share a helper module):
 
@@ -372,7 +378,10 @@ git commit -m "feat: the stage alerts carry a code, and only positions carry a t
 
 - [ ] **Step 1: Write the failing test**
 
-Same rule again: assert on the existing tests that already drive each path.
+Same rule again: assert on the existing tests that already drive each path — and the same warning as
+Task 3: **the table below is a guess. Trace the control flow, assert what actually fires, report
+every correction.** The site→code mapping by line is authoritative; the which-test-hits-it mapping
+is not.
 
 **`tests/test_run_day.py`:**
 

--- a/docs/superpowers/plans/2026-08-24-alert-issue-filer.md
+++ b/docs/superpowers/plans/2026-08-24-alert-issue-filer.md
@@ -1,0 +1,1220 @@
+# Alert Identity and Issue Filer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give every alert a stable machine identity, then file an unmatched alert as a GitHub issue so it becomes tracked work.
+
+**Architecture:** A new `append_alert()` in `slackkit/outbox.py` takes `code` as a required positional and is the only way to write a `kind='alert'` row; all 25 emission sites migrate to it; an AST lint in `make lint` makes that permanent. A new stdlib-only `scripts/file_alert_issues.py` reads those codes, groups them into labels, asks an injected tracker what is already open, and files the rest. Dry run is the default.
+
+**Tech Stack:** Python 3.12, stdlib `ast`/`sqlite3`/`json`/`subprocess`, pytest, `gh` CLI.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-08-24-alert-issue-filer-design.md`. Do not invent fields.
+- **No trading behaviour changes.** Every production edit is at the alert-emission layer.
+- **`append_alert` never raises.** It runs on the alert path, frequently inside `except` blocks; a raise there converts "something needs human review" into "the day crashed" and violates invariant 4. All validation is static, in the lint.
+- **An alert code is a string literal** matching `^[a-z][a-z0-9_]*$` at the call site. Never an f-string, never a variable — a dynamic code is unbounded and files an issue per run.
+- `ticker` is a ticker symbol or absent. **Never** an order id, quantity, seat, timestamp or exception type.
+- `scripts/` is not a package. Scripts are argv-driven and stdlib-only; siblings are imported via `sys.path.insert(0, Path(__file__).resolve().parent)` (see `scripts/run_day.py:56,60`) and loaded in tests via `importlib.util.spec_from_file_location` (see `tests/test_audit_day.py:_load_audit`).
+- Run `make test` before every commit. Baseline on `4685579` is 1133 passed, 1 skipped.
+
+---
+
+### Task 1: `append_alert` — identity at the raise site
+
+**Files:**
+- Modify: `slackkit/outbox.py:19-25`
+- Test: `tests/test_slackkit.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `append_alert(conn, code: str, text: str, *, now_iso: str, ticker: str | None = None, clears: bool = False, **payload) -> int`. Every later migration task calls exactly this.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_slackkit.py`:
+
+`fund_db` is the existing conftest fixture used throughout `tests/test_slackkit.py`; it carries the
+full schema including `events`. Do not add a second events fixture.
+
+```python
+def test_append_alert_carries_code_ticker_and_extra_payload(fund_db):
+    conn = fund_db
+    from slackkit.outbox import append_alert
+    rowid = append_alert(conn, "unprotected_position", "NVDA 40 exposed",
+                         now_iso="2026-08-24T13:37:54+00:00", ticker="NVDA",
+                         accounting={"symbol": "NVDA", "held": 40})
+    row = conn.execute("SELECT kind, payload FROM events WHERE id=?",
+                       (rowid,)).fetchone()
+    assert row["kind"] == "alert"
+    assert json.loads(row["payload"]) == {
+        "text": "NVDA 40 exposed",
+        "code": "unprotected_position",
+        "ticker": "NVDA",
+        "accounting": {"symbol": "NVDA", "held": 40},
+    }
+
+
+def test_append_alert_omits_absent_ticker_and_clears(fund_db):
+    conn = fund_db
+    from slackkit.outbox import append_alert
+    rowid = append_alert(conn, "pm_timeout", "pm_timeout AAPL — defaulted to hold",
+                         now_iso="2026-08-24T13:36:11+00:00")
+    payload = json.loads(conn.execute(
+        "SELECT payload FROM events WHERE id=?", (rowid,)).fetchone()["payload"])
+    assert "ticker" not in payload and "clears" not in payload
+
+
+def test_append_alert_marks_a_clearing_alert(fund_db):
+    conn = fund_db
+    from slackkit.outbox import append_alert
+    rowid = append_alert(conn, "accounting_shortfall", "NVDA agrees again at 40",
+                         now_iso="2026-08-25T13:00:00+00:00", ticker="NVDA",
+                         clears=True)
+    payload = json.loads(conn.execute(
+        "SELECT payload FROM events WHERE id=?", (rowid,)).fetchone()["payload"])
+    assert payload["clears"] is True
+```
+
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python3 -m pytest tests/test_slackkit.py -k append_alert -v`
+Expected: FAIL with `ImportError: cannot import name 'append_alert'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Replace `slackkit/outbox.py:19-25` with:
+
+```python
+def _insert(conn: sqlite3.Connection, kind: str, payload: dict,
+            now_iso: str) -> int:
+    cur = conn.execute(
+        "INSERT INTO events (kind, payload, created_at) VALUES (?, ?, ?)",
+        (kind, json.dumps(payload), now_iso))
+    conn.commit()
+    return cur.lastrowid
+
+
+def append_event(conn: sqlite3.Connection, kind: str, payload: dict,
+                 now_iso: str) -> int:
+    return _insert(conn, kind, payload, now_iso)
+
+
+def append_alert(conn: sqlite3.Connection, code: str, text: str, *,
+                 now_iso: str, ticker: str | None = None,
+                 clears: bool = False, **payload) -> int:
+    """Append an alert carrying a stable machine identity.
+
+    `code` is what scripts/file_alert_issues.py keys a GitHub issue on, so it
+    must be identical across runs: never interpolate a ticker, order id,
+    quantity or exception type into it. `ticker` is the only permitted
+    per-entity key, and only where fixing one position would not fix another.
+
+    Deliberately validates nothing. This runs on the alert path, often inside
+    an `except`, and a raise here would turn "something needs review" into a
+    dead trading day (invariant 4). scripts/check_alert_codes.py enforces the
+    code's shape statically instead.
+    """
+    body: dict = {"text": text, "code": code, **payload}
+    if ticker is not None:
+        body["ticker"] = ticker
+    if clears:
+        body["clears"] = True
+    return _insert(conn, "alert", body, now_iso)
+```
+
+Routing `append_alert` through `_insert` rather than `append_event` is what lets Task 5's lint ban `append_event(..., "alert", ...)` with **no exemption for its own definition site**.
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `make test`
+Expected: 1136 passed, 1 skipped. `append_event`'s behaviour is unchanged, so nothing else moves.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add slackkit/outbox.py tests/test_slackkit.py
+git commit -m "feat: an alert can carry a stable code, not just prose"
+```
+
+---
+
+### Task 2: Migrate `orchestrator/reconcile.py` (10 sites)
+
+**Files:**
+- Modify: `orchestrator/reconcile.py:77,90,149,156,161,169,176,193,207,268`
+- Test: `tests/test_reconcile.py`
+
+**Interfaces:**
+- Consumes: `append_alert` from Task 1.
+- Produces: codes `fill_on_unapproved_decision`, `partial_fill_manual_review`, `order_unreconciled`, `order_unfilled_at_cap`, `order_partial_then_dead`, `order_unresolved_at_cap`. No `ticker` on any of them.
+
+- [ ] **Step 1: Write the failing test**
+
+Every one of these paths already has a passing test that drives it. **Add a code assertion to the
+existing test rather than re-driving the path** — duplicating the arrange logic is how the two copies
+drift. Add this helper at the top of `tests/test_reconcile.py`:
+
+```python
+def _codes(conn):
+    return [json.loads(r["payload"]).get("code") for r in conn.execute(
+        "SELECT payload FROM events WHERE kind='alert' ORDER BY id")]
+```
+
+Then add exactly one assertion to the end of each of these existing tests:
+
+| Existing test in `tests/test_reconcile.py` | Assertion to add |
+|---|---|
+| `test_fill_with_decision_not_approved_alerts_and_does_not_transition` (:192) | `assert _codes(fund_db) == ["fill_on_unapproved_decision"]` |
+| `test_partial_fill_left_submitted_with_alert` (:56) | `assert _codes(fund_db) == ["partial_fill_manual_review"]` |
+| `test_broker_error_fails_closed_no_transition` (:70) | `assert _codes(fund_db) == ["order_unreconciled"]` |
+| `test_malformed_fill_none_values_leaves_submitted_no_transition` (:81) | `assert _codes(fund_db) == ["order_unreconciled"]` |
+| `test_cancel_error_and_still_open_leaves_order_submitted` (:252) | `assert _codes(fund_db) == ["order_unreconciled"]` |
+| `test_requery_error_after_cancel_leaves_order_submitted` (:268) | `assert _codes(fund_db) == ["order_unreconciled"]` |
+| `test_pending_cancel_is_not_a_confirmed_cancel` (:288) | `assert _codes(fund_db) == ["order_unreconciled"]` |
+| `test_never_fills_within_cap_decision_failed_alert` (:38) | `assert _codes(fund_db) == ["order_unfilled_at_cap"]` |
+| `test_partial_then_canceled_records_the_shares_held` (:341) | `assert _codes(fund_db) == ["order_partial_then_dead"]` |
+| `test_broker_unreachable_at_cap_alerts_loudly` (:114) | `assert _codes(fund_db) == ["order_unresolved_at_cap"]` |
+
+The five `order_unreconciled` rows are the point: five reasons, one condition, one issue. If any of
+those five comes back as a distinct code, the migration is wrong.
+
+Then add one new test:
+
+```python
+def test_no_reconcile_alert_carries_a_ticker_key(fund_db, sim_clock):
+    """An order id or symbol as a key here would file an issue per order,
+    forever. Driven through the cheapest alerting path in this file."""
+    _submitted_order(fund_db, sim_clock.now())
+    _poll(fund_db, sim_clock, _Unreachable())      # the broker used at :114
+    payloads = [json.loads(r["payload"]) for r in fund_db.execute(
+        "SELECT payload FROM events WHERE kind='alert'")]
+    assert payloads and all("ticker" not in p for p in payloads)
+```
+
+Use whichever unreachable-broker class `test_broker_unreachable_at_cap_alerts_loudly` already
+constructs; do not add a second one.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python3 -m pytest tests/test_reconcile.py -k "code or ticker_key" -v`
+Expected: FAIL — `_codes` returns `[None, ...]`, because the payloads carry no `code` yet.
+
+- [ ] **Step 3: Rewrite each call**
+
+Change the import at the top of `orchestrator/reconcile.py` from `append_event` to `append_alert`, then convert each site. The text is unchanged in every case; only the call shape changes. Site 77:
+
+```python
+                    append_alert(conn, "fill_on_unapproved_decision",
+                        f"order {coid[:8]} filled but decision "
+                        f"{t['decision_id']} was '{dec_status}', not "
+                        "'approved' — left as-is, manual review",
+                        now_iso=now)
+```
+
+Site 90 → `partial_fill_manual_review`. Sites 149, 156, 161, 169, 176 → all `order_unreconciled`, keeping their distinct `stale.format(why=…)` text. Site 193 → `order_unfilled_at_cap`. Site 207 → `order_partial_then_dead`. Site 268 → `order_unresolved_at_cap`.
+
+- [ ] **Step 4: Run the suite**
+
+Run: `make test`
+Expected: all green. Existing reconcile tests assert on alert **text**, which is unchanged.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add orchestrator/reconcile.py tests/test_reconcile.py
+git commit -m "feat: reconcile's alerts say which condition they are"
+```
+
+---
+
+### Task 3: Migrate `daily.py`, `preconditions.py`, `protection.py` (7 sites)
+
+**Files:**
+- Modify: `orchestrator/daily.py:139,216,337`, `orchestrator/preconditions.py:56`, `orchestrator/protection.py:196,353,360`
+- Test: `tests/test_daily_stages.py`, `tests/test_preconditions.py`, `tests/test_protection.py`
+
+**Interfaces:**
+- Consumes: `append_alert` from Task 1.
+- Produces: `gate_error` (ticker), `pm_timeout` (no ticker), `ticket_open_after_exec`, `account_precondition_drift`, `unprotected_position` (ticker), `accounting_shortfall` (ticker, and `clears=True` on the clearing path), `accounting_unverified`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Same rule as Task 2: assert on the existing test that already drives the path.
+
+**`tests/test_daily_stages.py`** — reuse the `_codes` helper shape from Task 2 (define it locally in
+this file too; the two files do not share a helper module):
+
+| Existing test | Assertion to add |
+|---|---|
+| `test_pre_gate_drops_garbage_inputs` (:78) | `assert _codes(fund_db) == ["gate_error"]` and the payload's `ticker` equals the dropped ticker |
+| `test_decision_timeout_defaults_hold_with_event` (:205) | `assert _codes(fund_db) == ["pm_timeout"]` and `"ticker" not in payload` |
+
+Then one new test in `tests/test_daily_stages.py`, which is the one that actually pins the keying
+rule:
+
+```python
+def test_pm_timeout_on_three_tickers_is_one_code_with_no_ticker_key(fund_db, sim_clock):
+    """One root cause — the PM did not answer. A ticker key here would file
+    three issues for one silence."""
+    for ticker in ("AAPL", "MSFT", "NVDA"):
+        _seed_decision(fund_db, sim_clock, ticker, "hold", 0)
+    ctx = _ctx(fund_db, sim_clock, _nvda_inputs(), turns=None)
+    run_decision(ctx)                      # the PM turn that never answers
+    payloads = [json.loads(r["payload"]) for r in fund_db.execute(
+        "SELECT payload FROM events WHERE kind='alert' ORDER BY id")]
+    assert [p["code"] for p in payloads] == ["pm_timeout"] * 3
+    assert all("ticker" not in p for p in payloads)
+```
+
+Build the three-ticker arrange with `_seed_decision` / `_ctx` / `_nvda_inputs` exactly as
+`test_decision_timeout_defaults_hold_with_event` does; only the ticker count changes.
+
+**`tests/test_protection.py`** — this file already has an `_alerts(conn)` helper (:13); read `code`
+off the payloads it returns.
+
+| Existing test | Assertion to add |
+|---|---|
+| `test_a_promised_stop_that_is_gone_alerts` (:113) | code is `unprotected_position`, `ticker == "NVDA"` |
+| `test_a_stop_for_fewer_shares_than_held_alerts` (:185) | code is `unprotected_position`, `ticker == "NVDA"` |
+| `test_a_covered_symbol_and_a_naked_one_alert_exactly_once` (:213) | exactly one alert, and its `ticker` is the naked symbol — **not** the covered one |
+| `test_a_missing_broker_alerts` (:344) | code is `accounting_unverified`, `"ticker" not in payload` |
+
+Then one new test for the clearing path, which no existing test covers:
+
+```python
+def test_the_accounting_clearing_alert_is_marked_clears(fund_db):
+    """assert_positions_accounted's clear path must be distinguishable, or
+    the filer reads a resolution as a new finding."""
+    # arrange a standing shortfall exactly as the accounting tests do, then a
+    # broker that agrees again, and run assert_positions_accounted twice
+    payload = json.loads(_alerts(fund_db)[-1]["payload"])
+    assert payload["code"] == "accounting_shortfall"
+    assert payload["clears"] is True
+    assert payload["accounting"]["cleared"] is True
+```
+
+**`tests/test_preconditions.py`** — add to the existing drift test (the one asserting on the `drift`
+payload) that `payload["code"] == "account_precondition_drift"` and that the `drift` dict it already
+asserts on is unchanged.
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `.venv/bin/python3 -m pytest tests/test_daily_stages.py tests/test_protection.py tests/test_preconditions.py -k "code or clears or ticker" -v`
+Expected: FAIL with `KeyError: 'code'`.
+
+- [ ] **Step 3: Rewrite each call**
+
+`orchestrator/daily.py:139`:
+
+```python
+            append_alert(ctx.conn, "gate_error",
+                         f"gate_error {ticker} — dropped from"
+                         " today's universe (malformed feed)",
+                         now_iso=now, ticker=ticker)
+```
+
+`daily.py:216` → `pm_timeout`, **no `ticker=`**. `daily.py:337` → `ticket_open_after_exec`, no ticker.
+
+`orchestrator/preconditions.py:56` — the local `alert` closure becomes:
+
+```python
+    def alert(text: str, drift: dict) -> int:
+        append_alert(conn, "account_precondition_drift", text,
+                     now_iso=now_iso, drift=drift)
+        return 1
+```
+
+`orchestrator/protection.py:196` — the local `alert` closure gains the symbol it already has in scope at each call site; give it a `ticker` parameter and pass the position's symbol:
+
+```python
+    def alert(text: str, ticker: str | None = None) -> None:
+        append_alert(conn, "unprotected_position", text,
+                     now_iso=now_iso, ticker=ticker)
+```
+
+`protection.py:353` — `accounting_shortfall`, `ticker=symbol`, and on the clearing branch add `clears=True` (the existing `{"symbol": …, "cleared": True}` accounting dict stays untouched):
+
+```python
+    def alert(text: str, accounting: dict) -> None:
+        append_alert(conn, "accounting_shortfall", text, now_iso=now_iso,
+                     ticker=accounting["symbol"],
+                     clears=bool(accounting.get("cleared")),
+                     accounting=accounting)
+```
+
+`protection.py:360` — the `unverified` closure → `accounting_unverified`, no ticker (it fires when no per-symbol read succeeded).
+
+- [ ] **Step 4: Run the suite**
+
+Run: `make test`
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add orchestrator/daily.py orchestrator/preconditions.py orchestrator/protection.py tests/
+git commit -m "feat: the stage alerts carry a code, and only positions carry a ticker"
+```
+
+---
+
+### Task 4: Migrate `scripts/run_day.py` (6 sites) and `agents/runtime.py` (2 sites)
+
+**Files:**
+- Modify: `scripts/run_day.py:282,297,341,366,383,428,458`, `agents/runtime.py:114,387`
+- Test: `tests/test_run_day.py`, `tests/test_runtime_hooks.py`
+
+**Interfaces:**
+- Consumes: `append_alert` from Task 1.
+- Produces: `seat_turn_failed`, `exec_turn_violation`, `missing_price_history`, `unmapped_sector`, `audit_failed`, `run_day_failed`, `order_gate_denied`, `cost_unavailable`. None carry a ticker.
+
+- [ ] **Step 1: Write the failing test**
+
+Same rule again: assert on the existing tests that already drive each path.
+
+**`tests/test_run_day.py`:**
+
+| Existing test | Assertion to add |
+|---|---|
+| `test_a_seat_turn_that_raises_alerts_and_lets_the_stage_default_land` (:503) | code is `seat_turn_failed`, and the text still starts `analyst_turn_failed —` |
+| `test_an_exec_tool_call_violation_is_alerted_after_the_cost_is_recorded` (:537) | code is `exec_turn_violation` |
+| `test_a_held_ticker_with_no_price_history_is_named_in_an_alert` (:311) | code is `missing_price_history`, and `tickers` is unchanged |
+| `test_a_held_ticker_missing_from_sectors_yaml_is_named_in_an_alert` (:355) | code is `unmapped_sector`, and `tickers` is unchanged |
+| `test_a_raise_inside_the_day_alerts_slack_and_exits_nonzero` (:225) | code is `run_day_failed` |
+| `test_a_drifted_account_setting_alerts_but_does_not_abort_the_day` (:845) | code is `account_precondition_drift` |
+
+The seat-turn one is the case that matters most, so it also gets its own test:
+
+```python
+def test_seat_turn_failure_uses_a_literal_code_not_the_seat_name(wired):
+    """The seat belongs in the TEXT. A code of f"{seat}_turn_failed" mints a
+    new code — and therefore a new issue — for every seat that ever fails."""
+    # arrange exactly as test_a_seat_turn_that_raises_alerts... does (:503)
+    payload = json.loads(_alerts(wired.conn)[-1]["payload"])
+    assert payload["code"] == "seat_turn_failed"
+    assert payload["text"].startswith("analyst_turn_failed —")
+```
+
+And the rollup, which no existing test asserts the marker on:
+
+```python
+def test_the_audit_rollup_keeps_its_self_alert_marker(wired):
+    """audit_day.SELF_ALERT_KEY is how BOTH audit_day and the filer avoid
+    double-counting the rollup. Migrating must not drop it."""
+    # arrange as test_a_zero_ticker_day... (:631) but with a failing audit
+    payload = json.loads(_alerts(wired.conn)[-1]["payload"])
+    assert payload["code"] == "audit_failed"
+    assert payload[audit_day.SELF_ALERT_KEY] is True
+```
+
+**`tests/test_runtime_hooks.py`:**
+
+| Existing test | Assertion to add |
+|---|---|
+| `test_order_gate_deny_appends_one_alert_naming_ticker_reason_and_ticket` (:66) | code is `order_gate_denied` |
+| `test_order_gate_deny_alert_survives_malformed_tool_input` (:99) | code is `order_gate_denied` |
+| `test_record_turn_result_none_cost_records_nothing_and_alerts` (:402) | code is `cost_unavailable` |
+
+`test_order_gate_deny_survives_an_unrecordable_alert` (:264) must keep passing untouched — it proves
+a failed alert write does not undo the denial, and `append_alert` deliberately adds no new raise
+path there.
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `.venv/bin/python3 -m pytest tests/test_run_day.py tests/test_runtime_hooks.py -k code -v`
+Expected: FAIL with `KeyError: 'code'`.
+
+- [ ] **Step 3: Rewrite `_alert` and each call**
+
+`scripts/run_day.py:341` — the private `_alert` helper gains a code and delegates:
+
+```python
+def _alert(conn, clock, code: str, text: str, **payload) -> None:
+    log(f"ALERT {text}")
+    append_alert(conn, code, text, now_iso=iso(clock.now()), **payload)
+```
+
+Then each caller passes its literal code as the third argument: `:282` → `"seat_turn_failed"` (the seat name stays inside the text, which is already `f"{seat}_turn_failed — …"`); `:297` → `"exec_turn_violation"`; `:366` → `"missing_price_history"` (keeps `tickers=gaps`); `:383` → `"unmapped_sector"` (keeps `tickers=gaps`); `:428` → `"audit_failed"`, keeping `**{audit_day.SELF_ALERT_KEY: True}`.
+
+`run_day.py:458` is the last-resort handler inside `guarded` and calls `append_event` directly, deliberately outside `_alert` — convert it to `append_alert(conn, "run_day_failed", text, now_iso=iso(clock.now()))`, keeping its surrounding try/except exactly as it is.
+
+`agents/runtime.py:114` → `append_alert(conn(), "order_gate_denied", alert_text, now_iso=iso(clock.now()))`, leaving the surrounding try/except that logs a failed write. `agents/runtime.py:387` → `cost_unavailable`.
+
+- [ ] **Step 4: Run the suite**
+
+Run: `make test`
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/run_day.py agents/runtime.py tests/
+git commit -m "feat: the day's own alerts carry codes, and _alert stops being a second way to raise one"
+```
+
+---
+
+### Task 5: The lint that makes it permanent
+
+**Files:**
+- Create: `scripts/check_alert_codes.py`
+- Modify: `Makefile` (the `lint` target)
+- Test: `tests/test_markers.py` (or a new `tests/test_alert_codes_lint.py`)
+
+**Interfaces:**
+- Consumes: the completed migration from Tasks 2–4.
+- Produces: `check_file(path: Path) -> list[str]` and `main() -> int`, matching `scripts/check_purity.py`'s shape exactly.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_alert_codes_lint.py`:
+
+```python
+"""The lint's own negative controls. A lint whose negative control also
+passes is not a lint — this repo has three documented instances of exactly
+that, two caught by luck."""
+import importlib.util, subprocess, sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "check_alert_codes.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("check_alert_codes", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_the_real_tree_is_clean():
+    assert subprocess.run([sys.executable, str(SCRIPT)]).returncode == 0
+
+
+def test_a_direct_append_event_alert_is_rejected(tmp_path):
+    p = tmp_path / "bad.py"
+    p.write_text('append_event(conn, "alert", {"text": "x"}, now)\n')
+    errors = _load().check_file(p)
+    assert len(errors) == 1 and "append_alert" in errors[0]
+
+
+def test_an_interpolated_code_is_rejected(tmp_path):
+    p = tmp_path / "bad.py"
+    p.write_text('append_alert(conn, f"{seat}_turn_failed", "x", now_iso=n)\n')
+    errors = _load().check_file(p)
+    assert len(errors) == 1 and "string literal" in errors[0]
+
+
+def test_a_shouty_code_is_rejected(tmp_path):
+    p = tmp_path / "bad.py"
+    p.write_text('append_alert(conn, "PM Timeout", "x", now_iso=n)\n')
+    errors = _load().check_file(p)
+    assert len(errors) == 1 and "lower_snake" in errors[0]
+
+
+def test_a_good_call_is_accepted(tmp_path):
+    p = tmp_path / "good.py"
+    p.write_text('append_alert(conn, "pm_timeout", "x", now_iso=n)\n')
+    assert _load().check_file(p) == []
+
+
+def test_a_non_alert_append_event_is_accepted(tmp_path):
+    p = tmp_path / "good.py"
+    p.write_text('append_event(conn, "fill", {"text": "x"}, now)\n')
+    assert _load().check_file(p) == []
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `.venv/bin/python3 -m pytest tests/test_alert_codes_lint.py -v`
+Expected: FAIL — `scripts/check_alert_codes.py` does not exist.
+
+- [ ] **Step 3: Write the lint**
+
+```python
+#!/usr/bin/env python3
+"""Alert-code lint (CI-enforced; see docs/agents/devops.md).
+
+Every kind='alert' row must carry a stable `code`, because that code is what
+scripts/file_alert_issues.py keys a GitHub issue on. A site that forgets one
+still alerts and still reaches Slack, and is silently invisible to the filer
+forever — absence reading as health, the failure shape this repo keeps hitting.
+
+Two checks:
+  1. No append_event(..., 'alert', ...) anywhere. Use append_alert().
+  2. append_alert's code is a string literal matching ^[a-z][a-z0-9_]*$.
+     An f-string code is unbounded and would file an issue per run.
+
+Zero dependencies. Exit 1 on any violation.
+"""
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGES = ["orchestrator", "agents", "scripts", "slackkit", "gate", "state",
+            "market", "evals"]
+CODE_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+
+
+def _callee(node: ast.Call) -> str | None:
+    fn = node.func
+    if isinstance(fn, ast.Attribute):
+        return fn.attr
+    return getattr(fn, "id", None)
+
+
+def check_file(path: Path) -> list[str]:
+    errors: list[str] = []
+    tree = ast.parse(path.read_text(), filename=str(path))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        name = _callee(node)
+        if name == "append_event":
+            kind = node.args[1] if len(node.args) > 1 else None
+            if isinstance(kind, ast.Constant) and kind.value == "alert":
+                errors.append(
+                    f"{path}:{node.lineno}: append_event(..., 'alert', ...) —"
+                    " use append_alert() so the alert carries a code")
+        elif name == "append_alert":
+            code = node.args[1] if len(node.args) > 1 else None
+            if not isinstance(code, ast.Constant) or not isinstance(code.value, str):
+                errors.append(
+                    f"{path}:{node.lineno}: append_alert code must be a string"
+                    " literal, not an expression — a dynamic code files an"
+                    " issue per run")
+            elif not CODE_RE.match(code.value):
+                errors.append(
+                    f"{path}:{node.lineno}: alert code {code.value!r} is not a"
+                    " bare lower_snake identifier")
+    return errors
+
+
+def main() -> int:
+    errors: list[str] = []
+    for package in PACKAGES:
+        root = ROOT / package
+        if not root.exists():
+            continue
+        for path in sorted(root.rglob("*.py")):
+            if "__pycache__" in path.parts:
+                continue
+            errors.extend(check_file(path))
+    for e in errors:
+        print(e, file=sys.stderr)
+    if errors:
+        print(f"ALERT CODE LINT: {len(errors)} violation(s)", file=sys.stderr)
+        return 1
+    print(f"ALERT CODE LINT: clean ({len(PACKAGES)} packages)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 4: Wire it into `make lint`**
+
+In `Makefile`, extend the existing `lint` target:
+
+```make
+# Purity lint: no LLM imports, no wall clock in business logic (CLAUDE.md invariant 3).
+# Alert-code lint: every alert carries a stable code (docs/agents/devops.md).
+lint: deps
+	$(PYTHON) scripts/check_purity.py
+	$(PYTHON) scripts/check_alert_codes.py
+```
+
+- [ ] **Step 5: Run and commit**
+
+Run: `make test`
+Expected: `ALERT CODE LINT: clean (8 packages)`, then all tests green.
+
+```bash
+git add scripts/check_alert_codes.py tests/test_alert_codes_lint.py Makefile
+git commit -m "feat: a site that forgets an alert code fails the build"
+```
+
+---
+
+### Task 6: `plan_filings` — all the dedupe logic, no network
+
+**Files:**
+- Create: `scripts/file_alert_issues.py`
+- Test: `tests/test_file_alert_issues.py`
+
+**Interfaces:**
+- Consumes: alert payloads produced by Tasks 2–4; `audit_day.SELF_ALERT_KEY` and `audit_day.et_day_window` via the sibling-import idiom.
+- Produces: `Filing` (frozen dataclass with `action: str`, `labels: tuple[str, ...]`, `code: str`, `ticker: str | None`, `title: str`, `body: str`, `issue: int | None = None`), `plan_filings(conn, since: str, tracker, db_path: str = "") -> tuple[list[Filing], list[str]]` returning `(filings, malformed)`, and the tracker protocol `open_issue(labels: tuple[str, ...]) -> int | None`.
+
+**Grouping rule** — this refines spec §3.4 step 5, which was ambiguous about a condition that both fires and clears inside one window:
+
+- Group alerts by their label tuple. A clearing alert never contributes text.
+- Group has non-clearing text → an open issue means `skip`, no open issue means `create`. The body notes if it later cleared. *A condition that fired and resolved in the window still files: the symptom clearing is not the defect being fixed.*
+- Group has clearing alerts only → an open issue means `comment`; no open issue means nothing at all. Never file an issue to announce a resolution.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_file_alert_issues.py`:
+
+```python
+"""The filer's dedupe, against the REAL alert texts from 2026-08-21 and
+2026-08-24. Synthetic text would not prove the key survives interpolation,
+which is the entire defect this script exists to fix."""
+import importlib.util, json, sqlite3, sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "file_alert_issues.py"
+
+NVDA_0821 = ("NVDA 80 was ticketed with a stop at 215.0 but the broker covers"
+             " only 40 of 80 shares — the position is exposed and no code path"
+             " will protect it; place or restore a stop manually")
+NVDA_0824 = ("NVDA 40 was ticketed with a stop at 215.0 but the broker has NO"
+             " live protective order — the position is exposed and no code path"
+             " will protect it; place or restore a stop manually")
+
+
+def _load():
+    sys.path.insert(0, str(ROOT / "scripts"))
+    spec = importlib.util.spec_from_file_location("file_alert_issues", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class FakeTracker:
+    """Records every lookup; answers from a fixed open set."""
+    def __init__(self, open_issues=None):
+        self.open_issues = open_issues or {}      # labels tuple -> issue number
+        self.lookups = []
+
+    def open_issue(self, labels):
+        self.lookups.append(labels)
+        return self.open_issues.get(tuple(labels))
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    return tmp_path / "t.sqlite"
+
+
+@pytest.fixture
+def db(db_path):
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("CREATE TABLE events (id INTEGER PRIMARY KEY, kind TEXT,"
+                 " payload TEXT, created_at TEXT, posted_at TEXT)")
+    return conn
+
+
+def _alert(conn, created_at, **payload):
+    conn.execute("INSERT INTO events (kind, payload, created_at) VALUES"
+                 " ('alert', ?, ?)", (json.dumps(payload), created_at))
+    conn.commit()
+
+
+def test_the_same_condition_with_different_text_files_once(db):
+    """THE defect. Both texts are verbatim from the production DBs."""
+    _alert(db, "2026-08-21T13:38:02+00:00", code="unprotected_position",
+           ticker="NVDA", text=NVDA_0821)
+    _alert(db, "2026-08-24T13:37:54+00:00", code="unprotected_position",
+           ticker="NVDA", text=NVDA_0824)
+    filings, _ = _load().plan_filings(db, "2026-08-21", FakeTracker())
+    assert [f.action for f in filings] == ["create"]
+    assert filings[0].labels == ("alert:unprotected_position", "ticker:NVDA")
+    assert NVDA_0821 in filings[0].body and NVDA_0824 in filings[0].body
+
+
+def test_negative_control_two_codes_file_two_issues(db):
+    """If this passed with one issue, the test above would prove nothing."""
+    _alert(db, "2026-08-24T13:37:54+00:00", code="unprotected_position",
+           ticker="NVDA", text=NVDA_0824)
+    _alert(db, "2026-08-24T13:37:54+00:00", code="accounting_shortfall",
+           ticker="NVDA", text="NVDA: recorded 80, broker holds 40")
+    filings, _ = _load().plan_filings(db, "2026-08-24", FakeTracker())
+    assert [f.action for f in filings] == ["create", "create"]
+
+
+def test_pm_timeout_on_three_tickers_is_one_issue(db):
+    for t in ("AAPL", "MSFT", "NVDA"):
+        _alert(db, "2026-08-18T13:36:11+00:00", code="pm_timeout",
+               text=f"pm_timeout {t} — defaulted to hold")
+    filings, _ = _load().plan_filings(db, "2026-08-18", FakeTracker())
+    assert [f.action for f in filings] == ["create"]
+    assert filings[0].labels == ("alert:pm_timeout",)
+
+
+def test_two_tickers_of_one_code_are_two_issues(db):
+    for t in ("NVDA", "MSFT"):
+        _alert(db, "2026-08-24T13:00:00+00:00", code="unprotected_position",
+               ticker=t, text=f"{t} exposed")
+    filings, _ = _load().plan_filings(db, "2026-08-24", FakeTracker())
+    assert sorted(f.labels[1] for f in filings) == ["ticker:MSFT", "ticker:NVDA"]
+
+
+def test_an_already_open_issue_files_nothing(db):
+    _alert(db, "2026-08-24T13:37:54+00:00", code="unprotected_position",
+           ticker="NVDA", text=NVDA_0824)
+    tracker = FakeTracker({("alert:unprotected_position", "ticker:NVDA"): 41})
+    filings, _ = _load().plan_filings(db, "2026-08-24", tracker)
+    assert [f.action for f in filings] == ["skip"]
+    assert filings[0].issue == 41
+
+
+def test_a_closed_issue_does_not_suppress_a_recurrence(db):
+    """Only OPEN issues match, so a recurrence gets a fresh issue."""
+    _alert(db, "2026-08-24T13:37:54+00:00", code="unprotected_position",
+           ticker="NVDA", text=NVDA_0824)
+    filings, _ = _load().plan_filings(db, "2026-08-24", FakeTracker({}))
+    assert [f.action for f in filings] == ["create"]
+
+
+def test_a_clearing_alert_comments_and_never_closes(db):
+    _alert(db, "2026-08-25T13:00:00+00:00", code="accounting_shortfall",
+           ticker="NVDA", clears=True, text="NVDA agrees again at 40")
+    tracker = FakeTracker({("alert:accounting_shortfall", "ticker:NVDA"): 42})
+    filings, _ = _load().plan_filings(db, "2026-08-25", tracker)
+    assert [f.action for f in filings] == ["comment"]
+    assert filings[0].issue == 42
+    assert all(f.action != "close" for f in filings)
+
+
+def test_a_clearing_alert_with_no_open_issue_does_nothing(db):
+    _alert(db, "2026-08-25T13:00:00+00:00", code="accounting_shortfall",
+           ticker="NVDA", clears=True, text="NVDA agrees again at 40")
+    filings, _ = _load().plan_filings(db, "2026-08-25", FakeTracker())
+    assert filings == []
+
+
+def test_a_condition_that_fired_and_cleared_in_one_window_still_files(db):
+    """The symptom cleared; the code defect did not."""
+    _alert(db, "2026-08-24T13:00:00+00:00", code="accounting_shortfall",
+           ticker="NVDA", text="NVDA: recorded 80, broker holds 40")
+    _alert(db, "2026-08-24T15:00:00+00:00", code="accounting_shortfall",
+           ticker="NVDA", clears=True, text="NVDA agrees again at 40")
+    filings, _ = _load().plan_filings(db, "2026-08-24", FakeTracker())
+    assert [f.action for f in filings] == ["create"]
+
+
+def test_the_audit_rollup_never_files(db):
+    _alert(db, "2026-08-24T13:38:01+00:00", code="audit_failed",
+           audit_report=True, text="audit 2026-08-24 FAILED: alert events raised: 2")
+    filings, _ = _load().plan_filings(db, "2026-08-24", FakeTracker())
+    assert filings == []
+
+
+def test_a_payload_with_no_code_is_reported_not_guessed(db):
+    _alert(db, "2026-08-24T13:00:00+00:00", text="something old and codeless")
+    _alert(db, "2026-08-24T13:01:00+00:00", code="pm_timeout", text="pm_timeout AAPL")
+    filings, malformed = _load().plan_filings(db, "2026-08-24", FakeTracker())
+    assert len(malformed) == 1 and "codeless" in malformed[0]
+    assert [f.action for f in filings] == ["create"]      # the rest still process
+
+
+def test_alerts_before_the_since_date_are_ignored(db):
+    _alert(db, "2026-08-20T13:00:00+00:00", code="pm_timeout", text="old")
+    filings, _ = _load().plan_filings(db, "2026-08-24", FakeTracker())
+    assert filings == []
+
+
+def test_a_changing_order_id_does_not_file_a_new_issue_each_day(db):
+    """ticket_open_after_exec embeds a fresh order id every run. Keyed on the
+    id it would file one issue per trading day, forever — the single worst
+    outcome available here."""
+    _alert(db, "2026-08-20T13:38:23+00:00", code="ticket_open_after_exec",
+           text="ticket c0a9ae97 open after exec turn — no order")
+    _alert(db, "2026-08-24T13:38:23+00:00", code="ticket_open_after_exec",
+           text="ticket 7f31b204 open after exec turn — no order")
+    filings, _ = _load().plan_filings(db, "2026-08-20", FakeTracker())
+    assert [f.action for f in filings] == ["create"]
+    assert filings[0].labels == ("alert:ticket_open_after_exec",)
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `.venv/bin/python3 -m pytest tests/test_file_alert_issues.py -v`
+Expected: FAIL — the script does not exist.
+
+- [ ] **Step 3: Write the module**
+
+```python
+#!/usr/bin/env python3
+"""File an unmatched alert as a GitHub issue (docs/agents/devops.md).
+
+Zero dependencies (stdlib only) and argv-driven, so it runs against a live or
+backed-up DB with nothing installed:
+
+    python3 scripts/file_alert_issues.py state/fund.sqlite --since 2026-08-21
+    python3 scripts/file_alert_issues.py state/fund.sqlite --since 2026-08-21 --apply
+
+DRY RUN IS THE DEFAULT. Filing is the only irreversible act here — an issue can
+be closed but not un-filed — so producing issues needs an explicit --apply.
+
+This is not a detector. It never decides whether a condition is true; it reads
+alerts the software already raised and asks the tracker what is already open.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))   # sibling audit_day
+import audit_day                                           # noqa: E402
+
+MAX_TITLE = 110
+
+
+@dataclass(frozen=True)
+class Filing:
+    action: str                  # "create" | "skip" | "comment"
+    labels: tuple[str, ...]
+    code: str
+    ticker: str | None
+    title: str
+    body: str
+    issue: int | None = None
+
+
+def _title(code: str, ticker: str | None, text: str) -> str:
+    head = f"{code}: " + (f"{ticker} — " if ticker else "")
+    room = MAX_TITLE - len(head)
+    return head + (text if len(text) <= room else text[:room - 1] + "…")
+
+
+def _body(code, ticker, occurrences, cleared, db_path) -> str:
+    lines = [f"Filed automatically from `{db_path}` by "
+             "`scripts/file_alert_issues.py`.", "",
+             f"- **code:** `{code}`"]
+    if ticker:
+        lines.append(f"- **ticker:** `{ticker}`")
+    lines += [f"- **occurrences in window:** {len(occurrences)}", ""]
+    if cleared:
+        lines += ["> A clearing alert arrived for this condition. The symptom"
+                  " resolved; whether the underlying defect is fixed is a"
+                  " human judgement.", ""]
+    lines.append("### Alert text seen")
+    for created_at, text in occurrences:
+        lines.append(f"- `{created_at}` — {text}")
+    return "\n".join(lines)
+
+
+def plan_filings(conn, since: str, tracker, db_path: str = "") -> tuple[list[Filing], list[str]]:
+    start, _ = audit_day.et_day_window(since)
+    rows = conn.execute(
+        "SELECT payload, created_at FROM events WHERE kind = 'alert'"
+        " AND created_at >= ? ORDER BY id", (start,)).fetchall()
+
+    groups: dict[tuple[str, ...], dict] = {}
+    malformed: list[str] = []
+    for row in rows:
+        try:
+            payload = json.loads(row["payload"])
+        except (ValueError, TypeError):
+            malformed.append(f"{row['created_at']}: unparseable payload")
+            continue
+        if payload.get(audit_day.SELF_ALERT_KEY):
+            continue                       # the rollup restates the others
+        code = payload.get("code")
+        if not code:
+            malformed.append(f"{row['created_at']}: no code — "
+                             f"{payload.get('text', '')[:80]}")
+            continue
+        ticker = payload.get("ticker")
+        labels = (f"alert:{code}",) + ((f"ticker:{ticker}",) if ticker else ())
+        group = groups.setdefault(labels, {"code": code, "ticker": ticker,
+                                           "occurrences": [], "cleared": False})
+        if payload.get("clears"):
+            group["cleared"] = True
+        else:
+            group["cleared"] = False       # a fresh firing reopens the finding
+            group["occurrences"].append((row["created_at"], payload.get("text", "")))
+
+    filings: list[Filing] = []
+    for labels, g in groups.items():
+        existing = tracker.open_issue(labels)
+        body = _body(g["code"], g["ticker"], g["occurrences"], g["cleared"], db_path)
+        if not g["occurrences"]:
+            # Nothing but clearing alerts. Comment if something is tracking
+            # it; never file an issue to announce that a problem went away.
+            if existing is not None:
+                filings.append(Filing("comment", labels, g["code"], g["ticker"],
+                                      "", body, existing))
+            continue
+        title = _title(g["code"], g["ticker"], g["occurrences"][0][1])
+        action = "skip" if existing is not None else "create"
+        filings.append(Filing(action, labels, g["code"], g["ticker"], title,
+                              body, existing))
+    return filings, malformed
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `.venv/bin/python3 -m pytest tests/test_file_alert_issues.py -v`
+Expected: PASS, all cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/file_alert_issues.py tests/test_file_alert_issues.py
+git commit -m "feat: one condition is one issue, however its wording changed"
+```
+
+---
+
+### Task 7: The `gh` tracker, and the `--apply` path
+
+**Files:**
+- Modify: `scripts/file_alert_issues.py`
+- Test: `tests/test_file_alert_issues.py`
+
+**Interfaces:**
+- Consumes: `Filing` and `plan_filings` from Task 6.
+- Produces: `GhTracker(repo: str, run=subprocess.run)` implementing `open_issue`, plus `ensure_label`, `create_issue`, `comment_issue`; and `main(argv) -> int`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_file_alert_issues.py`:
+
+```python
+class RecordingRun:
+    """Stands in for subprocess.run. Records argv, answers from a script."""
+    def __init__(self, replies=None):
+        self.calls, self.replies = [], replies or {}
+
+    def __call__(self, argv, **kw):
+        self.calls.append(argv)
+        key = " ".join(argv[:3])
+        out = self.replies.get(key, "[]")
+        class R: returncode, stdout, stderr = 0, out, ""
+        return R()
+
+
+def test_dry_run_performs_no_mutation(db, db_path, capsys):
+    """Seeded with an alert that WOULD file — otherwise 'no mutating calls'
+    passes vacuously and proves nothing."""
+    _alert(db, "2026-08-24T13:37:54+00:00", code="unprotected_position",
+           ticker="NVDA", text=NVDA_0824)
+    db.close()
+    run = RecordingRun()
+    rc = _load().main([str(db_path), "--since", "2026-08-24"], run=run)
+    assert rc == 0
+    assert "would file" in capsys.readouterr().out      # it had work to skip
+    mutating = [c for c in run.calls
+                if "create" in c or "comment" in c or "label" in c]
+    assert mutating == []          # asserted, not assumed
+
+
+def test_apply_creates_the_label_before_the_issue(db, db_path):
+    _alert(db, "2026-08-24T13:37:54+00:00", code="unprotected_position",
+           ticker="NVDA", text=NVDA_0824)
+    db.close()
+    mod = _load()
+    run = RecordingRun()
+    mod.main([str(db_path), "--since", "2026-08-24", "--apply"], run=run)
+    joined = [" ".join(c) for c in run.calls]
+    label_at = next(i for i, c in enumerate(joined) if "label create" in c)
+    issue_at = next(i for i, c in enumerate(joined) if "issue create" in c)
+    assert label_at < issue_at
+
+
+def test_gh_failure_is_reported_and_never_retried(db, db_path, capsys):
+    """A retry with a fresh id is how one condition becomes two issues."""
+    class FailingRun(RecordingRun):
+        def __call__(self, argv, **kw):
+            self.calls.append(argv)
+            class R:
+                returncode = 0 if "list" in argv else 1
+                stdout, stderr = "[]", "gh: HTTP 403"
+            return R()
+
+    _alert(db, "2026-08-24T13:37:54+00:00", code="unprotected_position",
+           ticker="NVDA", text=NVDA_0824)
+    db.close()
+    run = FailingRun()
+    rc = _load().main([str(db_path), "--since", "2026-08-24", "--apply"], run=run)
+    assert rc != 0
+    assert "FAILED" in capsys.readouterr().err
+    creates = [c for c in run.calls if "create" in c and "issue" in c]
+    assert len(creates) == 1          # reported once, never retried
+
+
+def test_an_unreadable_db_exits_non_zero_having_filed_nothing(tmp_path, capsys):
+    run = RecordingRun()
+    rc = _load().main([str(tmp_path / "nope.sqlite"), "--since", "2026-08-24",
+                       "--apply"], run=run)
+    assert rc != 0
+    assert run.calls == []
+```
+
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `.venv/bin/python3 -m pytest tests/test_file_alert_issues.py -k "dry_run or apply or gh_failure" -v`
+Expected: FAIL — `main` does not exist.
+
+- [ ] **Step 3: Implement `GhTracker` and `main`**
+
+Append to `scripts/file_alert_issues.py`. `run` is injected everywhere so the tests never touch the network:
+
+```python
+class GhTracker:
+    """The tracker, over the `gh` CLI (docs/agents/issue-tracker.md)."""
+
+    def __init__(self, repo: str, run=None):
+        import subprocess
+        self._run = run or subprocess.run
+        self.repo = repo
+
+    def _gh(self, *args: str) -> str:
+        r = self._run(["gh", *args, "--repo", self.repo],
+                      capture_output=True, text=True)
+        if r.returncode != 0:
+            raise RuntimeError(f"gh {' '.join(args)} failed: {r.stderr.strip()}")
+        return r.stdout
+
+    def open_issue(self, labels):
+        argv = ["issue", "list", "--state", "open", "--json", "number"]
+        for label in labels:
+            argv += ["--label", label]
+        found = json.loads(self._gh(*argv) or "[]")
+        return found[0]["number"] if found else None
+
+    def ensure_label(self, label: str) -> None:
+        self._gh("label", "create", label, "--force")
+
+    def create_issue(self, title, body, labels) -> None:
+        argv = ["issue", "create", "--title", title, "--body", body]
+        for label in labels:
+            argv += ["--label", label]
+        self._gh(*argv)
+
+    def comment_issue(self, number: int, body: str) -> None:
+        self._gh("issue", "comment", str(number), "--body", body)
+
+
+def main(argv: list[str] | None = None, run=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("db")
+    ap.add_argument("--since", required=True, help="ET calendar date YYYY-MM-DD")
+    ap.add_argument("--repo", default="benjaminematton/fund")
+    ap.add_argument("--apply", action="store_true",
+                    help="actually file; without it this is a dry run")
+    args = ap.parse_args(argv)
+
+    # sqlite3.connect CREATES a missing file rather than raising, so an
+    # unreadable DB surfaces as "no such table: events" on the first query,
+    # not on connect. Both are caught below and both file nothing.
+    conn = sqlite3.connect(args.db)
+    conn.row_factory = sqlite3.Row
+    tracker = GhTracker(args.repo, run=run)
+    try:
+        filings, malformed = plan_filings(conn, args.since, tracker, args.db)
+    except RuntimeError as e:
+        print(f"tracker unavailable: {e}", file=sys.stderr)
+        return 1
+    except sqlite3.Error as e:
+        print(f"cannot read {args.db}: {e}", file=sys.stderr)
+        return 1
+    finally:
+        conn.close()
+
+    for m in malformed:
+        print(f"MALFORMED (not filed): {m}", file=sys.stderr)
+
+    failed = 0
+    for f in filings:
+        if f.action == "skip":
+            print(f"already tracked as #{f.issue}: {' '.join(f.labels)}")
+            continue
+        verb = "filing" if args.apply else "would file"
+        if f.action == "comment":
+            print(f"{verb} a comment on #{f.issue}: cleared {f.code}")
+        else:
+            print(f"{verb}: {f.title}  [{' '.join(f.labels)}]")
+        if not args.apply:
+            continue
+        try:
+            if f.action == "comment":
+                tracker.comment_issue(f.issue, f.body)
+            else:
+                for label in f.labels:
+                    tracker.ensure_label(label)
+                tracker.create_issue(f.title, f.body, f.labels)
+        except RuntimeError as e:
+            # Reported, never retried: a retry with a fresh id is how you get
+            # two issues for one condition.
+            print(f"FAILED {f.action} for {' '.join(f.labels)}: {e}",
+                  file=sys.stderr)
+            failed += 1
+
+    if not filings and not malformed:
+        print(f"no alerts needing an issue since {args.since}")
+    return 1 if (failed or malformed) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `make test`
+Expected: all green, lint clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/file_alert_issues.py tests/test_file_alert_issues.py
+git commit -m "feat: an alert nobody tracked becomes an issue somebody can see"
+```
+
+---
+
+### Task 8: Verification against real data (spec §7)
+
+**Files:** none changed. This produces evidence, not code.
+
+- [ ] **Step 1: Dry run against a backup with known alerts**
+
+```bash
+.venv/bin/python3 scripts/file_alert_issues.py \
+    backups-from-vm/fund-2026-08-20.sqlite --since 2026-08-18
+```
+
+Expected: the 2026-08-18 `pm_timeout` trio resolves to **one** would-file line, the `analyst_turn_failed` / `pm_turn_failed` pair to `seat_turn_failed`, and the `audit 2026-08-18 FAILED` rollup appears **nowhere**. Rows predating the migration carry no `code` and must print as `MALFORMED (not filed)` — that is correct behaviour on historical data, not a bug.
+
+- [ ] **Step 2: Dry run against a copy of the droplet DB**
+
+Copy it down read-only first (production reads are unrestricted; **do not** run this against the droplet's live file):
+
+```bash
+scp root@138.197.47.97:/var/lib/fund/fund.sqlite /tmp/droplet-fund.sqlite
+.venv/bin/python3 scripts/file_alert_issues.py /tmp/droplet-fund.sqlite --since 2026-08-21
+```
+
+Expected: the NVDA condition present on **both** 08-21 and 08-24 resolves to a single would-file line. Same caveat on pre-migration rows.
+
+- [ ] **Step 3: Record the output in the PR body.** A green suite is not evidence the key survives real interpolated text; this output is.
+
+- [ ] **Step 4: Do not run `--apply` yet.** First real filing is Benjamin's call — it writes to the public tracker.
+
+---
+
+## Not in this plan
+
+- **`ops/fund-daily.service`'s heartbeat** (`ExecStopPost` carrying `${EXIT_STATUS}`). Separate branch: it lands by droplet deploy, not by merge, and `tests/test_ops_units.py` is where its test goes.
+- **`morning-standup` / `/eod-digest` reading these issues.** Downstream of this plan and specced in `docs/superpowers/specs/2026-08-21-day-bookends-design.md`.
+- **Backfilling codes onto historical alert rows.** They stay malformed-and-reported. Rewriting `events` history to make a report look tidy is not worth touching the source of truth for.

--- a/docs/superpowers/specs/2026-08-24-alert-issue-filer-design.md
+++ b/docs/superpowers/specs/2026-08-24-alert-issue-filer-design.md
@@ -118,8 +118,9 @@ any `append_event(...)` call anywhere passes the literal `"alert"` as its `kind`
 
 ### 3.3 The codes
 
-Twenty, across the 25 emission sites — five `reconcile.py` sites share one code. Most promote a
-token already sitting at the front of the text.
+**Twenty-one codes are minted across the 25 emission sites; twenty of them file.** Five
+`reconcile.py` sites share one code, and `audit_failed` is minted but never files (see below). Most
+promote a token already sitting at the front of the text.
 
 | Site (on `4685579`) | Code | `ticker` |
 |---|---|---|
@@ -190,10 +191,13 @@ same way `audit_day.py` does it, importing `audit_day` rather than duplicating t
 3. Build labels: `alert:<code>`, plus `ticker:<SYM>` when `ticker` is present.
 4. `gh issue list --state open --label …` for that exact label set (`--label` repeated per label;
    `gh` requires an issue to carry **all** of them to match).
-5. If `clears` is set: comment on the matching open issue if there is one; otherwise do nothing.
-   Never file an issue to announce that something resolved.
-6. If an open issue matches: do nothing.
-7. Otherwise ensure each label exists, then `gh issue create`.
+5. Alerts are grouped by their label tuple, and a clearing alert never contributes text. If the
+   group has **only** clearing alerts: comment on the matching open issue if there is one, otherwise
+   do nothing at all. Never file an issue to announce that something resolved.
+6. If the group has non-clearing text and an open issue matches: do nothing.
+7. Otherwise ensure each label exists, then `gh issue create`. **A condition that both fired and
+   cleared inside the window still files** — the symptom clearing is not the defect being fixed
+   (§3.5), and the body records that it later cleared.
 
 **Labels must be created, not assumed.** `gh issue create --label` errors on a label the repo does
 not have, and all 8 currently-open issues carry zero labels — there is no scheme to inherit.

--- a/docs/superpowers/specs/2026-08-24-alert-issue-filer-design.md
+++ b/docs/superpowers/specs/2026-08-24-alert-issue-filer-design.md
@@ -118,7 +118,7 @@ any `append_event(...)` call anywhere passes the literal `"alert"` as its `kind`
 
 ### 3.3 The codes
 
-**Twenty-one codes are minted across the 25 emission sites; twenty of them file.** Five
+**Twenty-two codes are minted across the 25 emission sites; twenty-one of them file.** Five
 `reconcile.py` sites share one code, and `audit_failed` is minted but never files (see below). Most
 promote a token already sitting at the front of the text.
 
@@ -128,7 +128,8 @@ promote a token already sitting at the front of the text.
 | `orchestrator/daily.py:216` | `pm_timeout` | no |
 | `orchestrator/daily.py:337` | `ticket_open_after_exec` | no |
 | `orchestrator/preconditions.py:56` | `account_precondition_drift` | no |
-| `orchestrator/protection.py:196` | `unprotected_position` | yes |
+| `orchestrator/protection.py:199` (no broker wired / positions unreadable / orders unreadable / re-read failed) | `protection_unverified` | no |
+| `orchestrator/protection.py:255` (per-position exposure) | `unprotected_position` | yes |
 | `orchestrator/protection.py:353` | `accounting_shortfall` | yes |
 | `orchestrator/protection.py:360` | `accounting_unverified` | no |
 | `orchestrator/reconcile.py:77` | `fill_on_unapproved_decision` | no |
@@ -157,10 +158,11 @@ promote a token already sitting at the front of the text.
 - A multi-ticker alert (`missing_price_history`, `unmapped_sector`) carries no `ticker`; its list
   is already in the existing `tickers` payload.
 
-Upper bound on simultaneously-open issues: 17 unkeyed codes, plus 3 ticker-keyed codes
-(`gate_error`, `unprotected_position`, `accounting_shortfall`) times a 3-name watchlist — **26**.
-Without the keying rules, `ticket_open_after_exec` alone would file one issue per trading day
-forever.
+Upper bound on simultaneously-open issues: 18 unkeyed codes (the split added `protection_unverified`,
+unkeyed by construction — no code path that mints it also knows which position, if any, is at
+fault), plus 3 ticker-keyed codes (`gate_error`, `unprotected_position`, `accounting_shortfall`)
+times a 3-name watchlist — **27**. Without the keying rules, `ticket_open_after_exec` alone would
+file one issue per trading day forever.
 
 **`audit_failed` (`run_day.py:428`) is deliberately absent and never files.** It is a rollup that
 restates the day's other alerts — filing it would double every issue. It already carries the

--- a/docs/superpowers/specs/2026-08-24-alert-issue-filer-design.md
+++ b/docs/superpowers/specs/2026-08-24-alert-issue-filer-design.md
@@ -1,0 +1,294 @@
+# Alert identity and the alert → issue filer
+
+Status: design, awaiting review (2026-08-24)
+
+Gives every alert a stable machine identity, then files an unmatched alert as a GitHub issue
+so it becomes work you can see the next morning.
+
+This is **devops tooling** (`docs/agents/devops.md`). It adds no stage, seat, table, MCP tool,
+charter or gate threshold, and it changes no trading behaviour: every production edit is at the
+alert-emission layer, and the filer runs outside the trading job entirely.
+
+---
+
+## 0. Why
+
+Detection already works. On 2026-08-21 an unprotected-position alert was raised at 13:38:02Z,
+projected to Slack the same second, and the run exited non-zero. It sat because **nothing turned
+it into a tracked item**. The same gap explains why #17, #18, #26 and #32 were each independently
+re-discovered by four different sessions that day.
+
+It is not hypothetical and it did not stop. The same condition fired again on **2026-08-24**
+(`events` id 65) and the run failed a second consecutive trading day.
+
+The broken link is the first arrow of the loop in `docs/agents/devops.md`:
+
+```
+alert fires  →  becomes a GitHub issue  →  standup shows it  →  work  →  closed
+```
+
+## 1. Why it cannot simply read the alerts that already exist
+
+The obvious implementation — read `events` where `kind='alert'`, call `gh issue create`, dedupe by
+label — has no field to key the label on. Every one of the ~25 emission sites writes
+`{"text": <interpolated free text>}` and nothing else identifying. Real rows:
+
+```
+"pm_timeout AAPL — defaulted to hold"            three alerts, one root cause,
+"pm_timeout MSFT — defaulted to hold"            one second apart      → 3 issues
+"pm_timeout NVDA — defaulted to hold"
+
+"ticket c0a9ae97 open after exec turn — no order"   id changes every run → 1 issue per run
+
+2026-08-21  "NVDA 80 was ticketed with a stop at 215.0 but the broker covers only 40 of 80 shares…"
+2026-08-24  "NVDA 40 was ticketed with a stop at 215.0 but the broker has NO live protective order…"
+                                                    same condition, text changed → 2 issues
+```
+
+Text-keyed dedupe files duplicates on day one. Deriving a key by parsing that text is forbidden
+outright by `CLAUDE.md`: *"Do not parse tickers, actions, or sizes out of free text anywhere."*
+
+So the identity has to be minted where the alert is raised. That is the whole reason this design
+is larger than "a small step in an existing path".
+
+### Prior art in this repo, which this design follows
+
+`orchestrator/protection.py::assert_positions_accounted` already solves the same problem one layer
+down. It keys a finding on `(symbol, recorded, held, cleared)`, stays silent while a finding is
+standing, and emits an explicit **clearing** alert when it resolves. This design generalises that
+shape rather than inventing one.
+
+It also proves the filer cannot lean on source-side suppression: `assert_positions_protected`, in
+the same module, has no such suppression and re-fires every run. **Some sites self-suppress and
+some do not**, so dedupe must live in the filer, keyed on identity, independent of the raiser.
+
+## 2. Non-goals
+
+- **Not a second detector.** It reads alerts the software already raised. It never decides whether
+  a condition is true. `docs/agents/devops.md`: *do not build a second checker that can disagree
+  with the first.*
+- **Not a severity system.** `events` has no severity and this does not add one. Every alert code
+  files. A filter here would be a second opinion about importance that can disagree with the code
+  that raised the alert. If a code proves noisy, the fix is to stop raising it.
+- **Not a cron job.** Attended, per `2026-08-21-day-bookends-design.md` §1. It also cannot run on
+  the droplet: `gh` is not installed there, and adding a network dependency to the trading path
+  would be wrong even if it were.
+- **Not an escalation channel.** Slack alerting already works and is untouched.
+- **Nothing in the fund's own loop.** No calibration, scoreboards, charters or strategy gates.
+
+## 3. Components
+
+| Artifact | Location | New? |
+|---|---|---|
+| `append_alert()` | `slackkit/outbox.py` | new, beside `append_event` |
+| alert codes | the ~25 emission sites | new argument at each |
+| direct-`append_event`-alert lint | `scripts/check_alert_codes.py`, run in `make test` | new |
+| the filer | `scripts/file_alert_issues.py` | new |
+
+### 3.1 `append_alert` — identity at the raise site
+
+```python
+def append_alert(conn, code: str, text: str, *, ticker: str | None = None,
+                 clears: bool = False, now_iso: str, **payload) -> int:
+```
+
+Writes an ordinary `kind='alert'` event whose payload carries `code`, optionally `ticker`,
+optionally `clears`, plus whatever structured payload the site already passed. `code` is a
+required positional: a site physically cannot emit an alert without one.
+
+Three sites already ship structured payloads (`tickers`, `drift`, `accounting`) and keep them
+unchanged — `**payload` passes them through.
+
+It lands beside `append_event` in `slackkit/outbox.py`, which every emission site already imports,
+so no new dependency edge is created and `scripts/check_purity.py` is unaffected.
+
+`scripts/run_day.py`'s existing private `_alert` helper is absorbed into it rather than left as a
+second way to do the same thing.
+
+### 3.2 The lint — why convention is not enough
+
+A `code` argument that sites are merely *expected* to pass is a convention, and site 26 forgets it.
+The alert would still fire, still reach Slack, and be silently invisible to the filer forever — a
+signal that changes meaning without changing appearance, the failure shape this repo has been bitten
+by repeatedly.
+
+`scripts/check_alert_codes.py` is an AST lint in the style of `scripts/check_purity.py`: it fails if
+any `append_event(...)` call anywhere passes the literal `"alert"` as its `kind`. It runs in
+`make test`, so the invariant is tested rather than remembered.
+
+### 3.3 The codes
+
+Twenty, across the 25 emission sites — five `reconcile.py` sites share one code. Most promote a
+token already sitting at the front of the text.
+
+| Site (on `4685579`) | Code | `ticker` |
+|---|---|---|
+| `orchestrator/daily.py:139` | `gate_error` | yes |
+| `orchestrator/daily.py:216` | `pm_timeout` | no |
+| `orchestrator/daily.py:337` | `ticket_open_after_exec` | no |
+| `orchestrator/preconditions.py:56` | `account_precondition_drift` | no |
+| `orchestrator/protection.py:196` | `unprotected_position` | yes |
+| `orchestrator/protection.py:353` | `accounting_shortfall` | yes |
+| `orchestrator/protection.py:360` | `accounting_unverified` | no |
+| `orchestrator/reconcile.py:77` | `fill_on_unapproved_decision` | no |
+| `orchestrator/reconcile.py:90` | `partial_fill_manual_review` | no |
+| `orchestrator/reconcile.py:149,156,161,169,176` | `order_unreconciled` | no |
+| `orchestrator/reconcile.py:193` | `order_unfilled_at_cap` | no |
+| `orchestrator/reconcile.py:207` | `order_partial_then_dead` | no |
+| `orchestrator/reconcile.py:268` | `order_unresolved_at_cap` | no |
+| `scripts/run_day.py:282` | `seat_turn_failed` | no |
+| `scripts/run_day.py:297` | `exec_turn_violation` | no |
+| `scripts/run_day.py:366` | `missing_price_history` | no |
+| `scripts/run_day.py:383` | `unmapped_sector` | no |
+| `scripts/run_day.py:458` | `run_day_failed` | no |
+| `agents/runtime.py:114` | `order_gate_denied` | no |
+| `agents/runtime.py:387` | `cost_unavailable` | no |
+
+**Keying rules, which are what keep the issue count bounded:**
+
+- `ticker` is a ticker symbol or absent. **Never** an order id, quantity, seat, timestamp or
+  exception type. Those are unbounded and would file an issue per run.
+- `ticker` is set only where the condition is genuinely per-position — where fixing NVDA does not
+  fix MSFT. `pm_timeout` fires per ticker but has one root cause (the PM did not answer), so it
+  carries no ticker and files one issue, not three.
+- The five `reconcile.py` sites sharing one `stale.format(...)` template share one code. The five
+  distinct reasons stay in the text, where a human reads them.
+- A multi-ticker alert (`missing_price_history`, `unmapped_sector`) carries no `ticker`; its list
+  is already in the existing `tickers` payload.
+
+Upper bound on simultaneously-open issues: 17 unkeyed codes, plus 3 ticker-keyed codes
+(`gate_error`, `unprotected_position`, `accounting_shortfall`) times a 3-name watchlist — **26**.
+Without the keying rules, `ticket_open_after_exec` alone would file one issue per trading day
+forever.
+
+**`audit_failed` (`run_day.py:428`) is deliberately absent and never files.** It is a rollup that
+restates the day's other alerts — filing it would double every issue. It already carries the
+`audit_report` marker that `scripts/audit_day.py` uses to avoid poisoning itself; the filer imports
+`audit_day.SELF_ALERT_KEY` and skips on the same marker rather than inventing a second one.
+
+### 3.4 `scripts/file_alert_issues.py`
+
+Follows `scripts/audit_day.py`'s precedent exactly: stdlib only, argv-driven, so it runs against a
+live or backed-up DB with nothing installed.
+
+```
+python3 scripts/file_alert_issues.py <db> --since YYYY-MM-DD          # dry run: prints what it would file
+python3 scripts/file_alert_issues.py <db> --since YYYY-MM-DD --apply  # files
+```
+
+**Dry run is the default.** Filing is the only irreversible act here — an issue can be closed but
+not un-filed — so producing issues requires an explicit `--apply`.
+
+**It scans a date range, not a day.** Run on Monday it backfills Friday. Missing a day delays the
+issue; it never loses it. `--since` is an ET calendar date resolved against `events.created_at` the
+same way `audit_day.py` does it, importing `audit_day` rather than duplicating the window helper.
+
+**Per alert, in order:**
+
+1. Skip if the payload carries `audit_day.SELF_ALERT_KEY`.
+2. Report and skip if the payload has no `code` (a malformed row is surfaced, never guessed at).
+3. Build labels: `alert:<code>`, plus `ticker:<SYM>` when `ticker` is present.
+4. `gh issue list --state open --label …` for that exact label set (`--label` repeated per label;
+   `gh` requires an issue to carry **all** of them to match).
+5. If `clears` is set: comment on the matching open issue if there is one; otherwise do nothing.
+   Never file an issue to announce that something resolved.
+6. If an open issue matches: do nothing.
+7. Otherwise ensure each label exists, then `gh issue create`.
+
+**Labels must be created, not assumed.** `gh issue create --label` errors on a label the repo does
+not have, and all 8 currently-open issues carry zero labels — there is no scheme to inherit.
+
+**Only open issues are matched.** A condition that recurs after its issue was closed files a fresh
+one, carrying none of the closed issue's history. That is intended, and it mirrors the
+clear-and-recur semantics `assert_positions_accounted` already has.
+
+**Issue body** carries the code, the ticker if any, every distinct alert text seen in the window
+with its `created_at`, the occurrence count, and which DB file it was read from. The title is the
+first alert text, truncated.
+
+**The `gh` invocation is injected**, in the same spirit as the `Clock` protocol, so tests exercise
+the whole path against a fake with no network and no tracker writes.
+
+### 3.5 Closing is a human act
+
+The filer **never closes an issue.** A clearing alert adds a comment and nothing more.
+
+The reason is the field brief's symptom/cause distinction. If a stop is placed on NVDA by hand, the
+`unprotected_position` symptom clears — but *"no code path will protect it"* is still true and still
+needs work. Auto-closing on the clearing alert would erase precisely the tracked item this design
+exists to create, and the recurrence next week would arrive with no history.
+
+## 4. Data flow
+
+```
+raise site ──append_alert(code, text, ticker=…)──> events row (payload carries code)
+                                                          │
+                                                          │  read, attended
+                                                          ▼
+                                        scripts/file_alert_issues.py --since
+                                                          │
+                              ┌───────────────────────────┼──────────────────────┐
+                       clears=True                  open issue exists        neither
+                              │                            │                     │
+                          comment                     do nothing          gh issue create
+                                                                        (labels ensured first)
+```
+
+## 5. Error handling
+
+Default is **report, never act** — the tooling twin of invariant 4.
+
+| Failure | Behaviour |
+|---|---|
+| `gh` missing or unauthenticated | render as a finding, exit non-zero, file nothing |
+| `gh issue list` fails for one alert | that alert is reported unfiled; the remaining alerts still process |
+| `gh issue create` fails | reported; no retry, no second attempt at a new id |
+| alert payload has no `code` | reported as malformed; never guessed at from text |
+| DB unreadable | exit non-zero having filed nothing |
+| no alerts in the window | print so, exit 0 |
+
+Dry run exits 0 whether or not it found work; only errors are non-zero.
+
+**Accepted limitation:** two concurrent `--apply` runs could both pass the `gh issue list` check and
+double-file. The tool is attended and single-operator, so this is accepted rather than locked
+against.
+
+## 6. Testing
+
+Runs in `make test` — offline, no network, no keys, `gh` faked throughout.
+
+**Every check's negative control must fail.** This repo has three documented instances of a test
+whose negative control also passed, two caught by luck.
+
+Required cases:
+
+- The two real NVDA texts from 2026-08-21 and 2026-08-24, verbatim, file **one** issue. Negative
+  control: with dedupe disabled they file two.
+- `pm_timeout` on three tickers files one issue.
+- `ticket_open_after_exec` with a different order id on two days files one issue.
+- An alert whose labels match an open issue files nothing.
+- An alert whose labels match a **closed** issue files a new one.
+- `clears=True` with a matching open issue comments and does not close; with no matching issue it
+  does nothing at all.
+- An `audit_report`-marked alert never files.
+- A payload with no `code` is reported, and does not abort the remaining alerts.
+- Dry run performs no `gh` mutation whatsoever — asserted against the fake, not assumed.
+- A label that does not exist is created before the issue that needs it.
+- The lint fails on a planted `append_event(conn, "alert", …)` call and passes on the real tree.
+
+## 7. Verification beyond the suite
+
+A green suite cannot show the dedupe key survives real interpolated text, so completion requires a
+dry run against `backups-from-vm/fund-2026-08-20.sqlite` and a copy of the droplet DB, printing the
+exact issues it would file — showing the NVDA condition present on both 08-21 and 08-24 resolving to
+one issue.
+
+## 8. Out of scope, recorded because they were found
+
+- **`ops/fund-daily.service`'s heartbeat pings only on success**, so watchdog silence cannot
+  distinguish a dead box from a failed run. Fix agreed separately (`ExecStopPost` carrying
+  `${EXIT_STATUS}`); it ships on its own branch because it lands by droplet deploy, not by merge.
+- **The droplet is 25 commits behind `origin/master`** and has never run PR #31's account-precondition
+  drift check.
+- **NVDA holds 40 shares with no protective order** going into 2026-08-25's open. Benjamin's
+  decision alone; recorded here, not acted on.

--- a/docs/superpowers/specs/2026-08-24-alert-issue-filer-design.md
+++ b/docs/superpowers/specs/2026-08-24-alert-issue-filer-design.md
@@ -118,9 +118,12 @@ any `append_event(...)` call anywhere passes the literal `"alert"` as its `kind`
 
 ### 3.3 The codes
 
-**Twenty-two codes are minted across the 25 emission sites; twenty-one of them file.** Five
+**Twenty-two codes are minted across the 26 emission sites; twenty-one of them file.** Five
 `reconcile.py` sites share one code, and `audit_failed` is minted but never files (see below). Most
 promote a token already sitting at the front of the text.
+
+Line numbers below are the sites as they stood on `4685579`, before the `protection_unverified`
+split added a closure; read the parenthetical, not the number, to identify a row.
 
 | Site (on `4685579`) | Code | `ticker` |
 |---|---|---|

--- a/orchestrator/daily.py
+++ b/orchestrator/daily.py
@@ -23,7 +23,7 @@ from orchestrator.clock import Clock, et_hhmm, iso
 from orchestrator.protection import (assert_positions_accounted,
                                      assert_positions_protected)
 from orchestrator.reconcile import reconcile_orders
-from slackkit.outbox import append_event, drain
+from slackkit.outbox import append_alert, append_event, drain
 from state.critiques import insert_default_critiques
 from state.journal import append_entry
 from state.transition import try_transition
@@ -136,9 +136,10 @@ def _pre_gate_stage(ctx: StageCtx) -> list[str]:
         elif all(isinstance(r, Rejected) and r.reason == "gate_error" for r in results):
             if now is None:
                 now = iso(ctx.clock.now())
-            append_event(ctx.conn, "alert",
-                         {"text": f"gate_error {ticker} — dropped from"
-                                  " today's universe (malformed feed)"}, now)
+            append_alert(ctx.conn, "gate_error",
+                         f"gate_error {ticker} — dropped from"
+                         " today's universe (malformed feed)",
+                         now_iso=now, ticker=ticker)
     return active
 
 
@@ -213,8 +214,8 @@ def run_decision(ctx: StageCtx, active: list[str]) -> None:
         # skipped forever. Committing the alert first means the only
         # crash window left re-runs both (a harmless duplicate alert),
         # never loses the alert outright.
-        append_event(ctx.conn, "alert",
-                     {"text": f"pm_timeout {ticker} — defaulted to hold"}, now)
+        append_alert(ctx.conn, "pm_timeout",
+                     f"pm_timeout {ticker} — defaulted to hold", now_iso=now)
         ctx.conn.execute(
             # 'none' for the same reason as the defaulted signal above: a
             # pm_timeout hold is the orchestrator recording silence, not a
@@ -334,9 +335,9 @@ def _alert_unexecuted_tickets(ctx: StageCtx) -> None:
             "SELECT 1 FROM orders WHERE client_order_id = ?",
             (ticket["id"],)).fetchone()
         if placed is None:
-            append_event(ctx.conn, "alert",
-                         {"text": f"ticket {ticket['id'][:8]} open after exec"
-                                  " turn — no order"}, now)
+            append_alert(ctx.conn, "ticket_open_after_exec",
+                         f"ticket {ticket['id'][:8]} open after exec"
+                         " turn — no order", now_iso=now)
 
 
 def run_execution(ctx: StageCtx, run_trader_turn: Callable[[], None] | None) -> str:

--- a/orchestrator/preconditions.py
+++ b/orchestrator/preconditions.py
@@ -40,7 +40,7 @@ from __future__ import annotations
 
 import sqlite3
 
-from slackkit.outbox import append_event
+from slackkit.outbox import append_alert
 
 
 def assert_account_config_unchanged(conn: sqlite3.Connection, *, broker,
@@ -53,7 +53,8 @@ def assert_account_config_unchanged(conn: sqlite3.Connection, *, broker,
     to refuse to trade."""
 
     def alert(text: str, drift: dict) -> int:
-        append_event(conn, "alert", {"text": text, "drift": drift}, now_iso)
+        append_alert(conn, "account_precondition_drift", text,
+                     now_iso=now_iso, drift=drift)
         return 1
 
     if not baseline:

--- a/orchestrator/protection.py
+++ b/orchestrator/protection.py
@@ -196,9 +196,21 @@ def assert_positions_protected(conn: sqlite3.Connection, *, broker,
     failure it is built to prevent."""
     nap = sleep or (lambda _s: None)
 
-    def alert(text: str, ticker: str | None = None) -> None:
+    def alert(text: str, ticker: str) -> None:
         append_alert(conn, "unprotected_position", text,
                      now_iso=now_iso, ticker=ticker)
+
+    def unverified(text: str) -> int:
+        # Distinct from `alert()`'s code on purpose (F1): this fires with no
+        # ticker, and `gh issue list --label` matches on has-label, not
+        # has-exact-label-set — so under one shared code, an open
+        # ticker-keyed `unprotected_position` issue for some symbol would
+        # silently satisfy the lookup for THIS unrelated, unkeyed finding.
+        # An unverifiable broker state must never hide behind a known
+        # per-position exposure. Mirrors accounting_shortfall/
+        # accounting_unverified below.
+        append_alert(conn, "protection_unverified", text, now_iso=now_iso)
+        return 1
 
     def why(e: Exception) -> str:
         # The type alone ("ConnectionError") is not actionable at 16:05 on a
@@ -209,16 +221,16 @@ def assert_positions_protected(conn: sqlite3.Connection, *, broker,
         return list(broker.open_orders())
 
     if broker is None:
-        alert("position protection UNVERIFIED — no broker wired into the run;"
-              " a held position could be unprotected and nothing would say so")
-        return 1
+        return unverified(
+            "position protection UNVERIFIED — no broker wired into the run;"
+            " a held position could be unprotected and nothing would say so")
     try:
         positions = list(broker.open_positions())
     except Exception as e:
-        alert("position protection UNVERIFIED — could not read positions"
-              f" ({why(e)}); a held position could be unprotected and nothing"
-              " would say so")
-        return 1
+        return unverified(
+            "position protection UNVERIFIED — could not read positions"
+            f" ({why(e)}); a held position could be unprotected and nothing"
+            " would say so")
     if not positions:
         return 0
 
@@ -230,8 +242,7 @@ def assert_positions_protected(conn: sqlite3.Connection, *, broker,
     try:
         problems = _evaluate(conn, positions, read_orders())
     except Exception as e:
-        alert(unread("read", e))
-        return 1
+        return unverified(unread("read", e))
     if problems:
         # An OTO stop leg is created 'held' and can lag its parent in the API
         # by moments — and this runs immediately after reconciliation, which
@@ -250,8 +261,7 @@ def assert_positions_protected(conn: sqlite3.Connection, *, broker,
                 return 0
             problems = _evaluate(conn, positions, read_orders())
         except Exception as e:
-            alert(unread("re-read", e))
-            return 1
+            return unverified(unread("re-read", e))
     for symbol, text in problems:
         alert(text, ticker=symbol)
     return len(problems)

--- a/orchestrator/protection.py
+++ b/orchestrator/protection.py
@@ -27,7 +27,7 @@ import json
 import sqlite3
 from typing import Callable
 
-from slackkit.outbox import append_event
+from slackkit.outbox import append_alert
 
 # One short wait before calling a position naked. Matches reconcile_orders'
 # poll_s default. Deliberately NOT max_wait_s (90s): this sits on the critical
@@ -130,11 +130,14 @@ def _promised_stop(conn: sqlite3.Connection, symbol: str) -> float | None | obje
 
 
 def _evaluate(conn: sqlite3.Connection, positions: list,
-              orders: list) -> list[str]:
-    """Alert texts for ONE snapshot of the account. Reads only; appends
-    nothing, so the caller can evaluate a snapshot, wait, and evaluate a
-    fresher one without having written anything it must retract."""
-    out: list[str] = []
+              orders: list) -> list[tuple[str, str]]:
+    """(symbol, alert text) pairs for ONE snapshot of the account. Reads
+    only; appends nothing, so the caller can evaluate a snapshot, wait, and
+    evaluate a fresher one without having written anything it must retract.
+    The symbol travels alongside the text so the caller can key the alert's
+    `ticker` on the actual position, rather than re-parsing it back out of
+    prose."""
+    out: list[tuple[str, str]] = []
     for raw in positions:
         p = raw if isinstance(raw, dict) else {}
         symbol = str(p.get("symbol") or "?")
@@ -142,33 +145,34 @@ def _evaluate(conn: sqlite3.Connection, positions: list,
         held = _qty(p.get("qty"))
         closing_side = _CLOSING_SIDE.get(side)
         if held is None or closing_side is None:
-            out.append(f"{symbol} position UNVERIFIED — cannot read"
+            out.append((symbol, f"{symbol} position UNVERIFIED — cannot read"
                        f" side={p.get('side')!r} qty={p.get('qty')!r}, so"
-                       " whether it is protected is unknown")
+                       " whether it is protected is unknown"))
             continue
         covered = _covering_qty(orders, symbol, closing_side)
         if covered is None:
-            out.append(f"{symbol} {held} UNVERIFIED — a live order for it"
-                       " could not be read, so its cover cannot be confirmed")
+            out.append((symbol, f"{symbol} {held} UNVERIFIED — a live order"
+                       " for it could not be read, so its cover cannot be"
+                       " confirmed"))
             continue
         if covered >= held:
             continue
         promised = _promised_stop(conn, symbol)
         if promised is _UNKNOWN:
-            out.append(f"{symbol} {held} is held with NO live protective order"
-                       " and no fund record of opening it — provenance"
-                       " unknown, so whether it should be protected cannot be"
-                       " established")
+            out.append((symbol, f"{symbol} {held} is held with NO live"
+                       " protective order and no fund record of opening"
+                       " it — provenance unknown, so whether it should be"
+                       " protected cannot be established"))
         elif promised is not None:
             # "NO live protective order (30 of 80 stopped)" contradicts
             # itself. Say which of the two situations this actually is.
             shortfall = ("the broker has NO live protective order" if not covered
                          else f"the broker covers only {covered} of {held}"
                               " shares")
-            out.append(f"{symbol} {held} was ticketed with a stop at"
+            out.append((symbol, f"{symbol} {held} was ticketed with a stop at"
                        f" {promised} but {shortfall} — the position is exposed"
                        " and no code path will protect it; place or restore a"
-                       " stop manually")
+                       " stop manually"))
         # promised is None: the PM opened this without a stop on purpose
         # (charters/pm.md:25). Standing exposure, not a fault — reported in
         # the EOD digest, not as an alert.
@@ -192,8 +196,9 @@ def assert_positions_protected(conn: sqlite3.Connection, *, broker,
     failure it is built to prevent."""
     nap = sleep or (lambda _s: None)
 
-    def alert(text: str) -> None:
-        append_event(conn, "alert", {"text": text}, now_iso)
+    def alert(text: str, ticker: str | None = None) -> None:
+        append_alert(conn, "unprotected_position", text,
+                     now_iso=now_iso, ticker=ticker)
 
     def why(e: Exception) -> str:
         # The type alone ("ConnectionError") is not actionable at 16:05 on a
@@ -247,8 +252,8 @@ def assert_positions_protected(conn: sqlite3.Connection, *, broker,
         except Exception as e:
             alert(unread("re-read", e))
             return 1
-    for text in problems:
-        alert(text)
+    for symbol, text in problems:
+        alert(text, ticker=symbol)
     return len(problems)
 
 
@@ -350,14 +355,16 @@ def assert_positions_accounted(conn: sqlite3.Connection, *, broker,
     nap = sleep or (lambda _s: None)
 
     def alert(text: str, accounting: dict) -> None:
-        append_event(conn, "alert",
-                     {"text": text, "accounting": accounting}, now_iso)
+        append_alert(conn, "accounting_shortfall", text, now_iso=now_iso,
+                     ticker=accounting["symbol"],
+                     clears=bool(accounting.get("cleared")),
+                     accounting=accounting)
 
     def why(e: Exception) -> str:
         return f"{type(e).__name__}: {str(e)[:120]}"
 
     def unverified(text: str) -> int:
-        append_event(conn, "alert", {"text": text}, now_iso)
+        append_alert(conn, "accounting_unverified", text, now_iso=now_iso)
         return 1
 
     recorded = {s: q for s, q in _recorded_holdings(conn).items() if q > 0}

--- a/orchestrator/reconcile.py
+++ b/orchestrator/reconcile.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import sqlite3
 from typing import Callable
 from orchestrator.clock import Clock, iso
-from slackkit.outbox import append_event
+from slackkit.outbox import append_alert, append_event
 from state.transition import EDGES, try_transition
 
 def _statuses(conn):
@@ -74,10 +74,11 @@ def _apply(conn, row, o, now) -> bool:
                     dec = conn.execute("SELECT status FROM decisions WHERE id=?",
                                        (t["decision_id"],)).fetchone()
                     dec_status = dec["status"] if dec is not None else "missing"
-                    append_event(conn, "alert", {"text":
+                    append_alert(conn, "fill_on_unapproved_decision",
                         f"order {coid[:8]} filled but decision "
                         f"{t['decision_id']} was '{dec_status}', not "
-                        "'approved' — left as-is, manual review"}, now)
+                        "'approved' — left as-is, manual review",
+                        now_iso=now)
         return moved
     if st == "partially_filled":
         filled_qty, filled_avg_price = _parse_fill(o)
@@ -87,8 +88,9 @@ def _apply(conn, row, o, now) -> bool:
         conn.commit()
         if try_transition(conn, "orders", {"client_order_id": coid},
                           "submitted", "partially_filled", now):
-            append_event(conn, "alert", {"text":
-                f"partial fill {row['symbol']} {coid[:8]} — manual review"}, now)
+            append_alert(conn, "partial_fill_manual_review",
+                f"partial fill {row['symbol']} {coid[:8]} — manual review",
+                now_iso=now)
         return False
     return False
 
@@ -146,36 +148,36 @@ def _timeout_close(conn, row, broker, now, max_wait_s) -> bool:
             raise ValueError("broker returned no order for this client_order_id")
         status = o.get("status")
     except Exception as e:
-        append_event(conn, "alert", {"text": stale.format(
-            why=f"re-query raised {type(e).__name__}{cancel_err}")}, now)
+        append_alert(conn, "order_unreconciled", stale.format(
+            why=f"re-query raised {type(e).__name__}{cancel_err}"), now_iso=now)
         return False
     if status in ("filled", "partially_filled"):
         try:
             return _apply(conn, row, o, now)      # the race: record the fill
         except Exception as e:
-            append_event(conn, "alert", {"text": stale.format(
+            append_alert(conn, "order_unreconciled", stale.format(
                 why=f"broker reports '{status}' but the payload is "
-                    f"unparseable ({type(e).__name__})")}, now)
+                    f"unparseable ({type(e).__name__})"), now_iso=now)
             return False
     if status not in _CONFIRMED_DEAD:
-        append_event(conn, "alert", {"text": stale.format(
-            why=f"broker still reports '{status}'{cancel_err}")}, now)
+        append_alert(conn, "order_unreconciled", stale.format(
+            why=f"broker still reports '{status}'{cancel_err}"), now_iso=now)
         return False
     dead = _CONFIRMED_DEAD[status]
     cur = conn.execute("SELECT status, qty FROM orders WHERE client_order_id=?",
                        (coid,)).fetchone()
     from_status = cur["status"] if cur is not None else "submitted"
     if (from_status, dead) not in EDGES["orders"]:
-        append_event(conn, "alert", {"text": stale.format(
+        append_alert(conn, "order_unreconciled", stale.format(
             why=f"broker reports '{status}' but the order is '{from_status}'"
-                " — no legal transition")}, now)
+                " — no legal transition"), now_iso=now)
         return False
     try:
         fill = _dead_fill(o)
     except Exception as e:
-        append_event(conn, "alert", {"text": stale.format(
+        append_alert(conn, "order_unreconciled", stale.format(
             why=f"broker reports '{status}' but the fill numbers are "
-                f"unparseable ({type(e).__name__})")}, now)
+                f"unparseable ({type(e).__name__})"), now_iso=now)
         return False
     if fill is not None:                 # shares really changed hands
         conn.execute("UPDATE orders SET filled_qty=?, filled_avg_price=?,"
@@ -190,10 +192,11 @@ def _timeout_close(conn, row, broker, now, max_wait_s) -> bool:
             moved = t is not None and try_transition(
                 conn, "decisions", {"id": t["decision_id"]},
                 "approved", "failed", now)
-            append_event(conn, "alert", {"text":
+            append_alert(conn, "order_unfilled_at_cap",
                 f"order {coid[:8]} unfilled after {int(max_wait_s)}s — "
                 f"{dead} at the broker, "
-                f"{'decision failed' if moved else 'decision unchanged'}"}, now)
+                f"{'decision failed' if moved else 'decision unchanged'}",
+                now_iso=now)
         else:                            # a real position exists: executed
             filled_qty, filled_avg_price = fill
             append_event(conn, "fill", {
@@ -204,11 +207,11 @@ def _timeout_close(conn, row, broker, now, max_wait_s) -> bool:
             moved = t is not None and try_transition(
                 conn, "decisions", {"id": t["decision_id"]},
                 "approved", "executed", now)
-            append_event(conn, "alert", {"text":
+            append_alert(conn, "order_partial_then_dead",
                 f"order {coid[:8]} partial {filled_qty} of {cur['qty']} then "
                 f"{dead} at the broker after {int(max_wait_s)}s, "
-                f"{'decision executed' if moved else 'decision unchanged'}"},
-                now)
+                f"{'decision executed' if moved else 'decision unchanged'}",
+                now_iso=now)
     return False
 
 
@@ -265,7 +268,8 @@ def reconcile_orders(conn: sqlite3.Connection, *, clock: Clock, broker,
         cur = conn.execute("SELECT status FROM orders WHERE client_order_id=?",
                            (coid,)).fetchone()
         cur_status = cur["status"] if cur is not None else "submitted"
-        append_event(conn, "alert", {"text":
+        append_alert(conn, "order_unresolved_at_cap",
             f"order {coid[:8]} unresolved — broker unreachable or response "
-            f"unparseable ({reason}) at cap, left {cur_status} for retry"}, now)
+            f"unparseable ({reason}) at cap, left {cur_status} for retry",
+            now_iso=now)
     return filled

--- a/scripts/check_alert_codes.py
+++ b/scripts/check_alert_codes.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Alert-code lint (CI-enforced; see docs/agents/devops.md).
+
+Every kind='alert' row must carry a stable `code`, because that code is what
+scripts/file_alert_issues.py keys a GitHub issue on. A site that forgets one
+still alerts and still reaches Slack, and is silently invisible to the filer
+forever — absence reading as health, the failure shape this repo keeps hitting.
+
+Two checks:
+  1. No append_event(..., 'alert', ...) anywhere. Use append_alert().
+  2. Every alert-raising call passes a string-literal code matching
+     ^[a-z][a-z0-9_]*$. An f-string code is unbounded and would file an issue
+     per run.
+
+Zero dependencies. Exit 1 on any violation.
+
+**The pass-through rule.** scripts/run_day.py keeps a thin `_alert(conn, clock,
+code, text, **payload)` wrapper that logs and delegates, so its one
+`append_alert(conn, code, ...)` call forwards a *variable* by construction.
+Rather than exempt that file, the rule is general: a call sitting inside a
+function that declares its own `code` parameter is a forwarder and is skipped
+— and `_alert` itself is checked as an alert raiser, so its five call sites
+still owe a literal. Known edge, documented rather than hidden: a NEW wrapper
+named something else would have its own callers unchecked until its name is
+added to ALERT_FUNCS.
+"""
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGES = ["orchestrator", "agents", "scripts", "slackkit", "gate", "state",
+            "market", "evals"]
+CODE_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+ALERT_FUNCS = ("append_alert", "_alert")
+
+
+def _callee(node: ast.Call) -> str | None:
+    fn = node.func
+    if isinstance(fn, ast.Attribute):
+        return fn.attr
+    return getattr(fn, "id", None)
+
+
+def _forwarded_calls(tree: ast.AST) -> set[int]:
+    """Calls inside a function that declares its own `code` parameter."""
+    forwarded: set[int] = set()
+    for fn in ast.walk(tree):
+        if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        params = [a.arg for a in fn.args.args + fn.args.kwonlyargs]
+        if "code" not in params:
+            continue
+        for inner in ast.walk(fn):
+            if isinstance(inner, ast.Call):
+                forwarded.add(id(inner))
+    return forwarded
+
+
+def check_file(path: Path) -> list[str]:
+    errors: list[str] = []
+    tree = ast.parse(path.read_text(), filename=str(path))
+    forwarded = _forwarded_calls(tree)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        name = _callee(node)
+        if name == "append_event":
+            kind = node.args[1] if len(node.args) > 1 else None
+            if isinstance(kind, ast.Constant) and kind.value == "alert":
+                errors.append(
+                    f"{path}:{node.lineno}: append_event(..., 'alert', ...) —"
+                    " use append_alert() so the alert carries a code")
+        elif name in ALERT_FUNCS:
+            if id(node) in forwarded:
+                continue                   # a wrapper forwarding its own code
+            # append_alert(conn, code, text, ...)  -> args[1]
+            # _alert(conn, clock, code, text, ...) -> args[2]
+            pos = 1 if name == "append_alert" else 2
+            code = node.args[pos] if len(node.args) > pos else None
+            if not isinstance(code, ast.Constant) or not isinstance(code.value, str):
+                errors.append(
+                    f"{path}:{node.lineno}: {name} code must be a string"
+                    " literal, not an expression — a dynamic code files an"
+                    " issue per run")
+            elif not CODE_RE.match(code.value):
+                errors.append(
+                    f"{path}:{node.lineno}: alert code {code.value!r} is not a"
+                    " bare lower_snake identifier")
+    return errors
+
+
+def main() -> int:
+    errors: list[str] = []
+    checked = 0
+    for package in PACKAGES:
+        root = ROOT / package
+        if not root.exists():
+            continue
+        for path in sorted(root.rglob("*.py")):
+            if "__pycache__" in path.parts:
+                continue
+            checked += 1
+            errors.extend(check_file(path))
+    for e in errors:
+        print(e, file=sys.stderr)
+    if errors:
+        print(f"ALERT CODE LINT: {len(errors)} violation(s)", file=sys.stderr)
+        return 1
+    print(f"ALERT CODE LINT: clean ({checked} files across {len(PACKAGES)} packages)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_alert_codes.py
+++ b/scripts/check_alert_codes.py
@@ -17,12 +17,19 @@ Zero dependencies. Exit 1 on any violation.
 **The pass-through rule.** scripts/run_day.py keeps a thin `_alert(conn, clock,
 code, text, **payload)` wrapper that logs and delegates, so its one
 `append_alert(conn, code, ...)` call forwards a *variable* by construction.
-Rather than exempt that file, the rule is general: a call sitting inside a
-function that declares its own `code` parameter is a forwarder and is skipped
-— and `_alert` itself is checked as an alert raiser, so its five call sites
-still owe a literal. Known edge, documented rather than hidden: a NEW wrapper
-named something else would have its own callers unchecked until its name is
-added to ALERT_FUNCS.
+Rather than exempt that file, the rule is general: a call is a forwarder, and
+skipped, only when it passes the ENCLOSING function's own `code` parameter
+through as the code argument. Declaring a `code` parameter is not enough — a
+function that declares one and then passes something else is still checked,
+so a wrapper cannot launder a dynamic code past the lint. `_alert` itself is
+checked as an alert raiser, so its five call sites still owe a literal.
+
+Known edge, documented rather than hidden: a NEW wrapper named something else
+would have its own callers unchecked until its name is added to ALERT_FUNCS.
+A second edge: a code passed by keyword (`append_alert(conn, code="x", ...)`)
+finds no positional arg and is reported as a non-literal. That is a false
+positive, and deliberately so — it fails CLOSED, at build time, the moment it
+appears.
 """
 from __future__ import annotations
 

--- a/scripts/check_alert_codes.py
+++ b/scripts/check_alert_codes.py
@@ -33,7 +33,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 PACKAGES = ["orchestrator", "agents", "scripts", "slackkit", "gate", "state",
-            "market", "evals"]
+            "market", "evals", "fundbt", "stratgate", "calibration", "ops"]
 CODE_RE = re.compile(r"^[a-z][a-z0-9_]*$")
 ALERT_FUNCS = ("append_alert", "_alert")
 
@@ -46,16 +46,35 @@ def _callee(node: ast.Call) -> str | None:
 
 
 def _forwarded_calls(tree: ast.AST) -> set[int]:
-    """Calls inside a function that declares its own `code` parameter."""
+    """Alert-raising calls that pass the enclosing function's own `code`
+    parameter through, unchanged, as their code argument — a forwarder, not
+    a dynamic code.
+
+    Narrower than "any call inside a function declaring `code`": that
+    exempted every call in such a function, including a second alert call
+    built from an f-string that happens to sit next to the real forward.
+    Only a call whose code-position argument (positional or `code=`
+    keyword) is exactly a bare reference to the parameter is exempted."""
     forwarded: set[int] = set()
     for fn in ast.walk(tree):
         if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
             continue
-        params = [a.arg for a in fn.args.args + fn.args.kwonlyargs]
+        params = [a.arg for a in
+                  fn.args.posonlyargs + fn.args.args + fn.args.kwonlyargs]
         if "code" not in params:
             continue
         for inner in ast.walk(fn):
-            if isinstance(inner, ast.Call):
+            if not isinstance(inner, ast.Call):
+                continue
+            name = _callee(inner)
+            if name not in ALERT_FUNCS:
+                continue
+            pos = 1 if name == "append_alert" else 2
+            passed = inner.args[pos] if len(inner.args) > pos else None
+            if passed is None:
+                passed = next((kw.value for kw in inner.keywords
+                              if kw.arg == "code"), None)
+            if isinstance(passed, ast.Name) and passed.id == "code":
                 forwarded.add(id(inner))
     return forwarded
 

--- a/scripts/file_alert_issues.py
+++ b/scripts/file_alert_issues.py
@@ -15,6 +15,7 @@ alerts the software already raised and asks the tracker what is already open.
 """
 from __future__ import annotations
 
+import argparse
 import json
 import sqlite3
 import sys
@@ -108,3 +109,102 @@ def plan_filings(conn, since: str, tracker, db_path: str = "") -> tuple[list[Fil
         filings.append(Filing(action, labels, g["code"], g["ticker"], title,
                               body, existing))
     return filings, malformed
+
+
+class GhTracker:
+    """The tracker, over the `gh` CLI (docs/agents/issue-tracker.md)."""
+
+    def __init__(self, repo: str, run=None):
+        import subprocess
+        self._run = run or subprocess.run
+        self.repo = repo
+
+    def _gh(self, *args: str) -> str:
+        r = self._run(["gh", *args, "--repo", self.repo],
+                      capture_output=True, text=True)
+        if r.returncode != 0:
+            raise RuntimeError(f"gh {' '.join(args)} failed: {r.stderr.strip()}")
+        return r.stdout
+
+    def open_issue(self, labels):
+        argv = ["issue", "list", "--state", "open", "--json", "number"]
+        for label in labels:
+            argv += ["--label", label]
+        found = json.loads(self._gh(*argv) or "[]")
+        return found[0]["number"] if found else None
+
+    def ensure_label(self, label: str) -> None:
+        self._gh("label", "create", label, "--force")
+
+    def create_issue(self, title, body, labels) -> None:
+        argv = ["issue", "create", "--title", title, "--body", body]
+        for label in labels:
+            argv += ["--label", label]
+        self._gh(*argv)
+
+    def comment_issue(self, number: int, body: str) -> None:
+        self._gh("issue", "comment", str(number), "--body", body)
+
+
+def main(argv: list[str] | None = None, run=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("db")
+    ap.add_argument("--since", required=True, help="ET calendar date YYYY-MM-DD")
+    ap.add_argument("--repo", default="benjaminematton/fund")
+    ap.add_argument("--apply", action="store_true",
+                    help="actually file; without it this is a dry run")
+    args = ap.parse_args(argv)
+
+    # sqlite3.connect CREATES a missing file rather than raising, so an
+    # unreadable DB surfaces as "no such table: events" on the first query,
+    # not on connect. Both are caught below and both file nothing.
+    conn = sqlite3.connect(args.db)
+    conn.row_factory = sqlite3.Row
+    tracker = GhTracker(args.repo, run=run)
+    try:
+        filings, malformed = plan_filings(conn, args.since, tracker, args.db)
+    except RuntimeError as e:
+        print(f"tracker unavailable: {e}", file=sys.stderr)
+        return 1
+    except sqlite3.Error as e:
+        print(f"cannot read {args.db}: {e}", file=sys.stderr)
+        return 1
+    finally:
+        conn.close()
+
+    for m in malformed:
+        print(f"MALFORMED (not filed): {m}", file=sys.stderr)
+
+    failed = 0
+    for f in filings:
+        if f.action == "skip":
+            print(f"already tracked as #{f.issue}: {' '.join(f.labels)}")
+            continue
+        verb = "filing" if args.apply else "would file"
+        if f.action == "comment":
+            print(f"{verb} a comment on #{f.issue}: cleared {f.code}")
+        else:
+            print(f"{verb}: {f.title}  [{' '.join(f.labels)}]")
+        if not args.apply:
+            continue
+        try:
+            if f.action == "comment":
+                tracker.comment_issue(f.issue, f.body)
+            else:
+                for label in f.labels:
+                    tracker.ensure_label(label)
+                tracker.create_issue(f.title, f.body, f.labels)
+        except RuntimeError as e:
+            # Reported, never retried: a retry with a fresh id is how you get
+            # two issues for one condition.
+            print(f"FAILED {f.action} for {' '.join(f.labels)}: {e}",
+                  file=sys.stderr)
+            failed += 1
+
+    if not filings and not malformed:
+        print(f"no alerts needing an issue since {args.since}")
+    return 1 if (failed or malformed) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/file_alert_issues.py
+++ b/scripts/file_alert_issues.py
@@ -120,8 +120,11 @@ class GhTracker:
         self.repo = repo
 
     def _gh(self, *args: str) -> str:
-        r = self._run(["gh", *args, "--repo", self.repo],
-                      capture_output=True, text=True)
+        try:
+            r = self._run(["gh", *args, "--repo", self.repo],
+                          capture_output=True, text=True)
+        except FileNotFoundError as e:
+            raise RuntimeError(f"gh {' '.join(args)} failed: {e}") from e
         if r.returncode != 0:
             raise RuntimeError(f"gh {' '.join(args)} failed: {r.stderr.strip()}")
         return r.stdout

--- a/scripts/file_alert_issues.py
+++ b/scripts/file_alert_issues.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""File an unmatched alert as a GitHub issue (docs/agents/devops.md).
+
+Zero dependencies (stdlib only) and argv-driven, so it runs against a live or
+backed-up DB with nothing installed:
+
+    python3 scripts/file_alert_issues.py state/fund.sqlite --since 2026-08-21
+    python3 scripts/file_alert_issues.py state/fund.sqlite --since 2026-08-21 --apply
+
+DRY RUN IS THE DEFAULT. Filing is the only irreversible act here — an issue can
+be closed but not un-filed — so producing issues needs an explicit --apply.
+
+This is not a detector. It never decides whether a condition is true; it reads
+alerts the software already raised and asks the tracker what is already open.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))   # sibling audit_day
+import audit_day                                           # noqa: E402
+
+MAX_TITLE = 110
+
+
+@dataclass(frozen=True)
+class Filing:
+    action: str                  # "create" | "skip" | "comment"
+    labels: tuple[str, ...]
+    code: str
+    ticker: str | None
+    title: str
+    body: str
+    issue: int | None = None
+
+
+def _title(code: str, ticker: str | None, text: str) -> str:
+    head = f"{code}: " + (f"{ticker} — " if ticker else "")
+    room = MAX_TITLE - len(head)
+    return head + (text if len(text) <= room else text[:room - 1] + "…")
+
+
+def _body(code, ticker, occurrences, cleared, db_path) -> str:
+    lines = [f"Filed automatically from `{db_path}` by "
+             "`scripts/file_alert_issues.py`.", "",
+             f"- **code:** `{code}`"]
+    if ticker:
+        lines.append(f"- **ticker:** `{ticker}`")
+    lines += [f"- **occurrences in window:** {len(occurrences)}", ""]
+    if cleared:
+        lines += ["> A clearing alert arrived for this condition. The symptom"
+                  " resolved; whether the underlying defect is fixed is a"
+                  " human judgement.", ""]
+    lines.append("### Alert text seen")
+    for created_at, text in occurrences:
+        lines.append(f"- `{created_at}` — {text}")
+    return "\n".join(lines)
+
+
+def plan_filings(conn, since: str, tracker, db_path: str = "") -> tuple[list[Filing], list[str]]:
+    start, _ = audit_day.et_day_window(since)
+    rows = conn.execute(
+        "SELECT payload, created_at FROM events WHERE kind = 'alert'"
+        " AND created_at >= ? ORDER BY id", (start,)).fetchall()
+
+    groups: dict[tuple[str, ...], dict] = {}
+    malformed: list[str] = []
+    for row in rows:
+        try:
+            payload = json.loads(row["payload"])
+        except (ValueError, TypeError):
+            malformed.append(f"{row['created_at']}: unparseable payload")
+            continue
+        if payload.get(audit_day.SELF_ALERT_KEY):
+            continue                       # the rollup restates the others
+        code = payload.get("code")
+        if not code:
+            malformed.append(f"{row['created_at']}: no code — "
+                             f"{payload.get('text', '')[:80]}")
+            continue
+        ticker = payload.get("ticker")
+        labels = (f"alert:{code}",) + ((f"ticker:{ticker}",) if ticker else ())
+        group = groups.setdefault(labels, {"code": code, "ticker": ticker,
+                                           "occurrences": [], "cleared": False})
+        if payload.get("clears"):
+            group["cleared"] = True
+        else:
+            group["cleared"] = False       # a fresh firing reopens the finding
+            group["occurrences"].append((row["created_at"], payload.get("text", "")))
+
+    filings: list[Filing] = []
+    for labels, g in groups.items():
+        existing = tracker.open_issue(labels)
+        body = _body(g["code"], g["ticker"], g["occurrences"], g["cleared"], db_path)
+        if not g["occurrences"]:
+            # Nothing but clearing alerts. Comment if something is tracking
+            # it; never file an issue to announce that a problem went away.
+            if existing is not None:
+                filings.append(Filing("comment", labels, g["code"], g["ticker"],
+                                      "", body, existing))
+            continue
+        title = _title(g["code"], g["ticker"], g["occurrences"][0][1])
+        action = "skip" if existing is not None else "create"
+        filings.append(Filing(action, labels, g["code"], g["ticker"], title,
+                              body, existing))
+    return filings, malformed

--- a/scripts/file_alert_issues.py
+++ b/scripts/file_alert_issues.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import argparse
 import json
 import sqlite3
+import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -115,7 +116,6 @@ class GhTracker:
     """The tracker, over the `gh` CLI (docs/agents/issue-tracker.md)."""
 
     def __init__(self, repo: str, run=None):
-        import subprocess
         self._run = run or subprocess.run
         self.repo = repo
 

--- a/scripts/run_day.py
+++ b/scripts/run_day.py
@@ -73,7 +73,7 @@ from orchestrator.clock import et_run_date, iso                    # noqa: E402
 from orchestrator.daily import (StageCtx, allowed_actions,        # noqa: E402
                                 run_day)
 from orchestrator.preconditions import assert_account_config_unchanged  # noqa: E402
-from slackkit.outbox import append_event, drain                    # noqa: E402
+from slackkit.outbox import append_alert, drain                    # noqa: E402
 from state.db import connect                                       # noqa: E402
 
 # Core env. ALPACA_PAPER_TRADE is checked separately and first (invariant 1).
@@ -279,7 +279,7 @@ def make_turn(seat: str, cfg: dict, db_path: str, clock, conn, run_date: str,
                 _seat_session(cfg, db_path, clock, prompt, snapshot,
                               journals_root))
         except Exception as exc:
-            _alert(conn, clock,
+            _alert(conn, clock, "seat_turn_failed",
                    f"{seat}_turn_failed — {type(exc).__name__}: {exc};"
                    " stage default applies (default is HOLD)")
             return
@@ -294,7 +294,8 @@ def make_turn(seat: str, cfg: dict, db_path: str, clock, conn, run_date: str,
                 # longer open, so only genuinely unexecuted ones can accuse it
                 check_tool_calls(names, len(open_tickets(conn, iso(clock.now()))))
             except Exception as exc:
-                _alert(conn, clock, f"exec_turn_violation — {exc}")
+                _alert(conn, clock, "exec_turn_violation",
+                       f"exec_turn_violation — {exc}")
 
     return run
 
@@ -336,9 +337,9 @@ def record_cost_guarded(conn, clock, run_date: str, seat: str, result,
             " trading continues; the audit will flag the missing cost row")
 
 
-def _alert(conn, clock, text: str, **payload) -> None:
+def _alert(conn, clock, code: str, text: str, **payload) -> None:
     log(f"ALERT {text}")
-    append_event(conn, "alert", {"text": text, **payload}, iso(clock.now()))
+    append_alert(conn, code, text, now_iso=iso(clock.now()), **payload)
 
 
 # --- market-data gaps -------------------------------------------------------
@@ -363,7 +364,7 @@ def alert_missing_price_history(conn, clock, close_df, positions) -> None:
                    if total_blackout else
                    "today's correlations are understated and sizing is looser"
                    " than it should be")
-    _alert(conn, clock,
+    _alert(conn, clock, "missing_price_history",
            f"no usable price history for held {', '.join(gaps)} — excluded"
            f" from the book-correlation basket: {consequence}, until the"
            " feed recovers",
@@ -380,7 +381,7 @@ def alert_unmapped_sectors(conn, clock, positions, sectors) -> None:
     gaps = unmapped_holdings(positions, sectors)
     if not gaps:
         return
-    _alert(conn, clock,
+    _alert(conn, clock, "unmapped_sector",
            f"no config/sectors.yaml entry for held {', '.join(gaps)} —"
            " sector book value is NaN, so every buy fails closed"
            " (gate_error) until the yaml names them",
@@ -425,7 +426,8 @@ def report_audit(conn, slack, db_path: str, run_date: str, clock) -> int:
         log(f"AUDIT CLEAN {run_date}")
         return 0
     now = iso(clock.now())
-    _alert(conn, clock, f"audit {run_date} FAILED: " + "; ".join(problems),
+    _alert(conn, clock, "audit_failed",
+           f"audit {run_date} FAILED: " + "; ".join(problems),
            **{audit_day.SELF_ALERT_KEY: True})
     drain(conn, slack, now)
     return 1
@@ -455,7 +457,7 @@ def guarded(conn, slack, clock, body: Callable[[], int]) -> int:
                 " traded (default is HOLD).")
         log(f"ALERT {text}")
         try:
-            append_event(conn, "alert", {"text": text}, iso(clock.now()))
+            append_alert(conn, "run_day_failed", text, now_iso=iso(clock.now()))
             drain(conn, slack, iso(clock.now()))
         except Exception as inner:
             log(f"could not record/post that alert ({type(inner).__name__}:"

--- a/slackkit/outbox.py
+++ b/slackkit/outbox.py
@@ -16,13 +16,41 @@ from .render import render
 log = logging.getLogger(__name__)
 
 
-def append_event(conn: sqlite3.Connection, kind: str, payload: dict,
-                 now_iso: str) -> int:
+def _insert(conn: sqlite3.Connection, kind: str, payload: dict,
+            now_iso: str) -> int:
     cur = conn.execute(
         "INSERT INTO events (kind, payload, created_at) VALUES (?, ?, ?)",
         (kind, json.dumps(payload), now_iso))
     conn.commit()
     return cur.lastrowid
+
+
+def append_event(conn: sqlite3.Connection, kind: str, payload: dict,
+                 now_iso: str) -> int:
+    return _insert(conn, kind, payload, now_iso)
+
+
+def append_alert(conn: sqlite3.Connection, code: str, text: str, *,
+                 now_iso: str, ticker: str | None = None,
+                 clears: bool = False, **payload) -> int:
+    """Append an alert carrying a stable machine identity.
+
+    `code` is what scripts/file_alert_issues.py keys a GitHub issue on, so it
+    must be identical across runs: never interpolate a ticker, order id,
+    quantity or exception type into it. `ticker` is the only permitted
+    per-entity key, and only where fixing one position would not fix another.
+
+    Deliberately validates nothing. This runs on the alert path, often inside
+    an `except`, and a raise here would turn "something needs review" into a
+    dead trading day (invariant 4). scripts/check_alert_codes.py enforces the
+    code's shape statically instead.
+    """
+    body: dict = {"text": text, "code": code, **payload}
+    if ticker is not None:
+        body["ticker"] = ticker
+    if clears:
+        body["clears"] = True
+    return _insert(conn, "alert", body, now_iso)
 
 
 def _dead_letter(conn: sqlite3.Connection, row, now_iso: str,

--- a/tests/test_alert_codes_lint.py
+++ b/tests/test_alert_codes_lint.py
@@ -1,0 +1,78 @@
+"""The lint's own negative controls. A lint whose negative control also
+passes is not a lint — this repo has three documented instances of exactly
+that, two caught by luck."""
+import importlib.util, subprocess, sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "check_alert_codes.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("check_alert_codes", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_the_real_tree_is_clean():
+    assert subprocess.run([sys.executable, str(SCRIPT)]).returncode == 0
+
+
+def test_a_direct_append_event_alert_is_rejected(tmp_path):
+    p = tmp_path / "bad.py"
+    p.write_text('append_event(conn, "alert", {"text": "x"}, now)\n')
+    errors = _load().check_file(p)
+    assert len(errors) == 1 and "append_alert" in errors[0]
+
+
+def test_an_interpolated_code_is_rejected(tmp_path):
+    p = tmp_path / "bad.py"
+    p.write_text('append_alert(conn, f"{seat}_turn_failed", "x", now_iso=n)\n')
+    errors = _load().check_file(p)
+    assert len(errors) == 1 and "string literal" in errors[0]
+
+
+def test_a_shouty_code_is_rejected(tmp_path):
+    p = tmp_path / "bad.py"
+    p.write_text('append_alert(conn, "PM Timeout", "x", now_iso=n)\n')
+    errors = _load().check_file(p)
+    assert len(errors) == 1 and "lower_snake" in errors[0]
+
+
+def test_a_good_call_is_accepted(tmp_path):
+    p = tmp_path / "good.py"
+    p.write_text('append_alert(conn, "pm_timeout", "x", now_iso=n)\n')
+    assert _load().check_file(p) == []
+
+
+def test_a_non_alert_append_event_is_accepted(tmp_path):
+    p = tmp_path / "good.py"
+    p.write_text('append_event(conn, "fill", {"text": "x"}, now)\n')
+    assert _load().check_file(p) == []
+
+
+def test_a_wrapper_forwarding_its_own_code_is_accepted(tmp_path):
+    """scripts/run_day.py's _alert logs then delegates, so it forwards a
+    variable by construction. That is a forwarder, not a dynamic code."""
+    p = tmp_path / "good.py"
+    p.write_text(
+        "def _alert(conn, clock, code, text, **payload):\n"
+        "    log(text)\n"
+        "    append_alert(conn, code, text, now_iso=n, **payload)\n")
+    assert _load().check_file(p) == []
+
+
+def test_a_wrappers_own_callers_still_owe_a_literal(tmp_path):
+    """The exemption must not leak to the call sites — otherwise routing
+    through a wrapper would launder a dynamic code past the lint."""
+    p = tmp_path / "bad.py"
+    p.write_text('_alert(conn, clock, f"{seat}_turn_failed", "x")\n')
+    errors = _load().check_file(p)
+    assert len(errors) == 1 and "string literal" in errors[0]
+
+
+def test_a_wrapper_call_site_with_a_literal_is_accepted(tmp_path):
+    p = tmp_path / "good.py"
+    p.write_text('_alert(conn, clock, "seat_turn_failed", "x")\n')
+    assert _load().check_file(p) == []

--- a/tests/test_alert_codes_lint.py
+++ b/tests/test_alert_codes_lint.py
@@ -19,6 +19,14 @@ def test_the_real_tree_is_clean():
     assert subprocess.run([sys.executable, str(SCRIPT)]).returncode == 0
 
 
+def test_package_list_is_not_narrower_than_the_repo_it_guards():
+    """F6: PACKAGES omitted fundbt, stratgate, calibration and ops — nothing
+    raises an alert there today, but a lint that only watches part of the
+    tree is a lint that can be silently outgrown."""
+    for pkg in ("fundbt", "stratgate", "calibration", "ops"):
+        assert pkg in _load().PACKAGES
+
+
 def test_a_direct_append_event_alert_is_rejected(tmp_path):
     p = tmp_path / "bad.py"
     p.write_text('append_event(conn, "alert", {"text": "x"}, now)\n')
@@ -75,4 +83,29 @@ def test_a_wrappers_own_callers_still_owe_a_literal(tmp_path):
 def test_a_wrapper_call_site_with_a_literal_is_accepted(tmp_path):
     p = tmp_path / "good.py"
     p.write_text('_alert(conn, clock, "seat_turn_failed", "x")\n')
+    assert _load().check_file(p) == []
+
+
+def test_forwarding_exemption_only_covers_the_actual_forward(tmp_path):
+    """F7: the old rule exempted EVERY call inside any function declaring a
+    `code` parameter, not only the call that forwards it. A second,
+    unrelated alert call in the same function — built from an f-string, not
+    a pass-through of the function's own `code` — must still owe a literal."""
+    p = tmp_path / "bad.py"
+    p.write_text(
+        "def _alert(conn, clock, code, text, **payload):\n"
+        "    log(text)\n"
+        "    append_alert(conn, code, text, now_iso=n, **payload)\n"
+        "    append_alert(conn, f'{code}_extra', text, now_iso=n)\n")
+    errors = _load().check_file(p)
+    assert len(errors) == 1 and "string literal" in errors[0]
+
+
+def test_a_posonly_code_param_is_still_recognized_as_a_forwarder(tmp_path):
+    """F7: posonlyargs must be collected alongside args/kwonlyargs when
+    looking for the function's own `code` parameter."""
+    p = tmp_path / "good.py"
+    p.write_text(
+        "def _alert(conn, clock, code, /, text, **payload):\n"
+        "    append_alert(conn, code, text, now_iso=n, **payload)\n")
     assert _load().check_file(p) == []

--- a/tests/test_daily_stages.py
+++ b/tests/test_daily_stages.py
@@ -59,6 +59,11 @@ def _seed_decision(fund_db, sim_clock, ticker, action, qty):
     fund_db.commit()
 
 
+def _codes(conn):
+    return [json.loads(r["payload"]).get("code") for r in conn.execute(
+        "SELECT payload FROM events WHERE kind='alert' ORDER BY id")]
+
+
 # --- pre-gate ---------------------------------------------------------------
 
 def test_pre_gate_drops_no_action_tickers(fund_db, sim_clock):
@@ -210,6 +215,23 @@ def test_decision_timeout_defaults_hold_with_event(fund_db, sim_clock):
     assert fund_db.execute("SELECT COUNT(*) c FROM critiques").fetchone()["c"] == 1
     assert fund_db.execute("SELECT COUNT(*) c FROM events WHERE kind='alert'"
                            " AND payload LIKE '%pm_timeout%'").fetchone()["c"] == 1
+    assert _codes(fund_db) == ["pm_timeout"]
+    payload = json.loads(fund_db.execute(
+        "SELECT payload FROM events WHERE kind='alert'").fetchone()["payload"])
+    assert "ticker" not in payload
+
+
+def test_pm_timeout_on_three_tickers_is_one_code_with_no_ticker_key(fund_db, sim_clock):
+    """One root cause — the PM did not answer. A ticker key here would file
+    three issues for one silence."""
+    tickers = ("AAPL", "MSFT", "NVDA")
+    market = {t: _nvda_inputs(ticker=t) for t in tickers}
+    ctx = _ctx(fund_db, sim_clock, market)
+    run_decision(ctx, active=list(tickers))      # the PM turn that never answers
+    payloads = [json.loads(r["payload"]) for r in fund_db.execute(
+        "SELECT payload FROM events WHERE kind='alert' ORDER BY id")]
+    assert [p["code"] for p in payloads] == ["pm_timeout"] * 3
+    assert all("ticker" not in p for p in payloads)
 
 
 def test_decision_critique_row_lands_before_the_pm_turn(fund_db, sim_clock):
@@ -437,6 +459,9 @@ def test_pre_gate_alerts_on_gate_error_but_stays_silent_on_no_headroom(fund_db, 
     texts = [json.loads(r["payload"])["text"] for r in alerts]
     assert any("gate_error" in t and "NVDA" in t for t in texts)
     assert not any("AAPL" in t for t in texts)
+    assert _codes(fund_db) == ["gate_error"]
+    payload = json.loads(alerts[0]["payload"])
+    assert payload["ticker"] == "NVDA"
 
 
 def test_close_journals_survive_a_crash_after_the_digest_commits(fund_db, sim_clock, tmp_path):
@@ -458,9 +483,9 @@ def test_close_journals_survive_a_crash_after_the_digest_commits(fund_db, sim_cl
 
 def test_decision_pm_timeout_alert_ordered_before_the_row_commit(
         fund_db, sim_clock, monkeypatch):
-    """review Minor 7: the row commit used to precede append_event, so a
-    kill in between plus the SELECT 1 resume-guard silently dropped the
-    pm_timeout alert forever. If append_event raises/crashes, the decision
+    """review Minor 7: the row commit used to precede the pm_timeout alert
+    write, so a kill in between plus the SELECT 1 resume-guard silently
+    dropped the alert forever. If append_alert raises/crashes, the decision
     row must not already be committed — otherwise the resume guard skips
     the ticker forever and the alert is lost for good."""
     import orchestrator.daily as daily
@@ -468,7 +493,7 @@ def test_decision_pm_timeout_alert_ordered_before_the_row_commit(
     def boom(*a, **k):
         raise RuntimeError("boom")
 
-    monkeypatch.setattr(daily, "append_event", boom)
+    monkeypatch.setattr(daily, "append_alert", boom)
     ctx = _ctx(fund_db, sim_clock, {"NVDA": _nvda_inputs()})
     with pytest.raises(RuntimeError):
         run_decision(ctx, active=["NVDA"])
@@ -729,6 +754,10 @@ def test_execution_alerts_when_the_turn_placed_no_order(fund_db, sim_clock):
     assert run_execution(ctx, lambda: None) == "done"      # turn does nothing
     assert _alert_texts(fund_db) == [
         f"ticket {TID[:8]} open after exec turn — no order"]
+    assert _codes(fund_db) == ["ticket_open_after_exec"]
+    payload = json.loads(fund_db.execute(
+        "SELECT payload FROM events WHERE kind='alert'").fetchone()["payload"])
+    assert "ticker" not in payload
     assert fund_db.execute("SELECT status FROM checkpoints WHERE stage='execution'"
                            ).fetchone()["status"] == "done"
     posts = ctx.slack.posts["#risk"]         # projected to #risk, drained once

--- a/tests/test_file_alert_issues.py
+++ b/tests/test_file_alert_issues.py
@@ -33,14 +33,24 @@ def _load():
 
 
 class FakeTracker:
-    """Records every lookup; answers from a fixed open set."""
+    """Records every lookup; answers from a fixed open set.
+
+    Matches by SUPERSET, not exact tuple equality — `gh issue list --label`
+    means "has this label" for each `--label` given, not "has exactly this
+    label set" (F1). An exact-tuple dict lookup here would hide the real bug:
+    a query for an unkeyed label tuple must still match an issue carrying
+    that label plus a `ticker:` label, exactly as `gh` would."""
     def __init__(self, open_issues=None):
         self.open_issues = open_issues or {}      # labels tuple -> issue number
         self.lookups = []
 
     def open_issue(self, labels):
         self.lookups.append(labels)
-        return self.open_issues.get(tuple(labels))
+        wanted = set(labels)
+        for existing_labels, number in self.open_issues.items():
+            if wanted <= set(existing_labels):
+                return number
+        return None
 
 
 @pytest.fixture
@@ -109,6 +119,33 @@ def test_an_already_open_issue_files_nothing(db):
     filings, _ = _load().plan_filings(db, "2026-08-24", tracker)
     assert [f.action for f in filings] == ["skip"]
     assert filings[0].issue == 41
+
+
+def test_fake_tracker_matches_by_superset_like_gh_does():
+    """`gh issue list --label X` means 'has label X', not 'has exactly {X}'.
+    An issue carrying alert:foo AND ticker:NVDA satisfies a bare query for
+    alert:foo — this is real `gh` behaviour, not a bug in the fake."""
+    tracker = FakeTracker({("alert:foo", "ticker:NVDA"): 7})
+    assert tracker.open_issue(("alert:foo",)) == 7
+
+
+def test_split_codes_no_longer_collide_on_the_shared_prefix(db):
+    """THE F1 defect and its fix. Before the code split, every UNVERIFIED
+    protection alert shared the code `unprotected_position` with the
+    ticker-keyed exposure alert, so an open NVDA-keyed issue for that code
+    silently satisfied the lookup for an unrelated, unkeyed 'broker
+    unreachable' finding — an unverifiable state hiding behind a known
+    exposure. With the codes split (orchestrator/protection.py), the unkeyed
+    finding now queries `alert:protection_unverified`, which shares no label
+    with an issue filed under `alert:unprotected_position` + `ticker:NVDA`,
+    so gh's has-label superset match (reproduced above) cannot conflate them."""
+    _alert(db, "2026-08-24T13:38:02+00:00", code="protection_unverified",
+           text="position protection UNVERIFIED — no broker wired into the"
+                " run; a held position could be unprotected and nothing"
+                " would say so")
+    tracker = FakeTracker({("alert:unprotected_position", "ticker:NVDA"): 41})
+    filings, _ = _load().plan_filings(db, "2026-08-24", tracker)
+    assert [f.action for f in filings] == ["create"]
 
 
 def test_a_closed_issue_does_not_suppress_a_recurrence(db):
@@ -191,6 +228,21 @@ class RecordingRun:
         out = self.replies.get(key, "[]")
         class R: returncode, stdout, stderr = 0, out, ""
         return R()
+
+
+def test_gh_tracker_queries_only_open_issues():
+    """F3: nothing pins `--state open` on GhTracker.open_issue's real argv —
+    test_a_closed_issue_does_not_suppress_a_recurrence exercises only
+    FakeTracker, which has no notion of open vs closed at all, so deleting
+    `--state open` from GhTracker would pass the whole suite while suppressing
+    every recurrence after a human closes an issue."""
+    run = RecordingRun()
+    tracker = _load().GhTracker("benjaminematton/fund", run=run)
+    tracker.open_issue(("alert:pm_timeout",))
+    assert len(run.calls) == 1
+    argv = run.calls[0]
+    assert "--state" in argv
+    assert argv[argv.index("--state") + 1] == "open"
 
 
 def test_dry_run_performs_no_mutation(db, db_path, capsys):

--- a/tests/test_file_alert_issues.py
+++ b/tests/test_file_alert_issues.py
@@ -130,7 +130,12 @@ def test_fake_tracker_matches_by_superset_like_gh_does():
 
 
 def test_split_codes_no_longer_collide_on_the_shared_prefix(db):
-    """THE F1 defect and its fix. Before the code split, every UNVERIFIED
+    """Documents the SHAPE the F1 fix produces. It does not pin the fix —
+    it seeds the codes directly rather than driving assert_positions_protected,
+    so it still passes if the split is reverted. The four assertions in
+    tests/test_protection.py are the pin; they do fail on revert.
+
+    Before the code split, every UNVERIFIED
     protection alert shared the code `unprotected_position` with the
     ticker-keyed exposure alert, so an open NVDA-keyed issue for that code
     silently satisfied the lookup for an unrelated, unkeyed 'broker

--- a/tests/test_file_alert_issues.py
+++ b/tests/test_file_alert_issues.py
@@ -1,0 +1,180 @@
+"""The filer's dedupe, against the REAL alert texts from 2026-08-21 and
+2026-08-24. Synthetic text would not prove the key survives interpolation,
+which is the entire defect this script exists to fix."""
+import importlib.util, json, sqlite3, sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "file_alert_issues.py"
+
+NVDA_0821 = ("NVDA 80 was ticketed with a stop at 215.0 but the broker covers"
+             " only 40 of 80 shares — the position is exposed and no code path"
+             " will protect it; place or restore a stop manually")
+NVDA_0824 = ("NVDA 40 was ticketed with a stop at 215.0 but the broker has NO"
+             " live protective order — the position is exposed and no code path"
+             " will protect it; place or restore a stop manually")
+
+
+def _load():
+    sys.path.insert(0, str(ROOT / "scripts"))
+    spec = importlib.util.spec_from_file_location("file_alert_issues", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    # Register before exec: Filing is a frozen dataclass under `from __future__
+    # import annotations`, so Python 3.14's dataclass field resolution looks
+    # the module up in sys.modules by name. Without this line the module
+    # loads but every dataclass() call inside it raises AttributeError on
+    # sys.modules.get(cls.__module__).__dict__ — a loader gap the brief's
+    # audit_day-style _load() never hit because audit_day.py has no dataclass.
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class FakeTracker:
+    """Records every lookup; answers from a fixed open set."""
+    def __init__(self, open_issues=None):
+        self.open_issues = open_issues or {}      # labels tuple -> issue number
+        self.lookups = []
+
+    def open_issue(self, labels):
+        self.lookups.append(labels)
+        return self.open_issues.get(tuple(labels))
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    return tmp_path / "t.sqlite"
+
+
+@pytest.fixture
+def db(db_path):
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("CREATE TABLE events (id INTEGER PRIMARY KEY, kind TEXT,"
+                 " payload TEXT, created_at TEXT, posted_at TEXT)")
+    return conn
+
+
+def _alert(conn, created_at, **payload):
+    conn.execute("INSERT INTO events (kind, payload, created_at) VALUES"
+                 " ('alert', ?, ?)", (json.dumps(payload), created_at))
+    conn.commit()
+
+
+def test_the_same_condition_with_different_text_files_once(db):
+    """THE defect. Both texts are verbatim from the production DBs."""
+    _alert(db, "2026-08-21T13:38:02+00:00", code="unprotected_position",
+           ticker="NVDA", text=NVDA_0821)
+    _alert(db, "2026-08-24T13:37:54+00:00", code="unprotected_position",
+           ticker="NVDA", text=NVDA_0824)
+    filings, _ = _load().plan_filings(db, "2026-08-21", FakeTracker())
+    assert [f.action for f in filings] == ["create"]
+    assert filings[0].labels == ("alert:unprotected_position", "ticker:NVDA")
+    assert NVDA_0821 in filings[0].body and NVDA_0824 in filings[0].body
+
+
+def test_negative_control_two_codes_file_two_issues(db):
+    """If this passed with one issue, the test above would prove nothing."""
+    _alert(db, "2026-08-24T13:37:54+00:00", code="unprotected_position",
+           ticker="NVDA", text=NVDA_0824)
+    _alert(db, "2026-08-24T13:37:54+00:00", code="accounting_shortfall",
+           ticker="NVDA", text="NVDA: recorded 80, broker holds 40")
+    filings, _ = _load().plan_filings(db, "2026-08-24", FakeTracker())
+    assert [f.action for f in filings] == ["create", "create"]
+
+
+def test_pm_timeout_on_three_tickers_is_one_issue(db):
+    for t in ("AAPL", "MSFT", "NVDA"):
+        _alert(db, "2026-08-18T13:36:11+00:00", code="pm_timeout",
+               text=f"pm_timeout {t} — defaulted to hold")
+    filings, _ = _load().plan_filings(db, "2026-08-18", FakeTracker())
+    assert [f.action for f in filings] == ["create"]
+    assert filings[0].labels == ("alert:pm_timeout",)
+
+
+def test_two_tickers_of_one_code_are_two_issues(db):
+    for t in ("NVDA", "MSFT"):
+        _alert(db, "2026-08-24T13:00:00+00:00", code="unprotected_position",
+               ticker=t, text=f"{t} exposed")
+    filings, _ = _load().plan_filings(db, "2026-08-24", FakeTracker())
+    assert sorted(f.labels[1] for f in filings) == ["ticker:MSFT", "ticker:NVDA"]
+
+
+def test_an_already_open_issue_files_nothing(db):
+    _alert(db, "2026-08-24T13:37:54+00:00", code="unprotected_position",
+           ticker="NVDA", text=NVDA_0824)
+    tracker = FakeTracker({("alert:unprotected_position", "ticker:NVDA"): 41})
+    filings, _ = _load().plan_filings(db, "2026-08-24", tracker)
+    assert [f.action for f in filings] == ["skip"]
+    assert filings[0].issue == 41
+
+
+def test_a_closed_issue_does_not_suppress_a_recurrence(db):
+    """Only OPEN issues match, so a recurrence gets a fresh issue."""
+    _alert(db, "2026-08-24T13:37:54+00:00", code="unprotected_position",
+           ticker="NVDA", text=NVDA_0824)
+    filings, _ = _load().plan_filings(db, "2026-08-24", FakeTracker({}))
+    assert [f.action for f in filings] == ["create"]
+
+
+def test_a_clearing_alert_comments_and_never_closes(db):
+    _alert(db, "2026-08-25T13:00:00+00:00", code="accounting_shortfall",
+           ticker="NVDA", clears=True, text="NVDA agrees again at 40")
+    tracker = FakeTracker({("alert:accounting_shortfall", "ticker:NVDA"): 42})
+    filings, _ = _load().plan_filings(db, "2026-08-25", tracker)
+    assert [f.action for f in filings] == ["comment"]
+    assert filings[0].issue == 42
+    assert all(f.action != "close" for f in filings)
+
+
+def test_a_clearing_alert_with_no_open_issue_does_nothing(db):
+    _alert(db, "2026-08-25T13:00:00+00:00", code="accounting_shortfall",
+           ticker="NVDA", clears=True, text="NVDA agrees again at 40")
+    filings, _ = _load().plan_filings(db, "2026-08-25", FakeTracker())
+    assert filings == []
+
+
+def test_a_condition_that_fired_and_cleared_in_one_window_still_files(db):
+    """The symptom cleared; the code defect did not."""
+    _alert(db, "2026-08-24T13:00:00+00:00", code="accounting_shortfall",
+           ticker="NVDA", text="NVDA: recorded 80, broker holds 40")
+    _alert(db, "2026-08-24T15:00:00+00:00", code="accounting_shortfall",
+           ticker="NVDA", clears=True, text="NVDA agrees again at 40")
+    filings, _ = _load().plan_filings(db, "2026-08-24", FakeTracker())
+    assert [f.action for f in filings] == ["create"]
+
+
+def test_the_audit_rollup_never_files(db):
+    _alert(db, "2026-08-24T13:38:01+00:00", code="audit_failed",
+           audit_report=True, text="audit 2026-08-24 FAILED: alert events raised: 2")
+    filings, _ = _load().plan_filings(db, "2026-08-24", FakeTracker())
+    assert filings == []
+
+
+def test_a_payload_with_no_code_is_reported_not_guessed(db):
+    _alert(db, "2026-08-24T13:00:00+00:00", text="something old and codeless")
+    _alert(db, "2026-08-24T13:01:00+00:00", code="pm_timeout", text="pm_timeout AAPL")
+    filings, malformed = _load().plan_filings(db, "2026-08-24", FakeTracker())
+    assert len(malformed) == 1 and "codeless" in malformed[0]
+    assert [f.action for f in filings] == ["create"]      # the rest still process
+
+
+def test_alerts_before_the_since_date_are_ignored(db):
+    _alert(db, "2026-08-20T13:00:00+00:00", code="pm_timeout", text="old")
+    filings, _ = _load().plan_filings(db, "2026-08-24", FakeTracker())
+    assert filings == []
+
+
+def test_a_changing_order_id_does_not_file_a_new_issue_each_day(db):
+    """ticket_open_after_exec embeds a fresh order id every run. Keyed on the
+    id it would file one issue per trading day, forever — the single worst
+    outcome available here."""
+    _alert(db, "2026-08-20T13:38:23+00:00", code="ticket_open_after_exec",
+           text="ticket c0a9ae97 open after exec turn — no order")
+    _alert(db, "2026-08-24T13:38:23+00:00", code="ticket_open_after_exec",
+           text="ticket 7f31b204 open after exec turn — no order")
+    filings, _ = _load().plan_filings(db, "2026-08-20", FakeTracker())
+    assert [f.action for f in filings] == ["create"]
+    assert filings[0].labels == ("alert:ticket_open_after_exec",)

--- a/tests/test_file_alert_issues.py
+++ b/tests/test_file_alert_issues.py
@@ -254,3 +254,66 @@ def test_an_unreadable_db_exits_non_zero_having_filed_nothing(tmp_path, capsys):
                        "--apply"], run=run)
     assert rc != 0
     assert run.calls == []
+
+
+def test_missing_gh_binary_during_planning_is_reported_not_a_traceback(db, db_path, capsys):
+    """open_issue runs during plan_filings, before --apply is even consulted.
+    A bare FileNotFoundError from subprocess.run must not escape main()."""
+    _alert(db, "2026-08-24T13:37:54+00:00", code="unprotected_position",
+           ticker="NVDA", text=NVDA_0824)
+    db.close()
+
+    def run(argv, **kw):
+        raise FileNotFoundError(2, "No such file or directory", "gh")
+
+    rc = _load().main([str(db_path), "--since", "2026-08-24"], run=run)
+    assert rc != 0
+    assert "tracker unavailable" in capsys.readouterr().err
+
+
+def test_missing_gh_binary_during_apply_is_reported_not_a_traceback(db, db_path, capsys):
+    """Here `gh` exists for the planning lookup (issue list) but disappears
+    before the mutating call — e.g. a PATH change between processes. The
+    apply-time FileNotFoundError must land as a FAILED line, not a crash."""
+    _alert(db, "2026-08-24T13:37:54+00:00", code="unprotected_position",
+           ticker="NVDA", text=NVDA_0824)
+    db.close()
+
+    def run(argv, **kw):
+        if "label" in argv and "create" in argv:
+            raise FileNotFoundError(2, "No such file or directory", "gh")
+        class R: returncode, stdout, stderr = 0, "[]", ""
+        return R()
+
+    rc = _load().main([str(db_path), "--since", "2026-08-24", "--apply"], run=run)
+    assert rc != 0
+    assert "FAILED" in capsys.readouterr().err
+
+
+def test_failing_label_create_is_reported_and_skips_only_that_filing(db, db_path, capsys):
+    """A failure in one filing's label-create must not abort the rest."""
+    _alert(db, "2026-08-24T13:37:54+00:00", code="unprotected_position",
+           ticker="NVDA", text=NVDA_0824)
+    _alert(db, "2026-08-24T13:00:00+00:00", code="pm_timeout",
+           text="pm_timeout AAPL — defaulted to hold")
+    db.close()
+
+    class FailLabelRun(RecordingRun):
+        def __call__(self, argv, **kw):
+            self.calls.append(argv)
+            failing = ("label" in argv and "create" in argv
+                       and "alert:unprotected_position" in argv)
+            class R:
+                returncode = 1 if failing else 0
+                stdout, stderr = "[]", "gh: HTTP 403"
+            return R()
+
+    run = FailLabelRun()
+    rc = _load().main([str(db_path), "--since", "2026-08-24", "--apply"], run=run)
+    assert rc != 0
+    err = capsys.readouterr().err
+    assert "FAILED" in err and "unprotected_position" in err
+
+    creates = [c for c in run.calls if "create" in c and "issue" in c]
+    assert not any("unprotected_position" in " ".join(c) for c in creates)
+    assert any("pm_timeout" in " ".join(c) for c in creates)  # second filing still ran

--- a/tests/test_file_alert_issues.py
+++ b/tests/test_file_alert_issues.py
@@ -178,3 +178,79 @@ def test_a_changing_order_id_does_not_file_a_new_issue_each_day(db):
     filings, _ = _load().plan_filings(db, "2026-08-20", FakeTracker())
     assert [f.action for f in filings] == ["create"]
     assert filings[0].labels == ("alert:ticket_open_after_exec",)
+
+
+class RecordingRun:
+    """Stands in for subprocess.run. Records argv, answers from a script."""
+    def __init__(self, replies=None):
+        self.calls, self.replies = [], replies or {}
+
+    def __call__(self, argv, **kw):
+        self.calls.append(argv)
+        key = " ".join(argv[:3])
+        out = self.replies.get(key, "[]")
+        class R: returncode, stdout, stderr = 0, out, ""
+        return R()
+
+
+def test_dry_run_performs_no_mutation(db, db_path, capsys):
+    """Seeded with an alert that WOULD file — otherwise 'no mutating calls'
+    passes vacuously and proves nothing."""
+    _alert(db, "2026-08-24T13:37:54+00:00", code="unprotected_position",
+           ticker="NVDA", text=NVDA_0824)
+    db.close()
+    run = RecordingRun()
+    rc = _load().main([str(db_path), "--since", "2026-08-24"], run=run)
+    assert rc == 0
+    assert "would file" in capsys.readouterr().out      # it had work to skip
+    mutating = [c for c in run.calls
+                if "create" in c or "comment" in c or "label" in c]
+    assert mutating == []          # asserted, not assumed
+
+
+def test_apply_creates_the_label_before_the_issue(db, db_path):
+    _alert(db, "2026-08-24T13:37:54+00:00", code="unprotected_position",
+           ticker="NVDA", text=NVDA_0824)
+    db.close()
+    mod = _load()
+    run = RecordingRun()
+    mod.main([str(db_path), "--since", "2026-08-24", "--apply"], run=run)
+    joined = [" ".join(c) for c in run.calls]
+    label_at = next(i for i, c in enumerate(joined) if "label create" in c)
+    issue_at = next(i for i, c in enumerate(joined) if "issue create" in c)
+    assert label_at < issue_at
+
+
+def test_gh_failure_is_reported_and_never_retried(db, db_path, capsys):
+    """A retry with a fresh id is how one condition becomes two issues."""
+    class FailingRun(RecordingRun):
+        # Only `gh issue create` fails. `returncode = 0 if "list" in argv
+        # else 1` (as first drafted) fails `label create` too, so the apply
+        # path never even reaches `issue create` — the "1 create attempt"
+        # assertion below would be unreachable (0 == 1), proving nothing
+        # about retries. Failing only the actual create call is what this
+        # test's name is about.
+        def __call__(self, argv, **kw):
+            self.calls.append(argv)
+            class R:
+                returncode = 1 if ("issue" in argv and "create" in argv) else 0
+                stdout, stderr = "[]", "gh: HTTP 403"
+            return R()
+
+    _alert(db, "2026-08-24T13:37:54+00:00", code="unprotected_position",
+           ticker="NVDA", text=NVDA_0824)
+    db.close()
+    run = FailingRun()
+    rc = _load().main([str(db_path), "--since", "2026-08-24", "--apply"], run=run)
+    assert rc != 0
+    assert "FAILED" in capsys.readouterr().err
+    creates = [c for c in run.calls if "create" in c and "issue" in c]
+    assert len(creates) == 1          # reported once, never retried
+
+
+def test_an_unreadable_db_exits_non_zero_having_filed_nothing(tmp_path, capsys):
+    run = RecordingRun()
+    rc = _load().main([str(tmp_path / "nope.sqlite"), "--since", "2026-08-24",
+                       "--apply"], run=run)
+    assert rc != 0
+    assert run.calls == []

--- a/tests/test_preconditions.py
+++ b/tests/test_preconditions.py
@@ -27,6 +27,12 @@ def _alerts(conn) -> list[str]:
     return [json.loads(r["payload"])["text"] for r in rows]
 
 
+def _payloads(conn) -> list[dict]:
+    rows = conn.execute(
+        "SELECT payload FROM events WHERE kind = 'alert' ORDER BY id").fetchall()
+    return [json.loads(r["payload"]) for r in rows]
+
+
 @pytest.fixture
 def conn(tmp_path):
     c = connect(str(tmp_path / "t.sqlite"))
@@ -48,6 +54,10 @@ def test_changed_field_alerts_naming_old_and_new(conn):
     assert n == 1
     text = _alerts(conn)[0]
     assert "no_shorting" in text and "True" in text and "False" in text
+    payload = _payloads(conn)[0]
+    assert payload["code"] == "account_precondition_drift"
+    assert payload["drift"] == {"field": "no_shorting", "expected": True,
+                                "actual": False}
 
 
 def test_one_alert_per_drifted_field(conn):

--- a/tests/test_protection.py
+++ b/tests/test_protection.py
@@ -340,6 +340,9 @@ def test_a_positions_read_that_raises_alerts(fund_db):
     n = assert_positions_protected(fund_db, broker=Down(), now_iso=NOW)
     assert n == 1
     assert "ConnectionError" in _alerts(fund_db)[0]
+    payload = _payloads(fund_db)[0]
+    assert payload["code"] == "protection_unverified"
+    assert "ticker" not in payload
 
 
 def test_an_orders_read_that_raises_alerts(fund_db):
@@ -353,16 +356,52 @@ def test_an_orders_read_that_raises_alerts(fund_db):
     assert n == 1
     assert "ConnectionError" in _alerts(fund_db)[0]
     assert "401 unauthorized" in _alerts(fund_db)[0]
+    payload = _payloads(fund_db)[0]
+    assert payload["code"] == "protection_unverified"
+    assert "ticker" not in payload
+
+
+def test_a_re_read_failure_alerts_as_unverified(fund_db):
+    """The re-read (:251) can itself raise — a broker that answered once and
+    then dropped. That is exactly as unverifiable as the first read failing,
+    and must carry the same code, never `unprotected_position` (F1: an
+    unverifiable state must never be filed under the same code as a known,
+    ticker-keyed exposure)."""
+    class FlakesOnSecondRead(Broker):
+        def __init__(self):
+            super().__init__([_long()], [])
+            self.reads = 0
+
+        def open_positions(self):
+            self.reads += 1
+            if self.reads > 1:
+                raise ConnectionError("broker down")
+            return self._positions
+
+    _promised(fund_db)
+    n = assert_positions_protected(
+        fund_db, broker=FlakesOnSecondRead(), now_iso=NOW, sleep=lambda _s: None)
+    assert n == 1
+    payload = _payloads(fund_db)[0]
+    assert payload["code"] == "protection_unverified"
+    assert "ticker" not in payload
 
 
 def test_a_missing_broker_alerts(fund_db):
     """A None broker in production is a wiring bug. It must scream, not skip:
     'no broker, so no check, so no alert' is the silent pass this whole module
-    exists to make impossible."""
+    exists to make impossible.
+
+    Its code is `protection_unverified`, not `unprotected_position` (F1): the
+    latter is reserved for a genuine per-position exposure and is always
+    ticker-keyed. Before this split, an open ticker-keyed
+    `unprotected_position` issue for one symbol silently satisfied `gh issue
+    list --label alert:unprotected_position` for THIS unkeyed, unrelated
+    finding — an unverifiable broker state hiding behind a known exposure."""
     n = assert_positions_protected(fund_db, broker=None, now_iso=NOW)
     assert n == 1
     payload = _payloads(fund_db)[0]
-    assert payload["code"] == "unprotected_position"
+    assert payload["code"] == "protection_unverified"
     assert "ticker" not in payload
 
 

--- a/tests/test_protection.py
+++ b/tests/test_protection.py
@@ -15,6 +15,11 @@ def _alerts(conn):
         "SELECT payload FROM events WHERE kind='alert' ORDER BY id").fetchall()]
 
 
+def _payloads(conn):
+    return [json.loads(r["payload"]) for r in conn.execute(
+        "SELECT payload FROM events WHERE kind='alert' ORDER BY id").fetchall()]
+
+
 class Broker:
     """A broker with an exact answer for both reads."""
     def __init__(self, positions=(), orders=()):
@@ -121,6 +126,9 @@ def test_a_promised_stop_that_is_gone_alerts(fund_db):
     assert n == 1
     assert "NVDA" in _alerts(fund_db)[0]
     assert "80" in _alerts(fund_db)[0]
+    payload = _payloads(fund_db)[0]
+    assert payload["code"] == "unprotected_position"
+    assert payload["ticker"] == "NVDA"
 
 
 def test_a_position_that_was_never_promised_a_stop_is_silent(fund_db):
@@ -190,6 +198,9 @@ def test_a_stop_for_fewer_shares_than_held_alerts(fund_db):
         now_iso=NOW)
     assert n == 1
     assert "only 30 of 80" in _alerts(fund_db)[0]
+    payload = _payloads(fund_db)[0]
+    assert payload["code"] == "unprotected_position"
+    assert payload["ticker"] == "NVDA"
 
 
 def test_stops_across_several_orders_sum(fund_db):
@@ -223,6 +234,9 @@ def test_a_covered_symbol_and_a_naked_one_alert_exactly_once(fund_db):
     assert n == 1
     assert "NVDA" in _alerts(fund_db)[0]
     assert "MSFT" not in _alerts(fund_db)[0]
+    payload = _payloads(fund_db)[0]
+    assert payload["code"] == "unprotected_position"
+    assert payload["ticker"] == "NVDA"
 
 
 def test_a_buy_order_does_not_protect_a_long(fund_db):
@@ -347,6 +361,9 @@ def test_a_missing_broker_alerts(fund_db):
     exists to make impossible."""
     n = assert_positions_protected(fund_db, broker=None, now_iso=NOW)
     assert n == 1
+    payload = _payloads(fund_db)[0]
+    assert payload["code"] == "unprotected_position"
+    assert "ticker" not in payload
 
 
 def test_it_never_raises_no_matter_how_broken_the_broker_is(fund_db):
@@ -480,6 +497,10 @@ def test_a_recorded_buy_the_broker_no_longer_holds_alerts(fund_db):
     text = _alerts(fund_db)[0]
     assert "NVDA" in text and "80" in text
     assert "0" in text
+    payload = _payloads(fund_db)[0]
+    assert payload["code"] == "accounting_shortfall"
+    assert payload["ticker"] == "NVDA"
+    assert "clears" not in payload
 
 
 def test_a_partial_disappearance_names_the_shortfall(fund_db):
@@ -551,6 +572,9 @@ def test_no_broker_fails_closed(fund_db):
     n = assert_positions_accounted(fund_db, broker=None, now_iso=NOW)
     assert n == 1
     assert "UNVERIFIED" in _alerts(fund_db)[0]
+    payload = _payloads(fund_db)[0]
+    assert payload["code"] == "accounting_unverified"
+    assert "ticker" not in payload
 
 
 def test_a_position_that_is_merely_slow_to_appear_is_not_a_discrepancy(fund_db):
@@ -593,6 +617,21 @@ def test_a_discrepancy_that_clears_and_recurs_alerts_again(fund_db):
     texts = _alerts(fund_db)
     assert len(texts) == 3
     assert "closed" in texts[1]
+
+
+def test_the_accounting_clearing_alert_is_marked_clears(fund_db):
+    """assert_positions_accounted's clear path must be distinguishable, or
+    the filer reads a resolution as a new finding."""
+    _promised(fund_db)
+    assert assert_positions_accounted(
+        fund_db, broker=Broker([], []), now_iso=NOW) == 1
+    # the gap closes: the broker shows the shares again
+    assert assert_positions_accounted(
+        fund_db, broker=Broker([_long("NVDA", "80")], []), now_iso=NOW) == 1
+    payload = _payloads(fund_db)[-1]
+    assert payload["code"] == "accounting_shortfall"
+    assert payload["clears"] is True
+    assert payload["accounting"]["cleared"] is True
 
 
 def test_a_standing_discrepancy_is_not_reported_as_cleared(fund_db):

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -1,8 +1,16 @@
+import json
 from orchestrator.clock import iso
 from orchestrator.reconcile import _apply, reconcile_orders
 from state.transition import try_transition
 from tests.fake_alpaca import FakeAlpaca
 from tests.test_tickets import TID, _seed
+
+def _codes(conn):
+    return [json.loads(r["payload"]).get("code") for r in conn.execute(
+        "SELECT payload FROM events WHERE kind='alert' ORDER BY id")]
+
+class _Unreachable:
+    def get_order_by_client_order_id(self, coid): raise ConnectionError()
 
 def _submitted_order(conn, now, qty=67):
     conn.execute("INSERT INTO orders (client_order_id, symbol, side, qty,"
@@ -52,6 +60,7 @@ def test_never_fills_within_cap_decision_failed_alert(fund_db, sim_clock):
     # filled_avg_price comes back as real None, never the string "None".
     o = broker.get_order_by_client_order_id(TID)
     assert o["filled_avg_price"] is None
+    assert _codes(fund_db) == ["order_unfilled_at_cap"]
 
 def test_partial_fill_left_submitted_with_alert(fund_db, sim_clock):
     _seed(fund_db)
@@ -66,17 +75,17 @@ def test_partial_fill_left_submitted_with_alert(fund_db, sim_clock):
                      poll_s=3.0, max_wait_s=3.0)   # one poll then stop
     assert fund_db.execute("SELECT status FROM orders").fetchone()["status"] == "partially_filled"
     assert fund_db.execute("SELECT COUNT(*) c FROM events WHERE kind='alert'").fetchone()["c"] == 1
+    assert _codes(fund_db) == ["partial_fill_manual_review"]
 
 def test_broker_error_fails_closed_no_transition(fund_db, sim_clock):
     _seed(fund_db)
     now = iso(sim_clock.now())
     fund_db.execute("UPDATE tickets SET status='consumed'"); fund_db.commit()
     _submitted_order(fund_db, now)
-    class Boom:
-        def get_order_by_client_order_id(self, coid): raise ConnectionError()
-    reconcile_orders(fund_db, clock=sim_clock, broker=Boom(),
+    reconcile_orders(fund_db, clock=sim_clock, broker=_Unreachable(),
                      sleep=lambda s: None, poll_s=3.0, max_wait_s=6.0)
     assert fund_db.execute("SELECT status FROM orders").fetchone()["status"] == "submitted"
+    assert _codes(fund_db) == ["order_unresolved_at_cap"]
 
 def test_malformed_fill_none_values_leaves_submitted_no_transition(fund_db, sim_clock):
     """CRITICAL regression: broker says 'filled' but the numbers are None
@@ -94,6 +103,7 @@ def test_malformed_fill_none_values_leaves_submitted_no_transition(fund_db, sim_
     assert fund_db.execute("SELECT status FROM decisions").fetchone()["status"] == "approved"
     assert fund_db.execute(
         "SELECT COUNT(*) c FROM events WHERE kind='fill'").fetchone()["c"] == 0
+    assert _codes(fund_db) == ["order_unresolved_at_cap"]
 
 def test_malformed_fill_missing_keys_leaves_submitted_no_transition(fund_db, sim_clock):
     """Same CRITICAL regression, but the broker omits the fill keys entirely."""
@@ -118,9 +128,7 @@ def test_broker_unreachable_at_cap_alerts_loudly(fund_db, sim_clock):
     now = iso(sim_clock.now())
     fund_db.execute("UPDATE tickets SET status='consumed'"); fund_db.commit()
     _submitted_order(fund_db, now)
-    class Boom:
-        def get_order_by_client_order_id(self, coid): raise ConnectionError()
-    reconcile_orders(fund_db, clock=sim_clock, broker=Boom(),
+    reconcile_orders(fund_db, clock=sim_clock, broker=_Unreachable(),
                      sleep=lambda s: None, poll_s=3.0, max_wait_s=6.0)
     assert fund_db.execute("SELECT status FROM orders").fetchone()["status"] == "submitted"
     assert fund_db.execute("SELECT status FROM decisions").fetchone()["status"] == "approved"
@@ -129,6 +137,19 @@ def test_broker_unreachable_at_cap_alerts_loudly(fund_db, sim_clock):
     assert alert is not None
     assert "ConnectionError" in alert["payload"]
     assert "unresolved" in alert["payload"]
+    assert _codes(fund_db) == ["order_unresolved_at_cap"]
+
+def test_no_reconcile_alert_carries_a_ticker_key(fund_db, sim_clock):
+    """An order id or symbol as a key here would file an issue per order,
+    forever. Driven through the cheapest alerting path in this file."""
+    _seed(fund_db)
+    fund_db.execute("UPDATE tickets SET status='consumed'"); fund_db.commit()
+    _submitted_order(fund_db, iso(sim_clock.now()))
+    reconcile_orders(fund_db, clock=sim_clock, broker=_Unreachable(),
+                     sleep=lambda s: None, poll_s=3.0, max_wait_s=6.0)
+    payloads = [json.loads(r["payload"]) for r in fund_db.execute(
+        "SELECT payload FROM events WHERE kind='alert'")]
+    assert payloads and all("ticker" not in p for p in payloads)
 
 def test_apply_returns_false_on_cas_noop_already_filled(fund_db, sim_clock):
     """Fix 5: _apply must not report a fill when another writer already
@@ -207,6 +228,7 @@ def test_fill_with_decision_not_approved_alerts_and_does_not_transition(fund_db,
     alert = fund_db.execute("SELECT payload FROM events WHERE kind='alert'").fetchone()
     assert alert is not None
     assert "expired" in alert["payload"] and "not" in alert["payload"]
+    assert _codes(fund_db) == ["fill_on_unapproved_decision"]
 
 
 def _pending(conn, sim_clock, qty=67):
@@ -263,6 +285,7 @@ def test_cancel_error_and_still_open_leaves_order_submitted(fund_db, sim_clock):
     assert fund_db.execute("SELECT status FROM decisions").fetchone()["status"] == "approved"
     alert = fund_db.execute("SELECT payload FROM events WHERE kind='alert'").fetchone()
     assert alert is not None and "cancel unconfirmed" in alert["payload"]
+    assert _codes(fund_db) == ["order_unreconciled"]
 
 
 def test_requery_error_after_cancel_leaves_order_submitted(fund_db, sim_clock):
@@ -283,6 +306,7 @@ def test_requery_error_after_cancel_leaves_order_submitted(fund_db, sim_clock):
     assert fund_db.execute("SELECT status FROM decisions").fetchone()["status"] == "approved"
     alert = fund_db.execute("SELECT payload FROM events WHERE kind='alert'").fetchone()
     assert alert is not None and "ConnectionError" in alert["payload"]
+    assert _codes(fund_db) == ["order_unreconciled"]
 
 
 def test_pending_cancel_is_not_a_confirmed_cancel(fund_db, sim_clock):
@@ -300,6 +324,7 @@ def test_pending_cancel_is_not_a_confirmed_cancel(fund_db, sim_clock):
     assert fund_db.execute("SELECT status FROM decisions").fetchone()["status"] == "approved"
     alert = fund_db.execute("SELECT payload FROM events WHERE kind='alert'").fetchone()
     assert alert is not None and "pending_cancel" in alert["payload"]
+    assert _codes(fund_db) == ["order_unreconciled"]
 
 
 def test_second_run_after_cancel_is_a_noop(fund_db, sim_clock):
@@ -359,6 +384,10 @@ def test_partial_then_canceled_records_the_shares_held(fund_db, sim_clock):
     alerts = [r["payload"] for r in fund_db.execute(
         "SELECT payload FROM events WHERE kind='alert'")]
     assert any("partial 5 of 10 then canceled" in a for a in alerts), alerts
+    # Two alerts on this path: the main poll loop's partial-fill alert when
+    # the order first goes submitted -> partially_filled, then the
+    # timeout-close alert when it is canceled with shares held.
+    assert _codes(fund_db) == ["partial_fill_manual_review", "order_partial_then_dead"]
 
 
 def test_zero_fill_cancel_fails_the_decision_and_writes_no_fill(fund_db, sim_clock):

--- a/tests/test_run_day.py
+++ b/tests/test_run_day.py
@@ -240,6 +240,10 @@ def test_a_raise_inside_the_day_alerts_slack_and_exits_nonzero(wired):
     assert "run_day_failed" in texts[0] and "OperationalError" in texts[0]
     assert conn.execute("SELECT COUNT(*) c FROM events WHERE kind = 'alert'"
                         " AND posted_at IS NOT NULL").fetchone()["c"] == 1
+    import json
+    payload = json.loads(conn.execute(
+        "SELECT payload FROM events WHERE kind = 'alert'").fetchone()["payload"])
+    assert payload["code"] == "run_day_failed"
 
 
 def sqlite3_error():
@@ -322,6 +326,7 @@ def test_a_held_ticker_with_no_price_history_is_named_in_an_alert(wired):
         conn, clock, close_df, {"AAPL": 40, "NVDA": 5})
     payloads = _alert_payloads(conn)
     assert len(payloads) == 1
+    assert payloads[0]["code"] == "missing_price_history"
     assert payloads[0]["tickers"] == ["AAPL"]
     assert "AAPL" in payloads[0]["text"] and "NVDA" not in payloads[0]["text"]
     assert "sizing is looser" in payloads[0]["text"]
@@ -361,6 +366,7 @@ def test_a_held_ticker_missing_from_sectors_yaml_is_named_in_an_alert(wired):
         conn, clock, {"AAPL": 40, "NVDA": 5}, {"NVDA": "tech"})
     payloads = _alert_payloads(conn)
     assert len(payloads) == 1
+    assert payloads[0]["code"] == "unmapped_sector"
     assert payloads[0]["tickers"] == ["AAPL"]
     assert "AAPL" in payloads[0]["text"] and "sectors.yaml" in payloads[0]["text"]
 
@@ -370,6 +376,21 @@ def test_a_fully_mapped_book_raises_no_sector_alert(wired):
     run_day_script.alert_unmapped_sectors(
         conn, clock, {"AAPL": 40, "NVDA": 5}, {"NVDA": "tech", "AAPL": "tech"})
     assert _alert_payloads(conn) == []
+
+
+def test_the_audit_rollup_keeps_its_self_alert_marker(wired, monkeypatch):
+    """audit_day.SELF_ALERT_KEY is how BOTH audit_day and the filer avoid
+    double-counting the rollup. Migrating must not drop it."""
+    conn, slack, clock = wired
+    monkeypatch.setattr(run_day_script.audit_day, "audit",
+                        lambda *a, **k: ["forced failure"])
+
+    code = run_day_script.report_audit(conn, slack, "db", "2026-07-06", clock)
+
+    assert code == 1
+    payload = _alert_payloads(conn)[-1]
+    assert payload["code"] == "audit_failed"
+    assert payload[run_day_script.audit_day.SELF_ALERT_KEY] is True
 
 
 # --- single-instance guard (Fix 5) ------------------------------------------
@@ -520,6 +541,7 @@ def test_a_seat_turn_that_raises_alerts_and_lets_the_stage_default_land(
     assert len(texts) == 1
     assert "analyst_turn_failed" in texts[0] and "TimeoutError" in texts[0]
     assert "default is HOLD" in texts[0]
+    assert _alert_payloads(conn)[0]["code"] == "seat_turn_failed"
 
     # ...and the stage that owns this turn still lands its own default: the
     # ticker gets neutral/0 "no report" instead of the day stopping.
@@ -532,6 +554,23 @@ def test_a_seat_turn_that_raises_alerts_and_lets_the_stage_default_land(
                        ).fetchone()
     assert (row["direction"], row["confidence"], row["summary"]) == (
         "neutral", 0, "no report")
+
+
+def test_seat_turn_failure_uses_a_literal_code_not_the_seat_name(
+        wired, monkeypatch):
+    """The seat belongs in the TEXT. A code of f"{seat}_turn_failed" mints a
+    new code — and therefore a new issue — for every seat that ever fails."""
+    conn, _, clock = wired
+
+    async def _boom(*a, **k):
+        raise TimeoutError("session never connected")
+
+    monkeypatch.setattr(run_day_script, "_seat_session", _boom)
+    _turn(conn, clock, seat="analyst")()
+
+    payload = _alert_payloads(conn)[-1]
+    assert payload["code"] == "seat_turn_failed"
+    assert payload["text"].startswith("analyst_turn_failed —")
 
 
 def test_an_exec_tool_call_violation_is_alerted_after_the_cost_is_recorded(
@@ -552,6 +591,7 @@ def test_an_exec_tool_call_violation_is_alerted_after_the_cost_is_recorded(
     assert len(texts) == 1 and "exec_turn_violation" in texts[0]
     assert "zero tool calls" in texts[0]
     assert conn.execute("SELECT COUNT(*) c FROM costs").fetchone()["c"] == 1
+    assert _alert_payloads(conn)[0]["code"] == "exec_turn_violation"
 
 
 def test_an_off_mandate_tool_call_is_alerted(wired, monkeypatch):

--- a/tests/test_runtime_hooks.py
+++ b/tests/test_runtime_hooks.py
@@ -82,6 +82,7 @@ def test_order_gate_deny_appends_one_alert_naming_ticker_reason_and_ticket(
     assert reason in alerts[0]
     assert fund_db.execute(
         "SELECT created_at FROM events").fetchone()["created_at"] == NOW
+    assert _alert_payloads(fund_db)[0]["code"] == "order_gate_denied"
 
 
 def test_order_gate_allowed_order_appends_no_alert(fund_db, sim_clock):
@@ -105,6 +106,8 @@ def test_order_gate_deny_alert_survives_malformed_tool_input(fund_db, sim_clock)
                          "tool_input": bad}, "t1", None))
         assert out["hookSpecificOutput"]["permissionDecision"] == "deny"
     assert len(_alerts(fund_db)) == 3
+    assert all(p["code"] == "order_gate_denied"
+              for p in _alert_payloads(fund_db))
 
 
 # --- ungated broker verbs ----------------------------------------------------
@@ -385,6 +388,11 @@ def _alerts(conn):
         "SELECT payload FROM events WHERE kind = 'alert' ORDER BY id")]
 
 
+def _alert_payloads(conn):
+    return [json.loads(r["payload"]) for r in conn.execute(
+        "SELECT payload FROM events WHERE kind = 'alert' ORDER BY id")]
+
+
 def test_record_turn_result_writes_the_cost_row(fund_db):
     """The live wiring seam (scripts/run_day.py calls this after every seat
     turn): a ResultMessage with a populated estimate becomes exactly one row."""
@@ -410,6 +418,7 @@ def test_record_turn_result_none_cost_records_nothing_and_alerts(fund_db):
     assert _alerts(fund_db) == [
         "cost_unavailable pm — turn completed with no total_cost_usd estimate"
         " (session s2); the day's est. inference cost understates spend"]
+    assert _alert_payloads(fund_db)[0]["code"] == "cost_unavailable"
 
 
 def test_record_turn_result_missing_attributes_do_not_crash_the_day(fund_db):

--- a/tests/test_slackkit.py
+++ b/tests/test_slackkit.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import json
 
 import pytest
 
@@ -726,6 +727,44 @@ def test_real_slack_leaves_every_other_slack_error_transient():
     with pytest.raises(SlackApiError) as exc:
         slack.post("#pnl", "hi")
     assert not isinstance(exc.value, PermanentPostError)
+
+
+def test_append_alert_carries_code_ticker_and_extra_payload(fund_db):
+    conn = fund_db
+    from slackkit.outbox import append_alert
+    rowid = append_alert(conn, "unprotected_position", "NVDA 40 exposed",
+                         now_iso="2026-08-24T13:37:54+00:00", ticker="NVDA",
+                         accounting={"symbol": "NVDA", "held": 40})
+    row = conn.execute("SELECT kind, payload FROM events WHERE id=?",
+                       (rowid,)).fetchone()
+    assert row["kind"] == "alert"
+    assert json.loads(row["payload"]) == {
+        "text": "NVDA 40 exposed",
+        "code": "unprotected_position",
+        "ticker": "NVDA",
+        "accounting": {"symbol": "NVDA", "held": 40},
+    }
+
+
+def test_append_alert_omits_absent_ticker_and_clears(fund_db):
+    conn = fund_db
+    from slackkit.outbox import append_alert
+    rowid = append_alert(conn, "pm_timeout", "pm_timeout AAPL — defaulted to hold",
+                         now_iso="2026-08-24T13:36:11+00:00")
+    payload = json.loads(conn.execute(
+        "SELECT payload FROM events WHERE id=?", (rowid,)).fetchone()["payload"])
+    assert "ticker" not in payload and "clears" not in payload
+
+
+def test_append_alert_marks_a_clearing_alert(fund_db):
+    conn = fund_db
+    from slackkit.outbox import append_alert
+    rowid = append_alert(conn, "accounting_shortfall", "NVDA agrees again at 40",
+                         now_iso="2026-08-25T13:00:00+00:00", ticker="NVDA",
+                         clears=True)
+    payload = json.loads(conn.execute(
+        "SELECT payload FROM events WHERE id=?", (rowid,)).fetchone()["payload"])
+    assert payload["clears"] is True
 
 
 def _written_kinds(root: Path) -> set[str]:


### PR DESCRIPTION
Closes the first arrow of the devops loop in `docs/agents/devops.md`:

```
alert fires  →  becomes a GitHub issue  →  standup shows it  →  work  →  closed
     ↑                                                                    │
     └──────────────── EOD sweeps what is still open ────────────────────┘
```

Detection already worked. On 2026-08-21 an unprotected-position alert was raised at 13:38:02Z, projected to Slack the same second, and the run exited non-zero. It sat, because nothing turned it into a tracked item. The same condition fired again on 2026-08-24 — a second consecutive failed trading day.

## Why this is bigger than "call `gh issue create`"

There was no field to key a dedupe label on. All 26 emission sites wrote `{"text": <interpolated free text>}` and nothing else identifying. From the real DBs:

```
"pm_timeout AAPL — defaulted to hold"           three alerts, one root cause,
"pm_timeout MSFT — defaulted to hold"           one second apart      → 3 issues
"pm_timeout NVDA — defaulted to hold"

"ticket c0a9ae97 open after exec turn"          id changes per run → 1 issue per DAY

2026-08-21  "NVDA 80 … covers only 40 of 80 shares…"    same condition,
2026-08-24  "NVDA 40 … has NO live protective order…"   text changed → 2 issues
```

Text-keyed dedupe files duplicates on day one, and deriving a key by parsing that text is forbidden outright by `CLAUDE.md`: *"Do not parse tickers, actions, or sizes out of free text anywhere."* So the identity is minted where the alert is raised.

## What changed

- **`append_alert(conn, code, text, *, now_iso, ticker=None, clears=False, **payload)`** in `slackkit/outbox.py`. Validates nothing and adds no raise surface — it is called inside `except` blocks, and a raise there would turn "something needs review" into a dead trading day (invariant 4).
- **22 codes across 26 sites.** `ticker` is set *only* where the condition is per-position (`gate_error`, `unprotected_position`, `accounting_shortfall`) — never an order id, quantity, seat or exception type, which are unbounded. `pm_timeout` fires per ticker but has one root cause, so it carries no ticker and files one issue, not three.
- **`scripts/check_alert_codes.py`**, wired into `make lint`. A site that forgets its code still alerts and still reaches Slack but is invisible to the filer forever — absence reading as health. The lint makes it a tested invariant rather than a habit.
- **`scripts/file_alert_issues.py`** — stdlib only, argv-driven, same shape as `scripts/audit_day.py`. **Dry run is the default**; filing needs `--apply`. It never closes an issue: a clearing alert comments only, because a hand-fix clears the symptom while the code defect remains.
- `audit_failed` is minted but never files — it is a rollup restating the day's other alerts, and reuses `audit_day.SELF_ALERT_KEY` rather than inventing a second marker.

No trading behaviour changes. Every production edit is at the alert-emission layer, and every alert's text is byte-for-byte unchanged.

## Evidence

`1177 passed, 1 skipped, 7 deselected`. `make lint` clean (purity + alert-code, 91 files).

A green suite cannot show the key survives real interpolated text, so:

- **Real backup** (`fund-2026-08-20.sqlite`, `--since 2026-08-18`): 6 pre-migration rows report `MALFORMED (not filed)`, and both `audit_report` rollups are silently excluded. Rollup suppression verified on production data.
- **Post-migration replay** — the three real droplet rows from 08-21/08-24, text untouched, codes applied as the migrated code assigns them:

```
would file: unprotected_position: NVDA — NVDA 80 was ticketed with a stop at 215.0 … [alert:unprotected_position ticker:NVDA]
would file: accounting_shortfall: NVDA — NVDA: the fund's own orders account for 80 … [alert:accounting_shortfall ticker:NVDA]
```

Three rows → two issues. The two differently-worded NVDA alerts deduped into one carrying both texts (`occurrences in window: 2`), while the genuinely distinct condition stayed separate.

**Honest caveat:** raw pre-migration rows carry no `code`, so they can only ever report as malformed. The replay above is a constructed post-migration view of real text, not raw production output. The dedupe-on-real-text claim is pinned by `test_the_same_condition_with_different_text_files_once`, which uses both verbatim strings.

## The defect final review caught

`unprotected_position` emitted **both** shapes — ticker-keyed for real exposure, unkeyed from four "protection UNVERIFIED" paths. `gh issue list --label X` means *has X*, not *has exactly X*, so once the NVDA-keyed issue existed every later "broker unreachable" alert would have reported `already tracked` and never filed: an unverifiable state hiding behind a known one, which is the exact failure class this PR exists to eliminate.

Fixed by splitting `protection_unverified` out (mirroring the existing `accounting_shortfall`/`accounting_unverified` split) **and** by fixing the test double, which did exact-tuple matching instead of `gh`'s superset semantics — the wrong fake is why no test caught it.

## Not in this PR

- `morning-standup` / `/eod-digest` reading these issues — downstream, specced in `docs/superpowers/specs/2026-08-21-day-bookends-design.md`.
- The `ExecStopPost` heartbeat fix — #47, separate because it ships by droplet deploy.
- **Nothing has been filed to the tracker.** `--apply` has never been run; the first real filing is a human decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)