### PR TITLE
Extend the tamper guard over evals/, and close three bypasses that walked past it

### DIFF
--- a/devloop/README.md
+++ b/devloop/README.md
@@ -29,14 +29,70 @@ checkboxes — there is no other loop state to manage.
 
 Any change → rejected: `specs/` (except ticking `- [ ]`→`- [x]` in
 acceptance.md), `fixtures/`, `charters/`, `scripts/`, `research/`, `fundbt/`,
-`stratgate/`, `calibration/`, `devloop/`, `.github/`, `CLAUDE.md`, `KICKOFF.md`,
-`Makefile`, `pyproject.toml`. Tests existing at the baseline commit
-(`devloop/.baseline`) are immutable; new tests are welcome.
+`stratgate/`, `calibration/`, `devloop/`, `.github/`, `evals/seats/`,
+`CLAUDE.md`, `KICKOFF.md`, `Makefile`, `pyproject.toml`, `.gitignore`,
+`evals/traces/recorded-expected.json`, and the root pytest configuration —
+`pytest.ini`, `setup.cfg`, `tox.ini`, `conftest.py`. None of those four exists
+in the repo, which is the point: the guard reads a creation as a change to a
+protected path. pytest takes its ini options from exactly one file, and the
+order is `pytest.ini` > `pyproject.toml` > `tox.ini` > `setup.cfg` — so of the
+three ini spellings only a root `pytest.ini`, even a bare `[pytest]`,
+displaces `pyproject.toml`'s `[tool.pytest.ini_options]` wholesale.
+`setup.cfg` and `tox.ini` lose to it today and are guarded as defence in
+depth: they are inert only while `pyproject.toml` keeps that table, so
+guarding them is what stops the attack moving sideways to another filename.
+What the displacement costs first is not coverage but the filter: `addopts = -m
+'not live and not eval'` stops applying, so `tests/test_live_smoke.py` (a real
+Alpaca paper round trip, account state, surface and schema pins), the live
+canary in `tests/test_markers.py` and the `eval`-marked PM suite in
+`tests/test_evals_live.py` all join the default run. The damage is graded.
+`make test` goes red first and unconditionally: the canary raises
+`AssertionError` whenever it runs, keys or no keys. Real network is
+unconditional too — the two pin tests carry no credential guard and spawn the
+broker MCP server over `uvx`. Only the money is conditional: the order-placing
+and account-reading smokes skip unless the Alpaca keys (plus `ANTHROPIC_API_KEY`
+for the two that place) are in the environment, so a keyless machine spends
+nothing. The scoped `filterwarnings` (`error::DeprecationWarning:fund.*`) is
+lost on the same line. Shrinking the suite is possible too, but it takes a
+deliberate line: an `--ignore-glob` in that file, or `collect_ignore_glob` in a
+root `conftest.py`.
+
+Tests, eval cases (`evals/cases/`) and traces (`evals/traces/`) existing at
+the baseline commit (`devloop/.baseline`) are immutable; new ones are welcome,
+so a run may still append a whole new label under `evals/traces/`. The whole
+trace directory is guarded, not just `recorded/`. `recorded/` because
+`tests/test_evals_recorded.py` regrades those files and asserts the result
+equals `evals/traces/recorded-expected.json`, so editing the inputs restores
+equality just as well as editing the expectation. Every other committed run
+label — eleven of them — because they are archived measurement evidence,
+what `make eval-report RUN=… BASELINE=…` diffs a new run against. Which label
+is the current comparison point is recorded per seat, in whichever
+`evals/seats/*.yaml` records one: today only `evals/seats/pm.yaml` does, naming
+`postfix3`, while `evals/seats/critic.yaml` names no baseline. Not here; it
+moves as charters change, and a superseded label is still history worth
+keeping. No test reads them; you do. Editing one moves the comparison
+point rather than the result.
+
+`evals/seats/` is frozen against additions too, which makes switching on a new
+invariant (its `invariants:` list) a human-commit step, alongside the measured
+I5 ceilings that sit in the same file. That is intended.
+
+A rename is not a way around any of this: the guard diffs with `--no-renames`,
+so `git mv specs/design.md attic/` reads as a deletion of a protected path.
+Nor is a typechange: replacing a baseline file with a symlink empties it
+without editing a line, and the baseline rule rejects every status but an
+addition rather than a named list of them.
 
 If the worker needs a protected change (e.g. a new dependency in
-`pyproject.toml`), it stops and writes the request to `devloop/NOTES.md`. Make
-the edit yourself, commit, delete `.baseline` if tests/fixtures legitimately
-changed, rerun.
+`pyproject.toml`, a fix to a `fixtures/` vector), it stops and writes the
+request to `devloop/NOTES.md`. Make the edit yourself, commit, rerun — a
+protected path is rejected whatever the baseline says, so there is no
+`.baseline` step for one.
+
+Delete `.baseline` only after committing a change to the baseline-guarded set
+— `tests/`, `evals/cases/`, `evals/traces/`. It re-pins the baseline to the new
+HEAD, which is what makes a test or eval case you just added immutable for the
+next run; leave it and the loop may edit that new file freely.
 
 ## When it halts
 

--- a/devloop/tamper_guard.py
+++ b/devloop/tamper_guard.py
@@ -8,13 +8,36 @@ must never change. Prompt rules alone don't hold under an agent chasing green
 enforceable backpressure instead of a sign.
 
 Policy, checked against `git diff HEAD` + untracked files:
-  1. PROTECTED paths: any change at all -> reject.
+  1. PROTECTED paths (PROTECTED_DIRS + PROTECTED_FILES, so fixtures/ too):
+     any change at all -> reject, additions included.
      Exception: specs/acceptance.md may change ONLY by ticking checkboxes
      (`- [ ]` -> `- [x]`, rest of the line identical).
-  2. tests/, fixtures files that existed at the BASELINE commit: modify or
-     delete -> reject. New test files are welcome.
-  3. Everything else (state/, gate/, orchestrator/, agents/, slackkit/, new
-     tests, devloop/NOTES.md) is the loop's workspace.
+     evals/seats/ is protected against additions too: the measured I5 ceilings
+     and the list of enabled invariants move by human commit only.
+  2. tests/, evals/cases/, evals/traces/ files that existed at the BASELINE
+     commit: anything but an addition -> reject (modify, delete, typechange).
+     Additions are free, so a run may still append a whole new label under
+     evals/traces/.
+     Traces are guarded because freezing evals/traces/recorded-expected.json
+     alone protects one half of an equality: tests/test_evals_recorded.py
+     asserts `got == expected` where `got` is regraded from the trace files
+     under evals/traces/recorded/, so editing those inputs restores equality
+     exactly as well as editing the expectation. The rest of the directory is
+     guarded for a different reason: every other committed run label under
+     evals/traces/ (eleven of them at time of writing) is archived
+     measurement evidence, the thing a later run is diffed against by
+     `make eval-report RUN=… BASELINE=…` (evals/report_cli.py; note that
+     scripts/critic_gate.py also reads evals/traces/<label>, but it grades one
+     label against MIN_DETECTION and has no baseline notion). Which label is
+     the current comparison point is recorded per seat, in whichever
+     evals/seats/*.yaml records one — today that is only evals/seats/pm.yaml,
+     which names postfix3; evals/seats/critic.yaml names no baseline at all.
+     Not here — it moves as charters change, and an older label can be the
+     wrong baseline while still being history worth keeping. No test reads
+     them; a human does. Editing one moves the comparison point instead of the
+     result.
+  3. Everything else (state/, gate/, orchestrator/, agents/, slackkit/, the
+     rest of evals/, new tests, devloop/NOTES.md) is the loop's workspace.
 
 Usage: tamper_guard.py <baseline-ref>   (exit 0 = clean, 1 = violations)
 Zero dependencies. Dev tooling only — not part of the fund runtime.
@@ -31,10 +54,31 @@ ROOT = Path(__file__).resolve().parents[1]
 PROTECTED_DIRS = (
     "specs/", "fixtures/", "charters/", "scripts/", "research/",
     "fundbt/", "stratgate/", "calibration/", "devloop/", ".github/",
+    "evals/seats/",
 )
-PROTECTED_FILES = {"CLAUDE.md", "KICKOFF.md", "Makefile", "pyproject.toml", ".gitignore"}
+# Matched by exact repo-relative path, never by prefix or suffix. The last
+# four do not exist in the repo, which is the point: creating one is the
+# attack, and the guard sees a creation as status "A" and rejects it.
+# Measured with pytest 9.1.1, the precedence is pytest.ini > pyproject.toml >
+# tox.ini > setup.cfg, so only a root pytest.ini actually displaces
+# pyproject.toml's [tool.pytest.ini_options]. setup.cfg and tox.ini are
+# guarded as defence in depth, not because they win: with either alongside,
+# pytest still reports `configfile: pyproject.toml (WARNING: ignoring pytest
+# config in setup.cfg!)` and pyproject's options apply. They are inert only
+# while pyproject.toml keeps that table — and pyproject.toml is itself
+# protected — so guarding all four is what stops the attack moving sideways to
+# another filename. A root conftest.py needs no precedence: it drops tests
+# from collection (collect_ignore_glob) or quietly rewrites what the survivors
+# mean (autouse fixtures, sys.path shims, monkeypatched module attributes).
+# Exact match also keeps evals/conftest.py and tests/conftest.py out of this
+# set.
+PROTECTED_FILES = {"CLAUDE.md", "KICKOFF.md", "Makefile", "pyproject.toml", ".gitignore",
+                   "evals/traces/recorded-expected.json",
+                   "pytest.ini", "setup.cfg", "tox.ini", "conftest.py"}
 CHECKBOX_FILE = "specs/acceptance.md"
-BASELINE_GUARDED_DIRS = ("tests/",)  # existing files immutable, additions free
+# existing files immutable, additions free — see policy rule 2 for why the
+# whole of evals/traces/ is here and not just recorded/.
+BASELINE_GUARDED_DIRS = ("tests/", "evals/cases/", "evals/traces/")
 DEVLOOP_SCRATCH = {"devloop/NOTES.md"}  # agent memory; exempt from PROTECTED
 
 
@@ -63,14 +107,33 @@ def main() -> int:
         print("usage: tamper_guard.py <baseline-ref>", file=sys.stderr)
         return 2
     baseline = sys.argv[1]
-    baseline_files = set(git("ls-tree", "-r", "--name-only", baseline).splitlines())
+    # `-z` here for the same reason as on the two commands below: without it a
+    # non-ASCII baseline path arrives quoted while the diff path arrives raw,
+    # so `path in baseline_files` is silently False and the file is editable.
+    # `-z` NUL-terminates every entry, so the trailing field is empty — drop it
+    # rather than admitting "" as a phantom baseline path.
+    baseline_files = {p for p in
+                      git("ls-tree", "-r", "--name-only", "-z", baseline).split("\0")
+                      if p}
 
     changes: list[tuple[str, str]] = []  # (status, path)
-    for line in git("diff", "HEAD", "--name-status").splitlines():
-        status, path = line.split("\t", 1)[0][:1], line.split("\t")[-1]
-        changes.append((status, path))
-    for path in git("ls-files", "--others", "--exclude-standard").splitlines():
-        changes.append(("A", path))
+    # `-z` on these too: it emits raw bytes instead of git's default
+    # core.quotePath escaping, which renders a non-ASCII path as
+    # `"specs/d\303\253sign.md"` — leading quote and all — and slips past the
+    # prefix tests below; it also survives paths containing a newline.
+    # `--name-status -z` is framed as NUL-separated STATUS, PATH fields (not
+    # tab-separated lines with the tabs swapped out). `--no-renames` keeps it
+    # to exactly those two fields per change: without it a rename is one
+    # 3-field `R100, old, new` record, and testing only the destination lets
+    # `git mv specs/design.md attic/` or `git mv tests/test_x.py tests/_x.py`
+    # move a guarded file out of the way for free. Decomposed into `D old` +
+    # `A new`, the `D` is already a violation.
+    fields = git("diff", "HEAD", "--name-status", "-z", "--no-renames").split("\0")
+    for status, path in zip(fields[::2], fields[1::2]):
+        changes.append((status[:1], path))
+    for path in git("ls-files", "--others", "--exclude-standard", "-z").split("\0"):
+        if path:
+            changes.append(("A", path))
 
     violations: list[str] = []
     for status, path in changes:
@@ -83,10 +146,29 @@ def main() -> int:
         if path in PROTECTED_FILES or path.startswith(PROTECTED_DIRS):
             violations.append(f"{path}: protected path ({status})")
             continue
-        if path.startswith(BASELINE_GUARDED_DIRS) and status in ("M", "D") \
+        # `!= "A"` and not a list of letters: `path in baseline_files` already
+        # proves the file existed at the baseline, so an addition is the only
+        # benign status here and everything else is a change to frozen
+        # evidence. A letter list has to be revised every time git grows a
+        # status — it was `("M", "D")`, which let `T` (typechange) through:
+        # `rm tests/test_x.py; ln -s /dev/null tests/test_x.py` dropped the
+        # file from collection and passed. Reachable here today is just
+        # A/M/D/T (`--no-renames` kills R and C, -B is not passed, and a
+        # conflicted file reports M, A, T or nothing at all depending on the
+        # conflict shape — measured: content `UU` -> `M`; delete/modify `DU`
+        # -> `A`; modify/delete `UD` -> no record at all; typechange `UA` ->
+        # `T` plus an `A` for git's `path~HEAD` sidecar. Never `U`: that letter
+        # only appears in the index-relative forms, `git diff --cached` and
+        # bare `git diff`, not in the `git diff HEAD` this reads), so
+        # `("M", "D", "T")` would be equivalent right now — this form is
+        # default-deny, so the next letter is rejected on arrival instead of
+        # after the next incident.
+        if path.startswith(BASELINE_GUARDED_DIRS) and status != "A" \
                 and path in baseline_files:
-            violations.append(f"{path}: pre-existing test {status}odified — "
-                              "tests may be added, never weakened")
+            verb = {"M": "modified", "D": "deleted",
+                    "T": "replaced (typechange)"}.get(status, f"changed ({status})")
+            violations.append(f"{path}: pre-existing evidence {verb} — tests, "
+                              "eval cases and traces may be added, never weakened")
 
     if violations:
         print("TAMPER GUARD: iteration rejected", file=sys.stderr)

--- a/docs/superpowers/specs/2026-08-24-standup-dispatch-design.md
+++ b/docs/superpowers/specs/2026-08-24-standup-dispatch-design.md
@@ -386,7 +386,13 @@ every repo; in one with no map issue it degrades per §4 Phase 0.
 **B. The `fund` board migration** — one-time, in the `fund` repo:
 
 - create the phase map issue
-- make the 8 open issues its sub-issues, in the order they should be worked
+- make the open issues its sub-issues, in the order they should be worked. **Read the live count from
+  `gh issue list`, never from this document** — it said "the 8 open issues" and was stale inside a day,
+  the 2026-08-25 audit having filed #38–#46 and taken it to 17. A count written into a spec is a
+  measurement with an expiry date on it
+- **not every open issue belongs on the board.** Map order *is* the priority decision, so a map with
+  seventeen children in an invented order is worse than one with five in a real one. Board what is
+  genuinely next and leave the rest in the backlog until it matters
 - add `blocked_by` edges where a real dependency exists
 - mark shipped plans dead with a status header rather than ticking 359 boxes
 - one line in `docs/agents/issue-tracker.md`: claims key on `sessionId` in `map.md`, not on the GitHub

--- a/docs/superpowers/specs/2026-08-24-standup-dispatch-design.md
+++ b/docs/superpowers/specs/2026-08-24-standup-dispatch-design.md
@@ -119,6 +119,13 @@ as much a guess).
   rows in a shape it can interpret; a row written by `get-aligned` or `split-the-plan` is left alone,
   never reinterpreted.
 - **region-declared** — see below; a lane with no declared region is excluded here, not carried forward
+- **not waiting on a human** — no label marking it as awaiting a ruling (`needs-decision`, or the
+  repo's equivalent). `blocked_by` models **issue-to-issue edges only**, so an issue blocked on a
+  decision nobody has made reports `blocked_by == 0` and reads as ready. Measured 2026-08-25 on the
+  first board built for `fund`: #38 and #42 both carried `needs-decision` and both reported
+  `blocked_by == 0`, and #38 was the second candidate lane the first dispatch would have handed out.
+  Dispatching such a lane does not get the decision made; it gets a seat to guess at it. Phase 3
+  surfaces it as a flag to the human instead, naming the decision it waits on
 
 in map order. These are the **candidate lanes**.
 

--- a/docs/superpowers/specs/2026-08-24-standup-dispatch-design.md
+++ b/docs/superpowers/specs/2026-08-24-standup-dispatch-design.md
@@ -390,11 +390,16 @@ every repo; in one with no map issue it degrades per §4 Phase 0.
   `gh issue list`, never from this document** — it said "the 8 open issues" and was stale inside a day,
   the 2026-08-25 audit having filed #38–#46 and taken it to 17. A count written into a spec is a
   measurement with an expiry date on it
-- **not every open issue belongs on the board.** Map order *is* the priority decision, so a map with
-  seventeen children in an invented order is worse than one with five in a real one. Board what is
-  genuinely next and leave the rest in the backlog until it matters
+- **how many to board is a live question, and it was ruled on.** Map order *is* the priority decision,
+  so a map with seventeen children in an invented order is worth less than one with five in a real
+  one. That fork was put to Benjamin on 2026-08-25 and he chose to board the full set in a proposed
+  severity-then-dependency order. Recorded because it is a decision, not a default — a later board
+  should re-ask rather than inherit it
 - add `blocked_by` edges where a real dependency exists
-- mark shipped plans dead with a status header rather than ticking 359 boxes
+- retire shipped plans with a status header rather than ticking 359 boxes. **State the evidence, not
+  the verdict**: which artifact is on master, and which issue tracks whatever remains. Two of the
+  eight had live follow-ups and one had a session working it, so "dead" would have been false while
+  the header still did the job of keeping anyone from reading the checkboxes as state
 - one line in `docs/agents/issue-tracker.md`: claims key on `sessionId` in `map.md`, not on the GitHub
   assignee
 

--- a/tests/test_tamper_guard.py
+++ b/tests/test_tamper_guard.py
@@ -1,0 +1,381 @@
+"""devloop/tamper_guard.py — what the build loop may and may not touch.
+
+Driven end-to-end against a throwaway git repo with the real script copied in,
+because the guard's answer depends on git's own status letters: a new eval
+trace arrives as an *untracked* file (`ls-files --others`), not as a diff, and
+that is the path an over-broad glob breaks.
+"""
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+GUARD = ROOT / "devloop" / "tamper_guard.py"
+
+# Ignore the developer's global/system git config so a personal excludesfile
+# can't hide an untracked file from the guard mid-test.
+ENV = {**os.environ,
+       "GIT_CONFIG_GLOBAL": os.devnull, "GIT_CONFIG_SYSTEM": os.devnull,
+       "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+       "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+
+BASELINE = (
+    ".gitignore",
+    "evals/cases/pm/a01.yaml",
+    "evals/cases/pm/ä01.yaml",
+    "evals/cases.py",
+    "evals/conftest.py",
+    "evals/seats/pm.yaml",
+    "evals/seatsmap.py",
+    "evals/runner.py",
+    "evals/traces/recorded-expected.json",
+    "evals/traces/control/abc123/a01/1.json",
+    "specs/design.md",
+    "specs/dësign.md",
+    "tests/test_thing.py",
+    "tests/tëst_thing.py",
+    "gate/risk.py",
+)
+
+
+def _write(repo: Path, path: str, text: str) -> None:
+    f = repo / path
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text(text)
+
+
+def _typechange(repo: Path, path: str) -> None:
+    """Swap a regular file for a symlink. git reports this as status `T`, not
+    `M` or `D`, and a symlink to /dev/null collects as an empty file."""
+    f = repo / path
+    f.unlink()
+    f.symlink_to(os.devnull)
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(repo), *args], check=True, env=ENV,
+                   capture_output=True, text=True)
+
+
+def _repo(tmp_path: Path) -> Path:
+    """A committed baseline tree with the real guard installed at devloop/."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    for path in BASELINE:
+        _write(repo, path, "baseline\n")
+    (repo / "devloop").mkdir(exist_ok=True)
+    shutil.copy(GUARD, repo / "devloop" / "tamper_guard.py")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "baseline")
+    return repo
+
+
+def _run(repo: Path, baseline: str = "HEAD") -> subprocess.CompletedProcess:
+    """`baseline` is HEAD for most tests; the loop pins it to the run's first
+    commit and lets HEAD advance, which only matters where a test commits."""
+    return subprocess.run(
+        [sys.executable, str(repo / "devloop" / "tamper_guard.py"), baseline],
+        capture_output=True, text=True, env=ENV)
+
+
+def _reject(repo: Path, path: str, baseline: str = "HEAD") -> None:
+    proc = _run(repo, baseline)
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    assert path in proc.stderr, proc.stderr
+
+
+def _allow(repo: Path, baseline: str = "HEAD") -> None:
+    proc = _run(repo, baseline)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
+def test_an_untouched_tree_is_clean(tmp_path):
+    _allow(_repo(tmp_path))
+
+
+# --- evals/cases/: baseline files immutable, additions free ---------------
+
+def test_editing_an_existing_eval_case_is_rejected(tmp_path):
+    """The cheapest way to turn a red case green is to edit its expectation."""
+    repo = _repo(tmp_path)
+    _write(repo, "evals/cases/pm/a01.yaml", "expects: whatever passes\n")
+    _reject(repo, "evals/cases/pm/a01.yaml")
+
+
+def test_deleting_an_existing_eval_case_is_rejected(tmp_path):
+    repo = _repo(tmp_path)
+    (repo / "evals/cases/pm/a01.yaml").unlink()
+    _reject(repo, "evals/cases/pm/a01.yaml")
+    # the message has to name what happened; it once rendered "Dodified".
+    assert "deleted" in _run(repo).stderr
+
+
+def test_adding_a_new_eval_case_is_allowed(tmp_path):
+    """Adding a case must stay cheap."""
+    repo = _repo(tmp_path)
+    _write(repo, "evals/cases/pm/b09.yaml", "id: b09\n")
+    _allow(repo)
+
+
+# --- evals/seats/: frozen outright ---------------------------------------
+
+def test_editing_a_seat_ceiling_is_rejected(tmp_path):
+    """max_turns / max_cost_usd are measured numbers; human commit only."""
+    repo = _repo(tmp_path)
+    _write(repo, "evals/seats/pm.yaml", "max_turns: 99\n")
+    _reject(repo, "evals/seats/pm.yaml")
+
+
+def test_adding_a_seat_file_is_rejected(tmp_path):
+    """Unlike cases, seats are frozen against additions too — switching on a
+    new invariant is a human-commit step."""
+    repo = _repo(tmp_path)
+    _write(repo, "evals/seats/analyst.yaml", "seat: analyst\n")
+    _reject(repo, "evals/seats/analyst.yaml")
+
+
+# --- evals/traces/: baseline traces frozen, new runs writable ------------
+
+def test_editing_the_recorded_expectations_is_rejected(tmp_path):
+    repo = _repo(tmp_path)
+    _write(repo, "evals/traces/recorded-expected.json", "{}\n")
+    _reject(repo, "evals/traces/recorded-expected.json")
+
+
+def test_re_creating_the_recorded_expectations_is_rejected(tmp_path):
+    """Additions under evals/traces/ are otherwise free, so the baseline guard
+    cannot cover this one: with the file gone from HEAD, writing a fresh
+    expectation is an ADDITION. Only the PROTECTED_FILES entry stops it."""
+    repo = _repo(tmp_path)
+    _git(repo, "rm", "-q", "evals/traces/recorded-expected.json")
+    _git(repo, "commit", "-qm", "expectations dropped")
+    _write(repo, "evals/traces/recorded-expected.json", '{"a01": "pass"}\n')
+    _reject(repo, "evals/traces/recorded-expected.json")
+
+
+def test_editing_an_existing_trace_is_rejected(tmp_path):
+    """`got == expected` has two sides; freezing the expectation alone leaves
+    the graded-from inputs as the cheaper way to restore equality."""
+    repo = _repo(tmp_path)
+    _write(repo, "evals/traces/control/abc123/a01/1.json", '{"turns": 1}\n')
+    _reject(repo, "evals/traces/control/abc123/a01/1.json")
+
+
+def test_a_new_trace_file_is_allowed(tmp_path):
+    """The regression that matters: runs append a whole new label here every
+    iteration, and it arrives untracked. Guarding traces must not wedge that."""
+    repo = _repo(tmp_path)
+    _write(repo, "evals/traces/somerun/deadbee/a01/1.json", '{"turns": 4}\n')
+    _allow(repo)
+
+
+def test_the_rest_of_evals_stays_the_workspace(tmp_path):
+    """Only cases/, seats/, traces/ are guarded — and by directory, not by
+    prefix: `evals/cases.py` and `evals/seatsmap.py` must stay editable even
+    though they start with `evals/cases` and `evals/seats`."""
+    repo = _repo(tmp_path)
+    _write(repo, "evals/cases.py", "# refactored\n")
+    _write(repo, "evals/seatsmap.py", "# refactored\n")
+    _allow(repo)
+
+
+def test_a_non_root_conftest_is_not_rejected(tmp_path):
+    """`conftest.py` is protected by exact path, so only the root one. Loosen
+    that to a suffix match and evals/conftest.py stops being editable."""
+    repo = _repo(tmp_path)
+    _write(repo, "evals/conftest.py", "# fixture tweak\n")
+    _allow(repo)
+
+
+# --- the pytest configuration surface ------------------------------------
+
+def test_creating_a_root_pytest_ini_is_rejected(tmp_path):
+    """It overrides pyproject.toml's [tool.pytest.ini_options]; a testpaths or
+    ignore line there drops the eval suites from collection."""
+    repo = _repo(tmp_path)
+    _write(repo, "pytest.ini", "[pytest]\ntestpaths = tests/unit\n")
+    _reject(repo, "pytest.ini")
+
+
+def test_creating_a_root_conftest_is_rejected(tmp_path):
+    """collect_ignore_glob removes tests outright; an autouse fixture or a
+    sys.path shim changes what the survivors mean."""
+    repo = _repo(tmp_path)
+    _write(repo, "conftest.py", 'collect_ignore_glob = ["*evals*"]\n')
+    _reject(repo, "conftest.py")
+
+
+def test_creating_a_root_setup_cfg_is_rejected(tmp_path):
+    """Defence in depth, not an override: measured on pytest 9.1.1 the order is
+    pytest.ini > pyproject.toml > tox.ini > setup.cfg, so [tool:pytest] here
+    loses to pyproject.toml and pytest says so ("WARNING: ignoring pytest
+    config in setup.cfg!"). It is inert only while pyproject.toml keeps its
+    [tool.pytest.ini_options] table — guarded so the attack cannot move
+    sideways to this filename if that ever stops being true."""
+    repo = _repo(tmp_path)
+    _write(repo, "setup.cfg", "[tool:pytest]\naddopts = -k not_eval\n")
+    _reject(repo, "setup.cfg")
+
+
+def test_creating_a_root_tox_ini_is_rejected(tmp_path):
+    """Same standing as setup.cfg: [pytest] in tox.ini also loses to
+    pyproject.toml, and is guarded for the same sideways-move reason. All four
+    filenames, so only pytest.ini is a live override and none is a spare."""
+    repo = _repo(tmp_path)
+    _write(repo, "tox.ini", "[pytest]\ntestpaths = tests/unit\n")
+    _reject(repo, "tox.ini")
+
+
+# --- .gitignore: it decides what the guard can even see -------------------
+
+def test_editing_the_gitignore_is_rejected(tmp_path):
+    """The guard finds new files with `ls-files --others --exclude-standard`,
+    so an ignore rule is a blind spot it would honour."""
+    repo = _repo(tmp_path)
+    _write(repo, ".gitignore", "evals/traces/\n")
+    _reject(repo, ".gitignore")
+
+
+# --- renames and non-ASCII paths -----------------------------------------
+
+def test_renaming_a_protected_path_is_rejected(tmp_path):
+    """`--name-status` reports a rename as one record whose last field is the
+    destination; read that alone and `git mv` walks anything out of scope.
+    Pinned so `--no-renames` cannot be tidied away."""
+    repo = _repo(tmp_path)
+    (repo / "attic").mkdir()
+    _git(repo, "mv", "specs/design.md", "attic/design.md")
+    _reject(repo, "specs/design.md")
+    # `--no-renames` is what turns the move into a deletion of the source;
+    # an `(R)` here means the flag went missing.
+    assert "specs/design.md: protected path (D)" in _run(repo).stderr
+
+
+def test_renaming_a_pre_existing_test_out_of_collection_is_rejected(tmp_path):
+    """The weaponised form: a red test renamed to a non-`test_` name is gone
+    from collection without a single line of it being edited."""
+    repo = _repo(tmp_path)
+    _git(repo, "mv", "tests/test_thing.py", "tests/_thing_helpers.py")
+    _reject(repo, "tests/test_thing.py")
+
+
+# --- typechange: the third status-letter bypass ---------------------------
+
+def test_typechanging_a_pre_existing_test_is_rejected(tmp_path):
+    """`rm tests/test_thing.py; ln -s /dev/null tests/test_thing.py` empties a
+    red test without editing a line of it, and git calls that `T`, not `M`.
+    Pinned so the baseline clause cannot go back to a list of status letters."""
+    repo = _repo(tmp_path)
+    _typechange(repo, "tests/test_thing.py")
+    _reject(repo, "tests/test_thing.py")
+    assert "typechange" in _run(repo).stderr
+
+
+def test_typechanging_an_existing_eval_case_is_rejected(tmp_path):
+    repo = _repo(tmp_path)
+    _typechange(repo, "evals/cases/pm/a01.yaml")
+    _reject(repo, "evals/cases/pm/a01.yaml")
+
+
+def test_typechanging_an_existing_trace_is_rejected(tmp_path):
+    repo = _repo(tmp_path)
+    _typechange(repo, "evals/traces/control/abc123/a01/1.json")
+    _reject(repo, "evals/traces/control/abc123/a01/1.json")
+
+
+def test_additions_under_the_guarded_dirs_survive_the_typechange_fix(tmp_path):
+    """The predicate is `status != "A"`, so the one status that must stay free
+    is the addition. All three guarded directories at once, because widening
+    from ("M", "D") is exactly the change that could have caught them."""
+    repo = _repo(tmp_path)
+    _write(repo, "tests/test_added.py", "def test_x(): pass\n")
+    _write(repo, "evals/cases/pm/z99.yaml", "id: z99\n")
+    _write(repo, "evals/traces/newrun/deadbee/a01/1.json", '{"turns": 2}\n')
+    _allow(repo)
+
+
+def test_a_non_ascii_protected_path_is_rejected(tmp_path):
+    """core.quotePath is on by default, so git renders this path as
+    `"specs/d\\303\\253sign.md"` — a leading quote defeats startswith()."""
+    repo = _repo(tmp_path)
+    _write(repo, "specs/dësign.md", "rewritten\n")
+    proc = _run(repo)
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    assert "sign.md" in proc.stderr and '"specs/' not in proc.stderr, proc.stderr
+
+
+def test_a_non_ascii_untracked_protected_path_is_rejected(tmp_path):
+    """Same escaping applies to `ls-files --others`."""
+    repo = _repo(tmp_path)
+    _write(repo, "specs/nöuveau.md", "smuggled\n")
+    proc = _run(repo)
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    assert "uveau.md" in proc.stderr and '"specs/' not in proc.stderr, proc.stderr
+
+
+def test_a_non_ascii_pre_existing_test_is_rejected(tmp_path):
+    """The protected-path tests above exit at `startswith(PROTECTED_DIRS)` and
+    never reach `baseline_files`. This is the branch that does: the baseline
+    listing has to be unquoted too, or the membership test is silently False
+    and a red test with an accented name is free to become `assert True`."""
+    repo = _repo(tmp_path)
+    _write(repo, "tests/tëst_thing.py", "assert True\n")
+    proc = _run(repo)
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    # matched on the ASCII tail: the filesystem may hand the accent back in a
+    # different unicode normalisation than this source file uses.
+    assert "st_thing.py: pre-existing evidence modified" in proc.stderr
+    assert '"tests/' not in proc.stderr, proc.stderr
+
+
+def test_deleting_a_non_ascii_eval_case_is_rejected(tmp_path):
+    """Same branch, the delete side, under the other guarded directory."""
+    repo = _repo(tmp_path)
+    (repo / "evals/cases/pm/ä01.yaml").unlink()
+    proc = _run(repo)
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    assert "01.yaml: pre-existing evidence deleted" in proc.stderr
+    assert '"evals/' not in proc.stderr, proc.stderr
+
+
+# --- pre-existing behaviour still holds ----------------------------------
+
+def test_a_specs_change_is_still_rejected(tmp_path):
+    repo = _repo(tmp_path)
+    _write(repo, "specs/design.md", "rewritten\n")
+    _reject(repo, "specs/design.md")
+
+
+def test_editing_a_pre_existing_test_is_still_rejected(tmp_path):
+    repo = _repo(tmp_path)
+    _write(repo, "tests/test_thing.py", "assert True\n")
+    _reject(repo, "tests/test_thing.py")
+
+
+def test_a_new_test_is_still_allowed(tmp_path):
+    repo = _repo(tmp_path)
+    _write(repo, "tests/test_new.py", "def test_x(): pass\n")
+    _allow(repo)
+
+
+def test_a_test_the_run_wrote_itself_stays_editable(tmp_path):
+    """What `path in baseline_files` buys: a test added by an earlier green
+    iteration is tracked in HEAD but absent from the baseline tree, so the run
+    may keep working on it. Drop that clause and the loop cannot edit its own
+    output — every iteration after the first would be rejected."""
+    repo = _repo(tmp_path)
+    _git(repo, "tag", "base")
+    _write(repo, "tests/test_new.py", "def test_x(): pass\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "iteration 1")
+    _write(repo, "tests/test_new.py", "def test_x(): assert compute() == 3\n")
+    _allow(repo, "base")
+
+
+def test_runtime_code_is_still_the_workspace(tmp_path):
+    repo = _repo(tmp_path)
+    _write(repo, "gate/risk.py", "# implemented\n")
+    _allow(repo)


### PR DESCRIPTION
Closes #46.

## ⚠️ Read this first: three commits here are not mine

`origin/master` is **3 commits behind local `master`**, so GitHub computes this PR against the older base and sweeps in unpushed work belonging to other sessions:

| commit | mine? |
|---|---|
| `7317a61` fix: eval cases, traces and the pytest config join what the build loop cannot touch | **yes — this lane** |
| `11dcb9a` docs: record the board-size ruling and the weaker plan-retirement claim | no |
| `77a9608` docs: a hardcoded issue count is a measurement with an expiry date | no |
| `aed6e97` docs: blocked_by cannot see a lane blocked on a person | no |

`docs/superpowers/specs/2026-08-24-standup-dispatch-design.md` appears in the diff for the same reason and is **not** part of this change. This lane touches exactly three files: `devloop/tamper_guard.py`, `devloop/README.md`, and the new `tests/test_tamper_guard.py`.

Pushing local `master` to `origin` makes the extra three disappear from this diff. I did not do that — they are other sessions' unpushed commits and not mine to publish.

## What this fixes

`devloop/tamper_guard.py` is the repo's only structural defence against an agent editing the artifacts that *define* correctness rather than fixing its own code. `evals/` was absent from every one of its lists. Against master's guard, a plain edit — no rename, no trick — of `evals/seats/pm.yaml`, `evals/traces/recorded-expected.json` or `evals/cases/pm/a01.yaml` each exits 0. Turning a red eval case green by rewriting its expectation was the cheapest move on the board.

Coverage added:

| path | rule |
|---|---|
| `evals/cases/`, `evals/traces/` | baseline-guarded — existing files immutable, **additions free** (a run still appends a whole new trace label) |
| `evals/seats/` | fully protected — the measured I5 ceilings and the enabled-invariant list move by human commit only |
| `evals/traces/recorded-expected.json` | protected **by name**, so it cannot be re-created after a delete |

`evals/traces/` is guarded whole for two distinct reasons, and the commit message keeps them separate: `recorded/` because `tests/test_evals_recorded.py` asserts `got == expected` over those files, so freezing one side of an equality leaves the other as the cheaper edit; the other eleven committed labels because they are archived measurement evidence that `make eval-report` diffs against.

## Three bypasses closed, all previously exit 0

Found by adversarial review, each demonstrated before and after:

- **Rename.** `git diff --name-status` reports a rename as one record whose last field is the destination, so the old parser judged the destination and discarded the source. `git mv specs/design.md attic/`, `charters/pm.md`, `CLAUDE.md`, and worst — `git mv tests/test_thing.py tests/_thing_helpers.py`, removing a pre-existing red test from collection with no line of it edited. **This hole predates this lane and reached every protected path in the repo.**
- **Typechange.** `--no-renames` decomposes `R`; it says nothing about `T`. `rm f; ln -s /dev/null f` reports `T`, exits 0, and pytest then collects nothing from the file. The baseline clause tested `status in ("M","D")`, so extending it to `evals/` would have carried the blind spot there too. Now rejects every status but `A`.
- **Non-ASCII quoting.** `core.quotePath` yields `"specs/d\303\253sign.md"`, leading quote included, defeating every prefix and set test. All three git calls now read NUL-separated output — including `ls-tree`, which an earlier round of this branch missed, leaving a live bypass where the membership test was silently false.

Plus the root pytest configuration (`pytest.ini`, `setup.cfg`, `tox.ini`, `conftest.py`) protected **before it exists** — a creation registers as status `A`. A bare root `pytest.ini` displaces `pyproject.toml` and takes collection from 1213-of-1220 to 1220 with nothing deselected; the seven that return include an unconditional-failure canary and the live paper smokes.

## Tests

`tests/test_tamper_guard.py`, 32 tests, drives the real script end to end against a throwaway git repo — the answers depend on git's own status letters, and a new trace arrives untracked rather than as a diff. Collection goes 1181 → 1213.

Every fix is mutation-tested: break it, name the test that dies. Two mutants survive and are documented rather than hidden — one is behaviourally indistinguishable from the shipped predicate, the other is the coverage gap escalated as #78.

**One pre-existing failure is unrelated:** `tests/test_deps_lock.py::test_installed_versions_match_the_lock` fails from local venv drift (`claude-agent-sdk` 0.2.116 installed vs 0.2.139 locked). This branch touches neither `requirements.lock` nor `pyproject.toml`; it reproduces on a clean tree. Full suite otherwise: **1211 passed, 1 skipped**.

## Filed, not fixed here

Deliberately out of scope, each with the evidence in its body: **#51** (binding the guard to a PR is a policy question about what a human may commit), **#68** (three separate levers — `git commit`, `--assume-unchanged`, `.git/info/exclude` — that blind the guard entirely; two of them survive the fix that issue was opened around), **#76** (case-variant filenames on a case-insensitive filesystem), **#77** (`checkbox_only_diff` untested in both directions), **#78** (`needs-decision`: may the loop re-create a baseline-guarded file, and what should `baseline_files` be a snapshot of). **#67** is owned by the `evals/` lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
