### PR TITLE
fix: purity lint matches resolved bindings, not source spellings (#43)

### DIFF
--- a/scripts/check_purity.py
+++ b/scripts/check_purity.py
@@ -1,25 +1,35 @@
 #!/usr/bin/env python3
 """Purity lint (CI-enforced; see CLAUDE.md invariant 3 and specs/design.md §4).
 
-Three checks over the no-LLM business-logic packages:
-  1. Forbidden imports: gate/, stratgate/, fundbt/, calibration/, orchestrator/,
-     state/ and market/ must not import LLM/SDK/Slack code (claude_agent_sdk,
-     anthropic, slack_bolt, slack_sdk) nor anything from agents/. Dynamic
-     imports (importlib.import_module, __import__) are forbidden outright: a
-     pure package has to stay statically analyzable, and the argument may be
-     computed ("claude" + "_agent_sdk").
-  2. No wall clock: datetime.now()/utcnow(), date.today(), time.sleep()/time()/
-     monotonic()/perf_counter(), asyncio.sleep() — time is an injected Clock
-     (design.md §4 Testability).
-  3. slackkit/__init__.py stays import-free. slackkit is in neither list above:
-     orchestrator legitimately imports slackkit.outbox, and slackkit/real.py
-     legitimately holds slack_sdk. The empty __init__.py is the entire mechanism
-     keeping the two apart, and slackkit/real.py:1-3 says so.
+Checks over the no-LLM business-logic packages listed in PURE_PACKAGES:
 
-Calls are matched on the *binding a name resolves to*, not on its source
-spelling, so `import time as _t; _t.sleep(1)` and `from time import sleep;
-sleep(1)` are caught while a local or parameter named `time`/`datetime` — and
-above all the injected `self._clock.now()` — are not.
+  1. Forbidden imports: LLM/SDK/Slack code (claude_agent_sdk, anthropic,
+     slack_bolt, slack_sdk), anything from agents/, and `slackkit.real`.
+     Matching is dotted-prefix, not root-module: `slackkit.real.helpers` is
+     forbidden, `slackkit.realtime` and `slackkit.outbox` are not.
+  2. No dynamic imports: importlib.import_module() and __import__(). A pure
+     package has to stay statically analyzable, and the argument may be
+     computed ("claude" + "_agent_sdk"), so the call itself is the violation.
+  3. No wall clock: datetime.now()/utcnow()/today(), date.today(), and the
+     time module's clock and sleep functions — time is an injected Clock
+     (design.md §4 Testability).
+  4. slackkit/__init__.py stays import-free, so `import slackkit` executes
+     nothing (slackkit/real.py:1-3). That file is NOT on its own sufficient to
+     keep slack_sdk out of linted code — it never stops `from slackkit.real
+     import RealSlack`. Rule 1's `slackkit.real` entry is what stops that, and
+     `slackkit/` is itself linted as a pure package with real.py excluded,
+     because real.py is the one file that is supposed to hold the SDK.
+
+Matching is on *resolved bindings*, not source spellings, and on *references*,
+not only calls:
+
+  * `import time as _t; _t.sleep(1)` and `from time import sleep; sleep(1)`
+    resolve to time.sleep and are caught.
+  * `_sleep = time.sleep`, `{"ts": datetime.utcnow}` and `getattr(time,
+    "sleep")` are caught without ever being called — capturing the callable is
+    the same banned dependency as calling it.
+  * A parameter or local named `time`/`datetime` shadows the module and is
+    left alone, which is what keeps the injected `self._clock.now()` green.
 
 Zero dependencies. Exit 1 on any violation. Directories that don't exist yet
 (e.g. gate/ before Phase 2) are skipped — add code, inherit the check.
@@ -34,43 +44,89 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 
 PURE_PACKAGES = ["gate", "stratgate", "fundbt", "calibration", "orchestrator",
-                 "state", "market"]
-FORBIDDEN_IMPORTS = ("claude_agent_sdk", "anthropic", "slack_bolt", "slack_sdk", "agents")
-# Fully-qualified callables that read the wall clock or block the thread.
-FORBIDDEN_CALL_TARGETS = {
-    "datetime.datetime.now", "datetime.datetime.utcnow", "datetime.date.today",
-    "time.sleep", "time.time", "time.monotonic", "time.perf_counter",
+                 "state", "market", "slackkit"]
+# Paths (relative to ROOT, posix) inside a pure package that are exempt.
+EXCLUDED_FILES = {"slackkit/real.py"}
+# Matched as dotted prefixes: "agents" covers agents.runtime, and
+# "slackkit.real" covers slackkit.real.helpers but not slackkit.realtime.
+FORBIDDEN_IMPORTS = ("claude_agent_sdk", "anthropic", "slack_bolt", "slack_sdk",
+                     "agents", "slackkit.real")
+# Fully-qualified names that read the wall clock or block the thread. Flagged
+# on *reference*, not just on call.
+FORBIDDEN_REFS = {
+    "datetime.datetime.now", "datetime.datetime.utcnow", "datetime.datetime.today",
+    "datetime.date.today",
+    "time.sleep", "time.time", "time.time_ns", "time.monotonic",
+    "time.monotonic_ns", "time.perf_counter", "time.perf_counter_ns",
+    "time.process_time", "time.localtime", "time.gmtime",
     "asyncio.sleep",
 }
-# Fully-qualified callables that import at runtime, defeating this lint.
-DYNAMIC_IMPORT_TARGETS = {"importlib.import_module", "importlib.__import__", "__import__"}
+# Fully-qualified names that import at runtime, defeating this lint entirely.
+DYNAMIC_IMPORT_REFS = {"importlib.import_module", "importlib.__import__",
+                       "builtins.__import__", "__import__"}
 
-# Nodes that open a new binding scope; their bodies are scanned separately.
-_SCOPE_NODES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef)
+# Nodes that open a new binding scope. Comprehensions are included: their
+# targets are invisible outside them, so folding one into the parent would let
+# `[None for time in ()]` silence a whole module.
+_SCOPE_NODES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef,
+                ast.ListComp, ast.SetComp, ast.DictComp, ast.GeneratorExp)
 
 
-def _dotted(node: ast.expr) -> str | None:
-    """`a.b.c` as a Name/Attribute chain -> "a.b.c"; anything else -> None."""
+def _forbidden_import(name: str) -> str | None:
+    """Dotted-prefix match against FORBIDDEN_IMPORTS.
+
+    Boundary-aware on purpose: a raw `name.startswith("slackkit.real")` would
+    also redden `slackkit.realtime`. Root-module comparison is the opposite
+    error — it can never match a dotted entry at all, which would leave
+    "slackkit.real" sitting in the tuple looking like a rule and matching
+    nothing, forever.
+    """
+    for entry in FORBIDDEN_IMPORTS:
+        if name == entry or name.startswith(entry + "."):
+            return entry
+    return None
+
+
+def _dotted(node: ast.AST) -> str | None:
+    """A Name/Attribute chain as "a.b.c"; anything else -> None.
+
+    `getattr(x, "lit")` is folded in as a spelling of `x.lit`, so a string
+    lookup is not a way around an attribute match.
+    """
     if isinstance(node, ast.Name):
         return node.id
     if isinstance(node, ast.Attribute):
         base = _dotted(node.value)
         return f"{base}.{node.attr}" if base else None
+    if (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+            and node.func.id == "getattr" and len(node.args) >= 2
+            and isinstance(node.args[1], ast.Constant)
+            and isinstance(node.args[1].value, str)):
+        base = _dotted(node.args[0])
+        return f"{base}.{node.args[1].value}" if base else None
     return None
 
 
-def _resolve(dotted: str, bindings: dict[str, str]) -> str | None:
-    """Rewrite a dotted expression through the local name -> module bindings."""
+def _candidates(dotted: str, bindings: dict[str, str | None],
+                stars: list[str]) -> list[str]:
+    """Fully-qualified names `dotted` could refer to in this scope.
+
+    A name present in `bindings` with value None is bound to something
+    unresolvable (a parameter, a local, a relative import) — it resolves to
+    nothing and must NOT fall through to the star-import guess.
+    """
     head, _, rest = dotted.partition(".")
-    target = bindings.get(head)
-    if target is None:
-        return None
-    return f"{target}.{rest}" if rest else target
+    if head in bindings:
+        base = bindings[head]
+        if base is None:
+            return []
+        return [f"{base}.{rest}" if rest else base]
+    return [f"{module}.{dotted}" for module in stars]
 
 
 def _import_bindings(node: ast.Import | ast.ImportFrom) -> dict[str, str | None]:
     """{local name: fully-qualified target}. None means "bound to something
-    unresolvable" — a relative import — which must clear any inherited binding
+    unresolvable" — a relative import — which must clear an inherited binding
     of that name rather than leave it standing."""
     out: dict[str, str | None] = {}
     if isinstance(node, ast.Import):
@@ -86,14 +142,17 @@ def _import_bindings(node: ast.Import | ast.ImportFrom) -> dict[str, str | None]
     else:
         module = node.module or ""
         for alias in node.names:
+            if alias.name == "*":
+                continue  # binds names, but not the literal name "*"
             name = alias.asname or alias.name
             out[name] = f"{module}.{alias.name}" if module else alias.name
     return out
 
 
 def _bound_names(node: ast.AST) -> set[str]:
-    """Names this node binds by means other than an import: assignment,
-    parameter, def/class, `except ... as`, comprehension or `with` target."""
+    """Names this node binds by means other than an import: assignment, walrus,
+    parameter, def/class, `except ... as`, `with ... as`, comprehension or
+    match/case capture."""
     if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store):
         return {node.id}
     if isinstance(node, ast.arg):
@@ -102,50 +161,107 @@ def _bound_names(node: ast.AST) -> set[str]:
         return {node.name}
     if isinstance(node, ast.ExceptHandler) and node.name:
         return {node.name}
+    if isinstance(node, (ast.MatchAs, ast.MatchStar)) and node.name:
+        return {node.name}
+    if isinstance(node, ast.MatchMapping) and node.rest:
+        return {node.rest}
     return set()
 
 
 def _scope_nodes(node: ast.AST):
-    """Descendants of `node` belonging to its own scope — nested defs, lambdas
-    and classes are yielded but not descended into."""
+    """Descendants of `node` belonging to its own scope. Nested scopes are
+    yielded but not descended into; they are scanned separately."""
     for child in ast.iter_child_nodes(node):
         yield child
         if not isinstance(child, _SCOPE_NODES):
             yield from _scope_nodes(child)
 
 
-def _scan_scope(node: ast.AST, inherited: dict[str, str], path: Path,
-                errors: list[str]) -> None:
+def _scan_scope(node: ast.AST, inherited: dict[str, str | None],
+                inherited_stars: list[str], path: Path, errors: list[str]) -> None:
     own = list(_scope_nodes(node))
     bindings = dict(inherited)
+    stars = list(inherited_stars)
+
+    imported: dict[str, str | None] = {}
+    for child in own:
+        if isinstance(child, ast.ImportFrom) and any(a.name == "*" for a in child.names):
+            if child.level == 0 and child.module:
+                stars.append(child.module)
+        if isinstance(child, (ast.Import, ast.ImportFrom)):
+            imported.update(_import_bindings(child))
+
+    rebound: dict[str, int] = {}
     for child in own:
         if isinstance(child, (ast.Import, ast.ImportFrom)):
-            for name, target in _import_bindings(child).items():
-                if target is None:
-                    bindings.pop(name, None)
-                else:
-                    bindings[name] = target
-    # A local binding of the same name shadows the module: `def elapsed(time)`
-    # is a caller's Timer, not the stdlib.
+            continue
+        for name in _bound_names(child):
+            rebound.setdefault(name, getattr(child, "lineno", 0))
+
+    bindings.update(imported)
+
+    # An import binding rebound in the SAME scope is incoherent code, and
+    # popping the name instead would make `import time` + `if False: time =
+    # None` a silent, condition-independent off switch for the whole scope. So
+    # it is a loud error, not a shadow.
+    #
+    # Deliberately does not fire on a rebinding in a NESTED scope: a
+    # function-local assignment makes the name local for that whole body, so a
+    # use there resolves to the local object or raises UnboundLocalError —
+    # never silently to the stdlib module. That exemption is not a hole in the
+    # collision rule. Where the local object is itself a forbidden binding, the
+    # reference check below catches it as a callable capture instead, which is
+    # the family it belongs to: `_s = time.sleep`, or `dt = datetime` followed
+    # by `dt.datetime.now()`, are both flagged there.
+    #
+    # What neither rule reaches is a capture whose source is not statically
+    # resolvable — `datetime = some_free_name`, or a clock handed in as a
+    # parameter. That is the ordinary limit of resolving names without running
+    # the program, not a decision taken here; do not read it as a ruling.
+    for name, lineno in sorted(rebound.items(), key=lambda item: item[1]):
+        if name in imported:
+            errors.append(f"{path}:{lineno}: '{name}' is imported and rebound in "
+                          f"the same scope — an import binding may not be "
+                          f"reassigned; it disables the purity check silently")
+        else:
+            bindings[name] = None
+
+    # `_clock_mod = time` / `_sleep = time.sleep`: an alias is the thing it
+    # aliases. Runs after the pass above so a real alias beats the None.
     for child in own:
-        if not isinstance(child, (ast.Import, ast.ImportFrom)):
-            for name in _bound_names(child):
-                bindings.pop(name, None)
+        if isinstance(child, (ast.Assign, ast.AnnAssign)) and child.value is not None:
+            targets = child.targets if isinstance(child, ast.Assign) else [child.target]
+            if len(targets) != 1 or not isinstance(targets[0], ast.Name):
+                continue
+            dotted = _dotted(child.value)
+            hits = _candidates(dotted, bindings, stars) if dotted else []
+            if len(hits) == 1:
+                bindings[targets[0].id] = hits[0]
 
     for child in own:
-        if isinstance(child, ast.Call):
-            dotted = _dotted(child.func)
-            target = _resolve(dotted, bindings) if dotted else None
-            if target in FORBIDDEN_CALL_TARGETS:
-                errors.append(f"{path}:{child.lineno}: wall-clock/sleep call "
-                              f"'{dotted}()' resolves to {target}() — "
-                              f"inject Clock instead")
-            elif target in DYNAMIC_IMPORT_TARGETS:
-                errors.append(f"{path}:{child.lineno}: dynamic import "
-                              f"'{dotted}()' — a pure package must be "
-                              f"statically analyzable")
-        elif isinstance(child, _SCOPE_NODES):
-            _scan_scope(child, bindings, path, errors)
+        if isinstance(child, (ast.Name, ast.Attribute)) and not isinstance(child.ctx, ast.Load):
+            continue
+        if not isinstance(child, (ast.Name, ast.Attribute, ast.Call)):
+            continue
+        dotted = _dotted(child)
+        if not dotted:
+            continue
+        for target in _candidates(dotted, bindings, stars):
+            if target in FORBIDDEN_REFS:
+                errors.append(f"{path}:{child.lineno}: wall-clock/sleep reference "
+                              f"'{dotted}' resolves to {target} — inject Clock instead")
+            elif target in DYNAMIC_IMPORT_REFS:
+                errors.append(f"{path}:{child.lineno}: dynamic import '{dotted}' — "
+                              f"a pure package must be statically analyzable")
+
+    # Class scope is not visible inside methods (`class Row: date = None` does
+    # not shadow a module-level `from datetime import date` for `Row.stamp`),
+    # so nested scopes inherit from the class's *enclosing* scope.
+    child_bindings = inherited if isinstance(node, ast.ClassDef) else bindings
+    child_stars = inherited_stars if isinstance(node, ast.ClassDef) else stars
+    for child in own:
+        if isinstance(child, _SCOPE_NODES):
+            _scan_scope(child, child_bindings, child_stars, path, errors)
 
 
 def check_file(path: Path) -> list[str]:
@@ -154,30 +270,33 @@ def check_file(path: Path) -> list[str]:
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             for alias in node.names:
-                root = alias.name.split(".")[0]
-                if root in FORBIDDEN_IMPORTS:
+                if _forbidden_import(alias.name):
                     errors.append(f"{path}:{node.lineno}: forbidden import '{alias.name}'")
-        elif isinstance(node, ast.ImportFrom):
-            root = (node.module or "").split(".")[0]
-            if node.level == 0 and root in FORBIDDEN_IMPORTS:
-                errors.append(f"{path}:{node.lineno}: forbidden import 'from {node.module}'")
-    _scan_scope(tree, {"__import__": "__import__"}, path, errors)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0:
+            module = node.module or ""
+            if _forbidden_import(module):
+                errors.append(f"{path}:{node.lineno}: forbidden import 'from {module}'")
+            else:
+                for alias in node.names:
+                    if alias.name != "*" and _forbidden_import(f"{module}.{alias.name}"):
+                        errors.append(f"{path}:{node.lineno}: forbidden import "
+                                      f"'from {module} import {alias.name}'")
+    _scan_scope(tree, {"__import__": "__import__"}, [], path, errors)
     return errors
 
 
 def check_slackkit_init(root: Path) -> list[str]:
     """slackkit/__init__.py must execute no imports at all — not just no
     forbidden ones. An __init__ that imports is one that can grow a slack_sdk
-    import, and every linted `from slackkit.outbox import ...` would inherit it.
-    Deliberately does not lint the rest of slackkit/: real.py is *supposed* to
-    hold the SDK."""
+    import, and every `import slackkit` would inherit it. This is a narrower
+    claim than it looks: it does nothing about `from slackkit.real import X`,
+    which FORBIDDEN_IMPORTS covers instead."""
     init = root / "slackkit" / "__init__.py"
     if not init.is_file():
         return []
     tree = ast.parse(init.read_text(), filename=str(init))
     return [f"{init}:{node.lineno}: slackkit/__init__.py must stay import-free "
-            f"— it is what lets linted code import slackkit.outbox without "
-            f"pulling in slack_sdk (slackkit/real.py:1-3)"
+            f"so `import slackkit` executes nothing (slackkit/real.py:1-3)"
             for node in ast.walk(tree)
             if isinstance(node, (ast.Import, ast.ImportFrom))]
 
@@ -190,6 +309,8 @@ def main() -> int:
         if not pkg_dir.is_dir():
             continue
         for py in sorted(pkg_dir.rglob("*.py")):
+            if py.relative_to(ROOT).as_posix() in EXCLUDED_FILES:
+                continue
             checked += 1
             errors.extend(check_file(py))
     errors.extend(check_slackkit_init(ROOT))

--- a/scripts/check_purity.py
+++ b/scripts/check_purity.py
@@ -6,13 +6,20 @@ Checks over the no-LLM business-logic packages listed in PURE_PACKAGES:
   1. Forbidden imports: LLM/SDK/Slack code (claude_agent_sdk, anthropic,
      slack_bolt, slack_sdk), anything from agents/, and `slackkit.real`.
      Matching is dotted-prefix, not root-module: `slackkit.real.helpers` is
-     forbidden, `slackkit.realtime` and `slackkit.outbox` are not.
+     forbidden, `slackkit.realtime` and `slackkit.outbox` are not. Relative
+     imports are resolved against the containing package, because every
+     intra-package import in slackkit/ is written relative — a rule that only
+     understood absolute spellings would guard the form nobody writes.
+     A forbidden module reached by attribute (`import slackkit` then
+     `slackkit.real.RealSlack()`) is the same violation and reported as one.
   2. No dynamic imports: importlib.import_module() and __import__(). A pure
      package has to stay statically analyzable, and the argument may be
      computed ("claude" + "_agent_sdk"), so the call itself is the violation.
-  3. No wall clock: datetime.now()/utcnow()/today(), date.today(), and the
-     time module's clock and sleep functions — time is an injected Clock
-     (design.md §4 Testability).
+  3. No wall clock: datetime.now()/utcnow()/today(), date.today(),
+     pandas.Timestamp.now()/today(), asyncio.sleep(), and the time module's
+     sleep, counters and clock readers. time.strftime/asctime/ctime read the
+     clock only in their no-argument form; given a value to render they are
+     pure formatters and are left alone (see ARITY_PURE_FROM).
   4. slackkit/__init__.py stays import-free, so `import slackkit` executes
      nothing (slackkit/real.py:1-3). That file is NOT on its own sufficient to
      keep slack_sdk out of linted code — it never stops `from slackkit.real
@@ -28,11 +35,12 @@ not only calls:
   * `_sleep = time.sleep`, `{"ts": datetime.utcnow}` and `getattr(time,
     "sleep")` are caught without ever being called — capturing the callable is
     the same banned dependency as calling it.
-  * A parameter or local named `time`/`datetime` shadows the module and is
-    left alone, which is what keeps the injected `self._clock.now()` green.
+  * The injected `self._clock.now()` stays green because `self` resolves to
+    nothing, not because of any shadowing rule. A name that resolves to no
+    import is not a match, and that is the whole mechanism.
 
-Zero dependencies. Exit 1 on any violation. Directories that don't exist yet
-(e.g. gate/ before Phase 2) are skipped — add code, inherit the check.
+Zero dependencies. Exit 1 on any violation. A package directory that does not
+exist is skipped, so a package can be added to the list before it is written.
 """
 
 from __future__ import annotations
@@ -58,18 +66,44 @@ FORBIDDEN_REFS = {
     "datetime.date.today",
     "time.sleep", "time.time", "time.time_ns", "time.monotonic",
     "time.monotonic_ns", "time.perf_counter", "time.perf_counter_ns",
-    "time.process_time", "time.localtime", "time.gmtime",
+    "time.process_time", "time.process_time_ns", "time.thread_time",
+    "time.thread_time_ns", "time.clock_gettime", "time.clock_gettime_ns",
+    "time.localtime", "time.gmtime",
     "asyncio.sleep",
+    "pandas.Timestamp.now", "pandas.Timestamp.today", "pandas.Timestamp.utcnow",
 }
+# Names that read the wall clock ONLY when called with too few arguments to
+# render: `time.ctime()` is now, `time.ctime(secs)` is a formatter. The value
+# is the argument count at which the call becomes pure. Bare references to
+# these are deliberately not flagged — the spelling alone does not say which
+# form is meant.
+ARITY_PURE_FROM = {"time.strftime": 2, "time.asctime": 1, "time.ctime": 1}
 # Fully-qualified names that import at runtime, defeating this lint entirely.
 DYNAMIC_IMPORT_REFS = {"importlib.import_module", "importlib.__import__",
                        "builtins.__import__", "__import__"}
 
-# Nodes that open a new binding scope. Comprehensions are included: their
-# targets are invisible outside them, so folding one into the parent would let
-# `[None for time in ()]` silence a whole module.
+# Nodes that open a new binding scope.
 _SCOPE_NODES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef,
                 ast.ListComp, ast.SetComp, ast.DictComp, ast.GeneratorExp)
+# Scopes where a rebinding does NOT hide the import from a use site, so a
+# collision is reportable. See the discriminator on _scan_scope.
+_COLLIDING_SCOPES = (ast.Module, ast.ClassDef)
+
+
+def _watched_bases() -> set[str]:
+    """Every dotted name a forbidden reference hangs off: `datetime`,
+    `datetime.datetime`, `time`, `pandas.Timestamp`, ... Used to decide whether
+    a rebinding could reach anything forbidden, and to resolve a name that a
+    star import could have supplied from anywhere."""
+    bases: set[str] = set()
+    for ref in FORBIDDEN_REFS | DYNAMIC_IMPORT_REFS | set(ARITY_PURE_FROM):
+        parts = ref.split(".")
+        for i in range(1, len(parts)):
+            bases.add(".".join(parts[:i]))
+    return bases
+
+
+WATCHED_BASES = _watched_bases()
 
 
 def _forbidden_import(name: str) -> str | None:
@@ -85,6 +119,18 @@ def _forbidden_import(name: str) -> str | None:
         if name == entry or name.startswith(entry + "."):
             return entry
     return None
+
+
+def _reaches_forbidden(target: str) -> bool:
+    """Could a name bound to `target` reach something this lint forbids?
+
+    This is an ANCESTOR test, not a descendant one, and the difference is the
+    whole rule. `from datetime import UTC` binds UTC -> `datetime.UTC`, which
+    is *under* the watched root `datetime` but is the base of nothing — asking
+    "does it resolve under a watched root?" reddens it, asking "is it the base
+    of a forbidden pattern?" does not.
+    """
+    return bool(_forbidden_import(target)) or target in WATCHED_BASES
 
 
 def _dotted(node: ast.AST) -> str | None:
@@ -112,8 +158,14 @@ def _candidates(dotted: str, bindings: dict[str, str | None],
     """Fully-qualified names `dotted` could refer to in this scope.
 
     A name present in `bindings` with value None is bound to something
-    unresolvable (a parameter, a local, a relative import) — it resolves to
-    nothing and must NOT fall through to the star-import guess.
+    unresolvable (a parameter, a local, an unresolved relative import) — it
+    resolves to nothing and must NOT fall through to a star-import guess.
+
+    Under a star import the head could have been re-exported from anywhere, so
+    two guesses are added: the star module itself, and any watched base whose
+    last segment matches the head. The second is what catches laundering —
+    `from state.helpers import *` followed by `datetime.now()` — without
+    following imports across modules, which stays out of scope (issue #69).
     """
     head, _, rest = dotted.partition(".")
     if head in bindings:
@@ -121,13 +173,34 @@ def _candidates(dotted: str, bindings: dict[str, str | None],
         if base is None:
             return []
         return [f"{base}.{rest}" if rest else base]
-    return [f"{module}.{dotted}" for module in stars]
+    if not stars:
+        return []
+    out = [f"{module}.{dotted}" for module in stars]
+    for base in WATCHED_BASES:
+        if base.rsplit(".", 1)[-1] == head:
+            out.append(f"{base}.{rest}" if rest else base)
+    return out
 
 
-def _import_bindings(node: ast.Import | ast.ImportFrom) -> dict[str, str | None]:
+def _resolve_relative(node: ast.ImportFrom, package: tuple[str, ...]) -> str | None:
+    """`from .real import X` inside slackkit/ -> "slackkit.real".
+
+    Without this, the only spelling the slackkit.real ban would catch is the
+    absolute one, which no file in slackkit/ uses.
+    """
+    if node.level == 0:
+        return node.module
+    if node.level > len(package):
+        return None
+    base = package[:len(package) - node.level + 1]
+    return ".".join([*base, *([node.module] if node.module else [])])
+
+
+def _import_bindings(node: ast.Import | ast.ImportFrom,
+                     package: tuple[str, ...]) -> dict[str, str | None]:
     """{local name: fully-qualified target}. None means "bound to something
-    unresolvable" — a relative import — which must clear an inherited binding
-    of that name rather than leave it standing."""
+    unresolvable", which must clear an inherited binding of that name rather
+    than leave it standing."""
     out: dict[str, str | None] = {}
     if isinstance(node, ast.Import):
         for alias in node.names:
@@ -136,16 +209,19 @@ def _import_bindings(node: ast.Import | ast.ImportFrom) -> dict[str, str | None]
             else:
                 root = alias.name.split(".")[0]
                 out[root] = root
-    elif node.level:  # `from .x import y` — not a resolvable absolute path
-        for alias in node.names:
-            out[alias.asname or alias.name] = None
-    else:
-        module = node.module or ""
-        for alias in node.names:
-            if alias.name == "*":
-                continue  # binds names, but not the literal name "*"
-            name = alias.asname or alias.name
-            out[name] = f"{module}.{alias.name}" if module else alias.name
+        return out
+    module = _resolve_relative(node, package)
+    for alias in node.names:
+        if alias.name == "*":
+            # No observable behaviour: "*" is not an identifier, so it can
+            # never come back out of _dotted or _bound_names, and no test can
+            # pin this branch. Differential-tested across 46 real files and 56
+            # snippets with zero diffs. It is kept because the next reader of
+            # _import_bindings would otherwise have to re-derive that, and
+            # deleted it would read as an oversight rather than a decision.
+            continue
+        name = alias.asname or alias.name
+        out[name] = f"{module}.{alias.name}" if module else None
     return out
 
 
@@ -168,17 +244,87 @@ def _bound_names(node: ast.AST) -> set[str]:
     return set()
 
 
-def _scope_nodes(node: ast.AST):
-    """Descendants of `node` belonging to its own scope. Nested scopes are
-    yielded but not descended into; they are scanned separately."""
+def _outer_exprs(node: ast.AST):
+    """Sub-expressions of a scope node that Python evaluates in the ENCLOSING
+    scope, before the new scope's bindings exist. Scanning these inside the
+    child is how `def stamp(datetime=datetime)` — which really does return the
+    wall clock — reads as clean."""
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+        args = node.args
+        yield from getattr(node, "decorator_list", [])
+        yield from args.defaults
+        yield from [d for d in args.kw_defaults if d is not None]
+        for arg in [*args.posonlyargs, *args.args, *args.kwonlyargs,
+                    args.vararg, args.kwarg]:
+            if arg is not None and arg.annotation is not None:
+                yield arg.annotation
+        if getattr(node, "returns", None) is not None:
+            yield node.returns
+    elif isinstance(node, ast.ClassDef):
+        yield from node.decorator_list
+        yield from node.bases
+        yield from [kw.value for kw in node.keywords]
+    elif isinstance(node, (ast.ListComp, ast.SetComp, ast.DictComp, ast.GeneratorExp)):
+        if node.generators:
+            yield node.generators[0].iter
+
+
+def _inner_children(node: ast.AST) -> list[ast.AST]:
+    """Children of a scope node evaluated INSIDE its own scope."""
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+        args = node.args
+        params = [a for a in [*args.posonlyargs, *args.args, *args.kwonlyargs,
+                              args.vararg, args.kwarg] if a is not None]
+        body = node.body if isinstance(node.body, list) else [node.body]
+        return [*params, *body]
+    if isinstance(node, ast.ClassDef):
+        return list(node.body)
+    if isinstance(node, (ast.ListComp, ast.SetComp, ast.DictComp, ast.GeneratorExp)):
+        parts: list[ast.AST] = ([node.key, node.value]
+                                if isinstance(node, ast.DictComp) else [node.elt])
+        for index, gen in enumerate(node.generators):
+            parts.append(gen.target)
+            if index:  # only the OUTERMOST iterable is evaluated outside
+                parts.append(gen.iter)
+            parts.extend(gen.ifs)
+        return parts
+    return list(ast.iter_child_nodes(node))
+
+
+def _walk_in_scope(node: ast.AST):
+    yield node
+    if isinstance(node, ast.arg):
+        return  # its annotation belongs to the enclosing scope
+    if isinstance(node, _SCOPE_NODES):
+        for expr in _outer_exprs(node):
+            yield from _walk_in_scope(expr)
+        return
     for child in ast.iter_child_nodes(node):
-        yield child
-        if not isinstance(child, _SCOPE_NODES):
-            yield from _scope_nodes(child)
+        yield from _walk_in_scope(child)
+
+
+def _scope_nodes(node: ast.AST):
+    for child in _inner_children(node):
+        yield from _walk_in_scope(child)
+
+
+def _param_defaults(node: ast.AST):
+    """(parameter, default expression) pairs. The default is evaluated in the
+    enclosing scope, so the parameter really holds whatever it resolves to."""
+    if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+        return
+    args = node.args
+    positional = [*args.posonlyargs, *args.args]
+    if args.defaults:
+        yield from zip(positional[len(positional) - len(args.defaults):], args.defaults)
+    for arg, default in zip(args.kwonlyargs, args.kw_defaults):
+        if default is not None:
+            yield arg, default
 
 
 def _scan_scope(node: ast.AST, inherited: dict[str, str | None],
-                inherited_stars: list[str], path: Path, errors: list[str]) -> None:
+                inherited_stars: list[str], path: Path, errors: list[str],
+                package: tuple[str, ...]) -> None:
     own = list(_scope_nodes(node))
     bindings = dict(inherited)
     stars = list(inherited_stars)
@@ -186,10 +332,12 @@ def _scan_scope(node: ast.AST, inherited: dict[str, str | None],
     imported: dict[str, str | None] = {}
     for child in own:
         if isinstance(child, ast.ImportFrom) and any(a.name == "*" for a in child.names):
-            if child.level == 0 and child.module:
-                stars.append(child.module)
+            module = _resolve_relative(child, package)
+            if module:
+                stars.append(module)
         if isinstance(child, (ast.Import, ast.ImportFrom)):
-            imported.update(_import_bindings(child))
+            imported.update(_import_bindings(child, package))
+    bindings.update(imported)
 
     rebound: dict[str, int] = {}
     for child in own:
@@ -198,31 +346,42 @@ def _scan_scope(node: ast.AST, inherited: dict[str, str | None],
         for name in _bound_names(child):
             rebound.setdefault(name, getattr(child, "lineno", 0))
 
-    bindings.update(imported)
-
-    # An import binding rebound in the SAME scope is incoherent code, and
-    # popping the name instead would make `import time` + `if False: time =
-    # None` a silent, condition-independent off switch for the whole scope. So
-    # it is a loud error, not a shadow.
+    # THE DISCRIMINATOR: can the rebinding make a use site resolve to the
+    # import? Not "is it rare" and not "is it suspicious" — reachability.
     #
-    # Deliberately does not fire on a rebinding in a NESTED scope: a
-    # function-local assignment makes the name local for that whole body, so a
-    # use there resolves to the local object or raises UnboundLocalError —
-    # never silently to the stdlib module. That exemption is not a hole in the
-    # collision rule. Where the local object is itself a forbidden binding, the
-    # reference check below catches it as a callable capture instead, which is
-    # the family it belongs to: `_s = time.sleep`, or `dt = datetime` followed
-    # by `dt.datetime.now()`, are both flagged there.
+    #   module scope ....... YES. Rebind and use share one namespace, and a use
+    #                        above the rebind reaches the real module.
+    #   class body ......... YES. LOAD_NAME falls back to the global, so
+    #                        `a = time.time()` above `time = None` is real.
+    #   enclosing-scope
+    #     positions ........ YES, handled by _outer_exprs: defaults,
+    #                        decorators, annotations, base lists and a
+    #                        comprehension's outermost iterable are evaluated
+    #                        before the new scope's bindings exist.
+    #   function body ...... NO. Binding a name ANYWHERE in a function makes it
+    #                        local for the whole body, so a use before the
+    #                        binding raises UnboundLocalError rather than
+    #                        reaching the module. Parameters, `except ... as`
+    #                        and `match`/`case` captures are alike here.
+    #   comprehension ...... NO. Python 3 scopes the target; it does not leak.
     #
-    # What neither rule reaches is a capture whose source is not statically
-    # resolvable — `datetime = some_free_name`, or a clock handed in as a
-    # parameter. That is the ordinary limit of resolving names without running
-    # the program, not a decision taken here; do not read it as a ruling.
+    # Narrowed to bindings that can reach something forbidden. It previously
+    # fired on any import/rebind pair, which reddened `try: import numpy /
+    # except ImportError: numpy = None` and four other ordinary defensive
+    # shapes, while the message claimed the rebinding "disables the purity
+    # check" — false for all five. If this ever over-fires again the remedy is
+    # a narrow exemption for the specific shape, never a weaker rule.
+    collides = isinstance(node, _COLLIDING_SCOPES)
     for name, lineno in sorted(rebound.items(), key=lambda item: item[1]):
-        if name in imported:
-            errors.append(f"{path}:{lineno}: '{name}' is imported and rebound in "
-                          f"the same scope — an import binding may not be "
-                          f"reassigned; it disables the purity check silently")
+        target = bindings.get(name)
+        if collides:
+            # LOAD_NAME still reaches the import here, so the binding stands.
+            if target is not None and _reaches_forbidden(target):
+                errors.append(f"{path}:{lineno}: '{name}' is imported and rebound "
+                              f"where the import stays reachable ({target}) — a use "
+                              f"above the rebinding still resolves to it")
+            elif name not in bindings:
+                bindings[name] = None
         else:
             bindings[name] = None
 
@@ -238,7 +397,23 @@ def _scan_scope(node: ast.AST, inherited: dict[str, str | None],
             if len(hits) == 1:
                 bindings[targets[0].id] = hits[0]
 
+    # A default is evaluated outside, so the parameter holds what it resolved
+    # to there — `def stamp(datetime=datetime)` really does read the clock.
+    for arg, default in _param_defaults(node):
+        dotted = _dotted(default)
+        hits = _candidates(dotted, inherited, inherited_stars) if dotted else []
+        if len(hits) == 1:
+            bindings[arg.arg] = hits[0]
+
     for child in own:
+        if isinstance(child, ast.Call):
+            dotted = _dotted(child.func)
+            for target in _candidates(dotted, bindings, stars) if dotted else []:
+                if target in ARITY_PURE_FROM and (
+                        len(child.args) + len(child.keywords) < ARITY_PURE_FROM[target]):
+                    errors.append(f"{path}:{child.lineno}: wall-clock/sleep reference "
+                                  f"'{dotted}()' resolves to {target}() with no value "
+                                  f"to render, which reads the clock — inject Clock")
         if isinstance(child, (ast.Name, ast.Attribute)) and not isinstance(child.ctx, ast.Load):
             continue
         if not isinstance(child, (ast.Name, ast.Attribute, ast.Call)):
@@ -253,6 +428,9 @@ def _scan_scope(node: ast.AST, inherited: dict[str, str | None],
             elif target in DYNAMIC_IMPORT_REFS:
                 errors.append(f"{path}:{child.lineno}: dynamic import '{dotted}' — "
                               f"a pure package must be statically analyzable")
+            elif _forbidden_import(target):
+                errors.append(f"{path}:{child.lineno}: forbidden import reached by "
+                              f"attribute — '{dotted}' resolves to {target}")
 
     # Class scope is not visible inside methods (`class Row: date = None` does
     # not shadow a module-level `from datetime import date` for `Row.stamp`),
@@ -261,10 +439,12 @@ def _scan_scope(node: ast.AST, inherited: dict[str, str | None],
     child_stars = inherited_stars if isinstance(node, ast.ClassDef) else stars
     for child in own:
         if isinstance(child, _SCOPE_NODES):
-            _scan_scope(child, child_bindings, child_stars, path, errors)
+            _scan_scope(child, child_bindings, child_stars, path, errors, package)
 
 
-def check_file(path: Path) -> list[str]:
+def check_file(path: Path, package: tuple[str, ...] = ()) -> list[str]:
+    """`package` is the dotted package the file sits in, used to resolve
+    relative imports. Empty means "unknown", which leaves them unresolved."""
     errors: list[str] = []
     tree = ast.parse(path.read_text(), filename=str(path))
     for node in ast.walk(tree):
@@ -272,8 +452,10 @@ def check_file(path: Path) -> list[str]:
             for alias in node.names:
                 if _forbidden_import(alias.name):
                     errors.append(f"{path}:{node.lineno}: forbidden import '{alias.name}'")
-        elif isinstance(node, ast.ImportFrom) and node.level == 0:
-            module = node.module or ""
+        elif isinstance(node, ast.ImportFrom):
+            module = _resolve_relative(node, package)
+            if not module:
+                continue
             if _forbidden_import(module):
                 errors.append(f"{path}:{node.lineno}: forbidden import 'from {module}'")
             else:
@@ -281,7 +463,7 @@ def check_file(path: Path) -> list[str]:
                     if alias.name != "*" and _forbidden_import(f"{module}.{alias.name}"):
                         errors.append(f"{path}:{node.lineno}: forbidden import "
                                       f"'from {module} import {alias.name}'")
-    _scan_scope(tree, {"__import__": "__import__"}, [], path, errors)
+    _scan_scope(tree, {"__import__": "__import__"}, [], path, errors, package)
     return errors
 
 
@@ -309,10 +491,11 @@ def main() -> int:
         if not pkg_dir.is_dir():
             continue
         for py in sorted(pkg_dir.rglob("*.py")):
-            if py.relative_to(ROOT).as_posix() in EXCLUDED_FILES:
+            relative = py.relative_to(ROOT)
+            if relative.as_posix() in EXCLUDED_FILES:
                 continue
             checked += 1
-            errors.extend(check_file(py))
+            errors.extend(check_file(py, relative.parts[:-1]))
     errors.extend(check_slackkit_init(ROOT))
     if errors:
         print(f"PURITY LINT: {len(errors)} violation(s) in {checked} file(s):")

--- a/scripts/check_purity.py
+++ b/scripts/check_purity.py
@@ -451,11 +451,27 @@ def _scan_scope(node: ast.AST, inherited: dict[str, str | None],
         rebound -= set(_walrus_targets(node))
 
     stands = isinstance(node, _BINDING_STANDS_SCOPES)
-    for name in rebound:
+    # `| declared_global` and not just `rebound`: a `global x` DECLARATION
+    # rebinds resolution on its own, with or without an assignment anywhere in
+    # the body. Iterating `rebound` alone made the assignment load-bearing, so
+    # `global time` + a bare `time.sleep(0.30)` kept the enclosing scope's
+    # shadow and read the real clock while the lint said clean. Deletion-check:
+    # revert to `for name in rebound:` on a copy and the assignment-free case
+    # in BINDING_STANDS_CASES goes clean while its with-assignment twin stays
+    # red — which is exactly why one case could not pin both.
+    for name in rebound | declared_global:
         if name in declared_nonlocal:
             continue  # the enclosing function's binding, which `inherited` holds
         if name in declared_global:
-            bindings[name] = module_bindings.get(name)
+            # `import x` in a scope that declared `global x` binds the MODULE's
+            # x to the module object, so this scope's own import wins over
+            # whatever the module scope held. Overwriting unconditionally
+            # clobbered it: `global time` + a function-local `import time` read
+            # 0.306s of real clock while the lint said clean. Deletion-check:
+            # drop the `not in imported` guard on a copy and the two
+            # A3=global/A4=import rows in the generated gate go clean again.
+            if name not in imported:
+                bindings[name] = module_bindings.get(name)
             continue
         # `name in imported` is the function-body exception: an import in this
         # same body binds the module to that local, so a use between the two

--- a/scripts/check_purity.py
+++ b/scripts/check_purity.py
@@ -1,12 +1,25 @@
 #!/usr/bin/env python3
 """Purity lint (CI-enforced; see CLAUDE.md invariant 3 and specs/design.md §4).
 
-Two checks over the no-LLM business-logic packages:
+Three checks over the no-LLM business-logic packages:
   1. Forbidden imports: gate/, stratgate/, fundbt/, calibration/, orchestrator/,
-     and state/ must not import LLM/SDK/Slack code (claude_agent_sdk, anthropic,
-     slack_bolt, slack_sdk) nor anything from agents/.
-  2. No wall clock: no datetime.now()/datetime.utcnow()/date.today()/time.sleep()
-     in business logic — time is an injected Clock (design.md §4 Testability).
+     state/ and market/ must not import LLM/SDK/Slack code (claude_agent_sdk,
+     anthropic, slack_bolt, slack_sdk) nor anything from agents/. Dynamic
+     imports (importlib.import_module, __import__) are forbidden outright: a
+     pure package has to stay statically analyzable, and the argument may be
+     computed ("claude" + "_agent_sdk").
+  2. No wall clock: datetime.now()/utcnow(), date.today(), time.sleep()/time()/
+     monotonic()/perf_counter(), asyncio.sleep() — time is an injected Clock
+     (design.md §4 Testability).
+  3. slackkit/__init__.py stays import-free. slackkit is in neither list above:
+     orchestrator legitimately imports slackkit.outbox, and slackkit/real.py
+     legitimately holds slack_sdk. The empty __init__.py is the entire mechanism
+     keeping the two apart, and slackkit/real.py:1-3 says so.
+
+Calls are matched on the *binding a name resolves to*, not on its source
+spelling, so `import time as _t; _t.sleep(1)` and `from time import sleep;
+sleep(1)` are caught while a local or parameter named `time`/`datetime` — and
+above all the injected `self._clock.now()` — are not.
 
 Zero dependencies. Exit 1 on any violation. Directories that don't exist yet
 (e.g. gate/ before Phase 2) are skipped — add code, inherit the check.
@@ -20,12 +33,119 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 
-PURE_PACKAGES = ["gate", "stratgate", "fundbt", "calibration", "orchestrator", "state"]
+PURE_PACKAGES = ["gate", "stratgate", "fundbt", "calibration", "orchestrator",
+                 "state", "market"]
 FORBIDDEN_IMPORTS = ("claude_agent_sdk", "anthropic", "slack_bolt", "slack_sdk", "agents")
-# (module, attr) call patterns that read the wall clock / block the thread
-FORBIDDEN_CALLS = {
-    ("datetime", "now"), ("datetime", "utcnow"), ("date", "today"), ("time", "sleep"),
+# Fully-qualified callables that read the wall clock or block the thread.
+FORBIDDEN_CALL_TARGETS = {
+    "datetime.datetime.now", "datetime.datetime.utcnow", "datetime.date.today",
+    "time.sleep", "time.time", "time.monotonic", "time.perf_counter",
+    "asyncio.sleep",
 }
+# Fully-qualified callables that import at runtime, defeating this lint.
+DYNAMIC_IMPORT_TARGETS = {"importlib.import_module", "importlib.__import__", "__import__"}
+
+# Nodes that open a new binding scope; their bodies are scanned separately.
+_SCOPE_NODES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef)
+
+
+def _dotted(node: ast.expr) -> str | None:
+    """`a.b.c` as a Name/Attribute chain -> "a.b.c"; anything else -> None."""
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        base = _dotted(node.value)
+        return f"{base}.{node.attr}" if base else None
+    return None
+
+
+def _resolve(dotted: str, bindings: dict[str, str]) -> str | None:
+    """Rewrite a dotted expression through the local name -> module bindings."""
+    head, _, rest = dotted.partition(".")
+    target = bindings.get(head)
+    if target is None:
+        return None
+    return f"{target}.{rest}" if rest else target
+
+
+def _import_bindings(node: ast.Import | ast.ImportFrom) -> dict[str, str | None]:
+    """{local name: fully-qualified target}. None means "bound to something
+    unresolvable" — a relative import — which must clear any inherited binding
+    of that name rather than leave it standing."""
+    out: dict[str, str | None] = {}
+    if isinstance(node, ast.Import):
+        for alias in node.names:
+            if alias.asname:
+                out[alias.asname] = alias.name
+            else:
+                root = alias.name.split(".")[0]
+                out[root] = root
+    elif node.level:  # `from .x import y` — not a resolvable absolute path
+        for alias in node.names:
+            out[alias.asname or alias.name] = None
+    else:
+        module = node.module or ""
+        for alias in node.names:
+            name = alias.asname or alias.name
+            out[name] = f"{module}.{alias.name}" if module else alias.name
+    return out
+
+
+def _bound_names(node: ast.AST) -> set[str]:
+    """Names this node binds by means other than an import: assignment,
+    parameter, def/class, `except ... as`, comprehension or `with` target."""
+    if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store):
+        return {node.id}
+    if isinstance(node, ast.arg):
+        return {node.arg}
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+        return {node.name}
+    if isinstance(node, ast.ExceptHandler) and node.name:
+        return {node.name}
+    return set()
+
+
+def _scope_nodes(node: ast.AST):
+    """Descendants of `node` belonging to its own scope — nested defs, lambdas
+    and classes are yielded but not descended into."""
+    for child in ast.iter_child_nodes(node):
+        yield child
+        if not isinstance(child, _SCOPE_NODES):
+            yield from _scope_nodes(child)
+
+
+def _scan_scope(node: ast.AST, inherited: dict[str, str], path: Path,
+                errors: list[str]) -> None:
+    own = list(_scope_nodes(node))
+    bindings = dict(inherited)
+    for child in own:
+        if isinstance(child, (ast.Import, ast.ImportFrom)):
+            for name, target in _import_bindings(child).items():
+                if target is None:
+                    bindings.pop(name, None)
+                else:
+                    bindings[name] = target
+    # A local binding of the same name shadows the module: `def elapsed(time)`
+    # is a caller's Timer, not the stdlib.
+    for child in own:
+        if not isinstance(child, (ast.Import, ast.ImportFrom)):
+            for name in _bound_names(child):
+                bindings.pop(name, None)
+
+    for child in own:
+        if isinstance(child, ast.Call):
+            dotted = _dotted(child.func)
+            target = _resolve(dotted, bindings) if dotted else None
+            if target in FORBIDDEN_CALL_TARGETS:
+                errors.append(f"{path}:{child.lineno}: wall-clock/sleep call "
+                              f"'{dotted}()' resolves to {target}() — "
+                              f"inject Clock instead")
+            elif target in DYNAMIC_IMPORT_TARGETS:
+                errors.append(f"{path}:{child.lineno}: dynamic import "
+                              f"'{dotted}()' — a pure package must be "
+                              f"statically analyzable")
+        elif isinstance(child, _SCOPE_NODES):
+            _scan_scope(child, bindings, path, errors)
 
 
 def check_file(path: Path) -> list[str]:
@@ -41,15 +161,25 @@ def check_file(path: Path) -> list[str]:
             root = (node.module or "").split(".")[0]
             if node.level == 0 and root in FORBIDDEN_IMPORTS:
                 errors.append(f"{path}:{node.lineno}: forbidden import 'from {node.module}'")
-        elif isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
-            attr = node.func.attr
-            base = node.func.value
-            base_name = base.id if isinstance(base, ast.Name) else (
-                base.attr if isinstance(base, ast.Attribute) else None)
-            if base_name and (base_name, attr) in FORBIDDEN_CALLS:
-                errors.append(f"{path}:{node.lineno}: wall-clock/sleep call "
-                              f"'{base_name}.{attr}()' — inject Clock instead")
+    _scan_scope(tree, {"__import__": "__import__"}, path, errors)
     return errors
+
+
+def check_slackkit_init(root: Path) -> list[str]:
+    """slackkit/__init__.py must execute no imports at all — not just no
+    forbidden ones. An __init__ that imports is one that can grow a slack_sdk
+    import, and every linted `from slackkit.outbox import ...` would inherit it.
+    Deliberately does not lint the rest of slackkit/: real.py is *supposed* to
+    hold the SDK."""
+    init = root / "slackkit" / "__init__.py"
+    if not init.is_file():
+        return []
+    tree = ast.parse(init.read_text(), filename=str(init))
+    return [f"{init}:{node.lineno}: slackkit/__init__.py must stay import-free "
+            f"— it is what lets linted code import slackkit.outbox without "
+            f"pulling in slack_sdk (slackkit/real.py:1-3)"
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.Import, ast.ImportFrom))]
 
 
 def main() -> int:
@@ -62,6 +192,7 @@ def main() -> int:
         for py in sorted(pkg_dir.rglob("*.py")):
             checked += 1
             errors.extend(check_file(py))
+    errors.extend(check_slackkit_init(ROOT))
     if errors:
         print(f"PURITY LINT: {len(errors)} violation(s) in {checked} file(s):")
         print("\n".join(errors))

--- a/scripts/check_purity.py
+++ b/scripts/check_purity.py
@@ -11,15 +11,18 @@ Checks over the no-LLM business-logic packages listed in PURE_PACKAGES:
      intra-package import in slackkit/ is written relative — a rule that only
      understood absolute spellings would guard the form nobody writes.
      A forbidden module reached by attribute (`import slackkit` then
-     `slackkit.real.RealSlack()`) is the same violation and reported as one.
+     `slackkit.real.RealSlack()`) is the same violation. It is reported once
+     per attribute prefix that lands inside the forbidden module, so
+     `slackkit.real.a.b.c` yields four lines naming one root cause.
   2. No dynamic imports: importlib.import_module() and __import__(). A pure
      package has to stay statically analyzable, and the argument may be
      computed ("claude" + "_agent_sdk"), so the call itself is the violation.
   3. No wall clock: datetime.now()/utcnow()/today(), date.today(),
      pandas.Timestamp.now()/today(), asyncio.sleep(), and the time module's
-     sleep, counters and clock readers. time.strftime/asctime/ctime read the
-     clock only in their no-argument form; given a value to render they are
-     pure formatters and are left alone (see ARITY_PURE_FROM).
+     sleep, counters and clock readers. strftime/asctime/ctime/gmtime/localtime
+     read the clock only when called with too few arguments to render a
+     supplied value; given one they are pure converters and are left alone
+     (see ARITY_PURE_FROM).
   4. slackkit/__init__.py stays import-free, so `import slackkit` executes
      nothing (slackkit/real.py:1-3). That file is NOT on its own sufficient to
      keep slack_sdk out of linted code — it never stops `from slackkit.real
@@ -36,8 +39,10 @@ not only calls:
     "sleep")` are caught without ever being called — capturing the callable is
     the same banned dependency as calling it.
   * The injected `self._clock.now()` stays green because `self` resolves to
-    nothing, not because of any shadowing rule. A name that resolves to no
-    import is not a match, and that is the whole mechanism.
+    nothing, not because of any shadowing rule. The converse does NOT hold, so
+    do not restate this as "resolving to no import is a pass": under a star
+    import an unbound name is deliberately still matched against every watched
+    base, which is how re-export laundering is caught (see _candidates).
 
 Zero dependencies. Exit 1 on any violation. A package directory that does not
 exist is skipped, so a package can be added to the list before it is written.
@@ -68,16 +73,22 @@ FORBIDDEN_REFS = {
     "time.monotonic_ns", "time.perf_counter", "time.perf_counter_ns",
     "time.process_time", "time.process_time_ns", "time.thread_time",
     "time.thread_time_ns", "time.clock_gettime", "time.clock_gettime_ns",
-    "time.localtime", "time.gmtime",
     "asyncio.sleep",
     "pandas.Timestamp.now", "pandas.Timestamp.today", "pandas.Timestamp.utcnow",
 }
 # Names that read the wall clock ONLY when called with too few arguments to
-# render: `time.ctime()` is now, `time.ctime(secs)` is a formatter. The value
-# is the argument count at which the call becomes pure. Bare references to
-# these are deliberately not flagged — the spelling alone does not say which
-# form is meant.
-ARITY_PURE_FROM = {"time.strftime": 2, "time.asctime": 1, "time.ctime": 1}
+# render or convert a supplied value: `time.ctime()` is now, `time.ctime(secs)`
+# is a formatter; `time.gmtime()` is now, `time.gmtime(epoch)` is a converter.
+# The value is the argument count at which the call becomes pure. Bare
+# references to these are deliberately not flagged — the spelling alone does
+# not say which form is meant.
+#
+# gmtime and localtime belong here and sat in FORBIDDEN_REFS unconditionally
+# until the docstring's own example failed on itself: in
+# `time.strftime("%Y", time.gmtime(0))` the outer call was correctly pure while
+# the inner one it was feeding got flagged.
+ARITY_PURE_FROM = {"time.strftime": 2, "time.asctime": 1, "time.ctime": 1,
+                   "time.gmtime": 1, "time.localtime": 1}
 # Fully-qualified names that import at runtime, defeating this lint entirely.
 DYNAMIC_IMPORT_REFS = {"importlib.import_module", "importlib.__import__",
                        "builtins.__import__", "__import__"}
@@ -85,16 +96,16 @@ DYNAMIC_IMPORT_REFS = {"importlib.import_module", "importlib.__import__",
 # Nodes that open a new binding scope.
 _SCOPE_NODES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef,
                 ast.ListComp, ast.SetComp, ast.DictComp, ast.GeneratorExp)
-# Scopes where a rebinding does NOT hide the import from a use site, so a
-# collision is reportable. See the discriminator on _scan_scope.
-_COLLIDING_SCOPES = (ast.Module, ast.ClassDef)
+# Scopes where a rebinding does NOT hide the import from a use site, so the
+# import binding STANDS rather than being popped. See the discriminator on
+# _scan_scope.
+_BINDING_STANDS_SCOPES = (ast.Module, ast.ClassDef)
 
 
 def _watched_bases() -> set[str]:
     """Every dotted name a forbidden reference hangs off: `datetime`,
-    `datetime.datetime`, `time`, `pandas.Timestamp`, ... Used to decide whether
-    a rebinding could reach anything forbidden, and to resolve a name that a
-    star import could have supplied from anywhere."""
+    `datetime.datetime`, `time`, `pandas.Timestamp`, ... Used to resolve a name
+    a star import could have supplied from anywhere."""
     bases: set[str] = set()
     for ref in FORBIDDEN_REFS | DYNAMIC_IMPORT_REFS | set(ARITY_PURE_FROM):
         parts = ref.split(".")
@@ -119,18 +130,6 @@ def _forbidden_import(name: str) -> str | None:
         if name == entry or name.startswith(entry + "."):
             return entry
     return None
-
-
-def _reaches_forbidden(target: str) -> bool:
-    """Could a name bound to `target` reach something this lint forbids?
-
-    This is an ANCESTOR test, not a descendant one, and the difference is the
-    whole rule. `from datetime import UTC` binds UTC -> `datetime.UTC`, which
-    is *under* the watched root `datetime` but is the base of nothing — asking
-    "does it resolve under a watched root?" reddens it, asking "is it the base
-    of a forbidden pattern?" does not.
-    """
-    return bool(_forbidden_import(target)) or target in WATCHED_BASES
 
 
 def _dotted(node: ast.AST) -> str | None:
@@ -308,6 +307,28 @@ def _scope_nodes(node: ast.AST):
         yield from _walk_in_scope(child)
 
 
+def _walrus_targets(node: ast.AST):
+    """Names a walrus binds in the scope CONTAINING `node`.
+
+    PEP 572 gives an assignment expression inside a comprehension to the
+    containing scope rather than the comprehension's, so `[(time := r) for r
+    in rows]` really does leave a local named `time` behind. Nested function
+    and class scopes are not crossed — a walrus inside one belongs to it.
+
+    KNOWN AND DELIBERATE: the target is ALSO bound inside the comprehension's
+    own scope, by _bound_names seeing the Store. That is not a faithful model
+    of PEP 572, but both paths bind it to unresolvable, so no verdict differs
+    and no test separates them. Suppressing the inner binding would be
+    untested logic serving tidiness — do not "fix" it into a behaviour change.
+    """
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, ast.NamedExpr) and isinstance(child.target, ast.Name):
+            yield child.target.id
+        if not isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef,
+                                  ast.Lambda, ast.ClassDef)):
+            yield from _walrus_targets(child)
+
+
 def _param_defaults(node: ast.AST):
     """(parameter, default expression) pairs. The default is evaluated in the
     enclosing scope, so the parameter really holds whatever it resolves to."""
@@ -339,12 +360,20 @@ def _scan_scope(node: ast.AST, inherited: dict[str, str | None],
             imported.update(_import_bindings(child, package))
     bindings.update(imported)
 
-    rebound: dict[str, int] = {}
+    rebound: set[str] = set()
+    declared_global: set[str] = set()
     for child in own:
         if isinstance(child, (ast.Import, ast.ImportFrom)):
             continue
-        for name in _bound_names(child):
-            rebound.setdefault(name, getattr(child, "lineno", 0))
+        if isinstance(child, ast.Global):
+            declared_global.update(child.names)
+        rebound.update(_bound_names(child))
+        # PEP 572: a walrus target inside a comprehension binds in the
+        # CONTAINING scope, so it leaks back out to here. A plain `for` target
+        # does not, which is why the two cannot share a row.
+        if isinstance(child, (ast.ListComp, ast.SetComp, ast.DictComp,
+                              ast.GeneratorExp)):
+            rebound.update(_walrus_targets(child))
 
     # THE DISCRIMINATOR: can the rebinding make a use site resolve to the
     # import? Not "is it rare" and not "is it suspicious" — reachability.
@@ -363,26 +392,43 @@ def _scan_scope(node: ast.AST, inherited: dict[str, str | None],
     #                        binding raises UnboundLocalError rather than
     #                        reaching the module. Parameters, `except ... as`
     #                        and `match`/`case` captures are alike here.
-    #   comprehension ...... NO. Python 3 scopes the target; it does not leak.
+    #   comprehension
+    #     `for` target ..... NO. Python 3 scopes it to the comprehension.
+    #   comprehension
+    #     WALRUS target .... NO, but not for the row above and it does not
+    #                        inherit from it. PEP 572 binds the target in the
+    #                        CONTAINING scope, so it leaks out and then lands
+    #                        under whichever row governs that scope — private
+    #                        inside a function, reachable at module scope.
+    #   `global x` ......... YES, even in a function body. The declared binding
+    #                        is the MODULE's, so the privacy the function-body
+    #                        row rests on does not hold: a read before the
+    #                        rebinding returns a live value instead of raising
+    #                        UnboundLocalError. `nonlocal` is unaffected — it
+    #                        can only bind an enclosing function's local, never
+    #                        an import.
     #
-    # Narrowed to bindings that can reach something forbidden. It previously
-    # fired on any import/rebind pair, which reddened `try: import numpy /
-    # except ImportError: numpy = None` and four other ordinary defensive
-    # shapes, while the message claimed the rebinding "disables the purity
-    # check" — false for all five. If this ever over-fires again the remedy is
-    # a narrow exemption for the specific shape, never a weaker rule.
-    collides = isinstance(node, _COLLIDING_SCOPES)
-    for name, lineno in sorted(rebound.items(), key=lambda item: item[1]):
-        target = bindings.get(name)
-        if collides:
-            # LOAD_NAME still reaches the import here, so the binding stands.
-            if target is not None and _reaches_forbidden(target):
-                errors.append(f"{path}:{lineno}: '{name}' is imported and rebound "
-                              f"where the import stays reachable ({target}) — a use "
-                              f"above the rebinding still resolves to it")
-            elif name not in bindings:
-                bindings[name] = None
-        else:
+    # The enclosing-scope row covers two different mechanisms. Defaults,
+    # decorators and base lists are EVALUATED at definition time, before the
+    # new scope's bindings exist. Annotations are not evaluated at all here —
+    # this file carries `from __future__ import annotations`, and on 3.14 they
+    # are lazy regardless — but the verdict is the same, because PEP 649's
+    # annotate function still closes over the enclosing scope. Deferred
+    # resolution, not evaluation; do not restate the annotation arm as
+    # something confirmed by executing it.
+    #
+    # There is deliberately NO report attached to any of this. A collision
+    # report lived here and was deleted after ablation showed it caught no
+    # purity violation the reference check did not already catch, while
+    # false-positiving on class-body fields that never use the name. What is
+    # load-bearing is only that the binding STANDS, so the reference check can
+    # still resolve through the rebind. Do not reintroduce a report, a warning
+    # or a flag.
+    stands = isinstance(node, _BINDING_STANDS_SCOPES)
+    for name in rebound:
+        if name in declared_global:
+            continue  # the module's binding, not a private local
+        if not stands or name not in bindings:
             bindings[name] = None
 
     # `_clock_mod = time` / `_sleep = time.sleep`: an alias is the thing it

--- a/scripts/check_purity.py
+++ b/scripts/check_purity.py
@@ -315,11 +315,11 @@ def _walrus_targets(node: ast.AST):
     in rows]` really does leave a local named `time` behind. Nested function
     and class scopes are not crossed — a walrus inside one belongs to it.
 
-    KNOWN AND DELIBERATE: the target is ALSO bound inside the comprehension's
-    own scope, by _bound_names seeing the Store. That is not a faithful model
-    of PEP 572, but both paths bind it to unresolvable, so no verdict differs
-    and no test separates them. Suppressing the inner binding would be
-    untested logic serving tidiness — do not "fix" it into a behaviour change.
+    The caller also uses this to SUPPRESS the target inside the comprehension's
+    own scope. Both halves are required: a use inside the comprehension
+    resolves to the containing scope too, so popping the name locally would
+    hide `[(time := time.sleep(0.30)) for _ in range(1)]`, which blocks for a
+    third of a second on a real clock.
     """
     for child in ast.iter_child_nodes(node):
         if isinstance(child, ast.NamedExpr) and isinstance(child.target, ast.Name):
@@ -345,7 +345,8 @@ def _param_defaults(node: ast.AST):
 
 def _scan_scope(node: ast.AST, inherited: dict[str, str | None],
                 inherited_stars: list[str], path: Path, errors: list[str],
-                package: tuple[str, ...]) -> None:
+                package: tuple[str, ...],
+                module_bindings: dict[str, str | None] | None = None) -> None:
     own = list(_scope_nodes(node))
     bindings = dict(inherited)
     stars = list(inherited_stars)
@@ -360,13 +361,19 @@ def _scan_scope(node: ast.AST, inherited: dict[str, str | None],
             imported.update(_import_bindings(child, package))
     bindings.update(imported)
 
+    if module_bindings is None:  # this IS the module scope
+        module_bindings = bindings
+
     rebound: set[str] = set()
     declared_global: set[str] = set()
+    declared_nonlocal: set[str] = set()
     for child in own:
         if isinstance(child, (ast.Import, ast.ImportFrom)):
             continue
         if isinstance(child, ast.Global):
             declared_global.update(child.names)
+        if isinstance(child, ast.Nonlocal):
+            declared_nonlocal.update(child.names)
         rebound.update(_bound_names(child))
         # PEP 572: a walrus target inside a comprehension binds in the
         # CONTAINING scope, so it leaks back out to here. A plain `for` target
@@ -387,26 +394,39 @@ def _scan_scope(node: ast.AST, inherited: dict[str, str | None],
     #                        decorators, annotations, base lists and a
     #                        comprehension's outermost iterable are evaluated
     #                        before the new scope's bindings exist.
-    #   function body ...... NO. Binding a name ANYWHERE in a function makes it
+    #   function body ...... NO, UNLESS the same scope also imports the name.
+    #                        Binding a name anywhere in a function makes it
     #                        local for the whole body, so a use before the
     #                        binding raises UnboundLocalError rather than
-    #                        reaching the module. Parameters, `except ... as`
-    #                        and `match`/`case` captures are alike here.
+    #                        reaching the module — parameters, `except ... as`
+    #                        and `match`/`case` captures are alike here. But an
+    #                        `import` in that same body IS a binding, and it
+    #                        assigns the module to that local, so a use between
+    #                        the import and the rebinding reads the real thing.
     #   comprehension
     #     `for` target ..... NO. Python 3 scopes it to the comprehension.
     #   comprehension
-    #     WALRUS target .... NO, but not for the row above and it does not
-    #                        inherit from it. PEP 572 binds the target in the
-    #                        CONTAINING scope, so it leaks out and then lands
-    #                        under whichever row governs that scope — private
-    #                        inside a function, reachable at module scope.
-    #   `global x` ......... YES, even in a function body. The declared binding
-    #                        is the MODULE's, so the privacy the function-body
-    #                        row rests on does not hold: a read before the
-    #                        rebinding returns a live value instead of raising
-    #                        UnboundLocalError. `nonlocal` is unaffected — it
-    #                        can only bind an enclosing function's local, never
-    #                        an import.
+    #     WALRUS target .... Two separate effects, and neither follows from the
+    #                        `for` row. PEP 572 binds the target in the
+    #                        CONTAINING scope, so (a) it leaks OUT and lands
+    #                        under whichever row governs that scope, and (b) a
+    #                        use INSIDE the comprehension resolves out there
+    #                        too — so the name must NOT be popped locally.
+    #                        Missing (b) hid six executing clock reads.
+    #   `global x` ......... YES. The declared binding is the MODULE's, so the
+    #                        privacy the function-body row rests on does not
+    #                        hold: a read before the rebinding returns a live
+    #                        value instead of raising UnboundLocalError.
+    #   `nonlocal x` ....... YES, onto the ENCLOSING FUNCTION's binding. This
+    #                        row previously read "unaffected — nonlocal can
+    #                        only bind an enclosing function's local, never an
+    #                        import". The premise is true and the conclusion
+    #                        does not follow: `import time` inside a function
+    #                        is a function-local binding whose value IS the
+    #                        module, so nonlocal reaches it. Executed: the
+    #                        inner function blocks 0.305s. Where the enclosing
+    #                        local is not an import there is nothing to reach
+    #                        and it stays clean, which is the committed twin.
     #
     # The enclosing-scope row covers two different mechanisms. Defaults,
     # decorators and base lists are EVALUATED at definition time, before the
@@ -424,11 +444,23 @@ def _scan_scope(node: ast.AST, inherited: dict[str, str | None],
     # load-bearing is only that the binding STANDS, so the reference check can
     # still resolve through the rebind. Do not reintroduce a report, a warning
     # or a flag.
+    # A walrus target belongs to the CONTAINING scope, so inside the
+    # comprehension itself it must not be treated as a local rebinding — a use
+    # there reads the containing scope's binding, import included.
+    if isinstance(node, (ast.ListComp, ast.SetComp, ast.DictComp, ast.GeneratorExp)):
+        rebound -= set(_walrus_targets(node))
+
     stands = isinstance(node, _BINDING_STANDS_SCOPES)
     for name in rebound:
+        if name in declared_nonlocal:
+            continue  # the enclosing function's binding, which `inherited` holds
         if name in declared_global:
-            continue  # the module's binding, not a private local
-        if not stands or name not in bindings:
+            bindings[name] = module_bindings.get(name)
+            continue
+        # `name in imported` is the function-body exception: an import in this
+        # same body binds the module to that local, so a use between the two
+        # reaches it.
+        if (not stands and name not in imported) or name not in bindings:
             bindings[name] = None
 
     # `_clock_mod = time` / `_sleep = time.sleep`: an alias is the thing it
@@ -485,7 +517,8 @@ def _scan_scope(node: ast.AST, inherited: dict[str, str | None],
     child_stars = inherited_stars if isinstance(node, ast.ClassDef) else stars
     for child in own:
         if isinstance(child, _SCOPE_NODES):
-            _scan_scope(child, child_bindings, child_stars, path, errors, package)
+            _scan_scope(child, child_bindings, child_stars, path, errors, package,
+                        module_bindings)
 
 
 def check_file(path: Path, package: tuple[str, ...] = ()) -> list[str]:

--- a/scripts/check_purity.py
+++ b/scripts/check_purity.py
@@ -149,6 +149,15 @@ def _dotted(node: ast.AST) -> str | None:
             and isinstance(node.args[1].value, str)):
         base = _dotted(node.args[0])
         return f"{base}.{node.args[1].value}" if base else None
+    if isinstance(node, ast.NamedExpr):
+        # A walrus EVALUATES to its value, so `(time := _src).sleep` is
+        # `_src.sleep`. Without this the return-expression shape resolves to
+        # nothing, because that walrus sits in no ast.Assign for the alias pass
+        # below to find. Deletion-check: remove these two lines on a copy and
+        # "walrus alias in a return expression" goes clean while the function,
+        # module, class and chained shapes stay red — the alias pass covers
+        # those, and only this arm covers a walrus used as an attribute base.
+        return _dotted(node.value)
     return None
 
 
@@ -490,6 +499,20 @@ def _scan_scope(node: ast.AST, inherited: dict[str, str | None],
             hits = _candidates(dotted, bindings, stars) if dotted else []
             if len(hits) == 1:
                 bindings[targets[0].id] = hits[0]
+        # `(time := _src)` aliases exactly as `time = _src` does. NamedExpr was
+        # known to this file only as a SCOPING event (_walrus_targets), so a
+        # walrus registered as a binder — popping or standing the name — while
+        # the module it named was discarded. Not restricted to walruses inside
+        # an Assign: `own` carries them from any statement, which is what makes
+        # the `if`/`while`-condition spellings work as well.
+        # Deletion-check: drop this branch on a copy and the function, module,
+        # class and chained walrus-alias cases go clean, while the
+        # return-expression case stays red on the _dotted arm above.
+        elif isinstance(child, ast.NamedExpr) and isinstance(child.target, ast.Name):
+            dotted = _dotted(child.value)
+            hits = _candidates(dotted, bindings, stars) if dotted else []
+            if len(hits) == 1:
+                bindings[child.target.id] = hits[0]
 
     # A default is evaluated outside, so the parameter holds what it resolved
     # to there — `def stamp(datetime=datetime)` really does read the clock.

--- a/tests/test_check_purity.py
+++ b/tests/test_check_purity.py
@@ -288,8 +288,15 @@ MASTER_REGRESSION_CASES = [
 #       binding raises UnboundLocalError and never reaches the module. This
 #       covers parameters, `except ... as`, and `match`/`case` captures alike —
 #       all three verified by execution.
-#   comprehension target ......................... NO, Python 3 scopes it and
-#       it does not leak.
+#   comprehension `for` target ................... NO, Python 3 scopes it to
+#       the comprehension and it does not leak.
+#   comprehension WALRUS target .................. NO, but for a DIFFERENT
+#       reason, and the row above does not carry over. PEP 572 binds a walrus
+#       target in the CONTAINING scope, so it DOES leak out of the
+#       comprehension — and then lands under whichever row governs that scope.
+#       Inside a function that is the function-body row, so it is private and
+#       clean; at module scope it is reachable and the reference check catches
+#       any real clock read regardless. Verified by execution.
 #
 # Rareness and suspiciousness are NOT the test; reachability is. A rule that
 # flags code which cannot produce the harm is the failure mode that gets lints
@@ -732,11 +739,25 @@ ENCLOSING_SCOPE_CASES = [
     # that away: nothing is rebound, the function is never called, and in the
     # first three the name is never referenced in the body either.
     #
-    # "Unused" is the whole point. A default, a decorator, an annotation and a
-    # base list are all evaluated in the ENCLOSING scope at definition time —
-    # `def f(x=time.sleep)` captures the real time.sleep the moment the def
-    # executes, whether or not anything ever calls f. Each of these pins one
-    # arm of _outer_exprs; delete that arm and the case goes silent.
+    # "Unused" is the whole point: none of these is reachable by looking at the
+    # function body, so a scanner that only walks bodies misses all four.
+    #
+    # Defaults, decorators and base lists are EVALUATED in the enclosing scope
+    # at definition time — `def f(x=time.sleep)` captures the real time.sleep
+    # the moment the def executes, whether or not anything ever calls f.
+    #
+    # Annotations are the exception and the earlier wording here was wrong.
+    # Every file in this suite carries `from __future__ import annotations`
+    # (see the module docstring at the top), so annotations are stringified and
+    # never evaluated at all; on 3.14 they are lazy regardless. The VERDICT is
+    # unchanged — PEP 649's annotate function still closes over the enclosing
+    # scope, so the name it would resolve is the enclosing one — but the
+    # mechanism is deferred resolution, not evaluation at definition time, and
+    # the previous claim that this was "confirmed by executing it" was false
+    # for the annotation arm. Do not re-derive the old sentence.
+    #
+    # Each of these pins one arm of _outer_exprs; delete that arm and the case
+    # goes silent.
     ("outer position alone: unused default argument", """
         import time
 
@@ -954,6 +975,25 @@ CLEAN_CASES = [
 
         _UNUSED = [None for time in ()]
     """),
+    # Twin of the case above, and the asymmetry IS the content: a normal `for`
+    # target does not leak out of the comprehension, but a WALRUS target binds
+    # in the CONTAINING scope (PEP 572). So `time` here is a genuine local of
+    # `elapsed`, the module import is unreachable from the whole body by the
+    # function-body row of the discriminator, and `time.monotonic()` is not a
+    # clock read at all.
+    #
+    # Executed to confirm the binding is real, not theoretical:
+    # `elapsed(["NOT-THE-STDLIB"])` returns 'NOT-THE-STDLIB'. The discriminator's
+    # comprehension row is written for the `for` target and does not carry over
+    # to the walrus — do not collapse the two.
+    ("walrus target in a comprehension binds in the CONTAINING scope", """
+        import time
+
+
+        def elapsed(rows):
+            marks = [(time := r) for r in rows]
+            return time.monotonic()
+    """),
     ("comprehension target reusing an imported name — list", """
         import json
 
@@ -1026,11 +1066,18 @@ CLEAN_CASES = [
 
         annotations = {"a": 1}
     """),
-    ("optional dependency: `import numpy` / `numpy = None`", """
+    # RE-POINTED from numpy to pandas. As written with `numpy` this guard
+    # PASSED VACUOUSLY and pinned nothing: `numpy` is not in WATCHED_BASES
+    # (verified — `"numpy" in WATCHED_BASES` is False), so no rule could ever
+    # have fired on it and the case could not fail. `pandas` IS a watched base,
+    # via pandas.Timestamp.now, and is a hard dependency of fundbt/ — so this
+    # spelling is both the realistic one and the one that can actually fail.
+    # A guard that cannot fail is the same defect as an unpinned block.
+    ("optional dependency: `import pandas` / `pandas = None`", """
         try:
-            import numpy
+            import pandas
         except ImportError:
-            numpy = None
+            pandas = None
     """),
     # --- round three: arity discriminates a clock read from a formatter ----
     # time.strftime/asctime/ctime read the wall clock ONLY in their no-arg

--- a/tests/test_check_purity.py
+++ b/tests/test_check_purity.py
@@ -290,13 +290,24 @@ MASTER_REGRESSION_CASES = [
 #       all three verified by execution.
 #   comprehension `for` target ................... NO, Python 3 scopes it to
 #       the comprehension and it does not leak.
-#   comprehension WALRUS target .................. NO, but for a DIFFERENT
-#       reason, and the row above does not carry over. PEP 572 binds a walrus
-#       target in the CONTAINING scope, so it DOES leak out of the
-#       comprehension — and then lands under whichever row governs that scope.
-#       Inside a function that is the function-body row, so it is private and
-#       clean; at module scope it is reachable and the reference check catches
-#       any real clock read regardless. Verified by execution.
+#   comprehension WALRUS target .................. DEPENDS, and the `for` row
+#       above does not carry over. PEP 572 binds a walrus target in the
+#       CONTAINING scope, so it leaks out of the comprehension and lands under
+#       whichever row governs that scope: private inside a function body,
+#       reachable at module scope.
+#
+#       AND — a use INSIDE the same comprehension also resolves to the
+#       containing scope, so if the name is import-bound there the use reaches
+#       the real module. `[(time := time.sleep(0.30)) for _ in range(1)]`
+#       blocks for a third of a second and leaves `time` as None. The name must
+#       therefore NOT be popped inside the comprehension.
+#
+#       CORRECTION: this row previously ended "at module scope it is reachable
+#       and the reference check catches any real clock read regardless." That
+#       was mine and it was false — the reference check did NOT catch the
+#       self-use shape, which is how six evasions survived a round. It is the
+#       kind of claim this file exists to disprove, so it is recorded rather
+#       than quietly replaced.
 #
 # Rareness and suspiciousness are NOT the test; reachability is. A rule that
 # flags code which cannot produce the harm is the failure mode that gets lints
@@ -323,7 +334,7 @@ MASTER_REGRESSION_CASES = [
 #      left as a husk; this comment is the durable artefact, not that table.
 #   4. The collision REPORT was deleted outright and every case here was
 #      re-measured against an ablated copy rather than reassigned by
-#      assumption. Seven stayed violations under the reference check and their
+#      assumption. EIGHT stayed violations under the reference check and their
 #      rule moved from the deleted RULE_COLLISION to RULE_CLOCK_REF; `global`
 #      stayed red for a different reason (see its case); two moved to
 #      CLEAN_CASES. RULE_COLLISION was removed because nothing asserts it.
@@ -409,6 +420,81 @@ BINDING_STANDS_CASES = [
             grabbed = time.time
             time = None
             return grabbed
+    """, RULE_CLOCK_REF),
+    # `nonlocal` onto an enclosing function's IMPORT. Twin of "nonlocal onto a
+    # NON-import enclosing local" in CLEAN_CASES, and the difference between
+    # them is the whole rule: an `import` inside a function is a function-local
+    # binding whose value IS the module, so `nonlocal` reaches it. The earlier
+    # claim that `nonlocal` "can never reach an import" was wrong, and the case
+    # written on it has been corrected rather than deleted.
+    # Executed: inner() blocks 0.305s on a real wall clock.
+    ("nonlocal onto an enclosing function's import", """
+        def outer():
+            import time
+
+            def inner():
+                nonlocal time
+                v = time.sleep(0.30)
+                time = None
+                return v
+
+            return inner
+    """, RULE_CLOCK_REF),
+    # --- walrus used INSIDE its own comprehension --------------------------
+    # PEP 572 gives the walrus target to the CONTAINING scope, so a use inside
+    # the comprehension resolves there — to the import. The lint also binds the
+    # target inside the comprehension's own scope, which pops the name exactly
+    # where the use is read, so the use resolves to nothing and the clock read
+    # goes clean. Every one of these executes and blocks ~0.30s on a real wall
+    # clock; the module-scope variants leave `time` set to None afterwards.
+    #
+    # This was previously documented in the lint as harmless because "both paths
+    # bind to unresolvable, so no verdict differs". That is falsified by every
+    # case below and is the fourth "harmless by construction" claim in this
+    # change to turn out false. Measure such claims; do not accept them.
+    ("walrus used inside its own listcomp", """
+        import time
+
+        _U = [(time := time.sleep(0.30)) for _ in range(1)]
+    """, RULE_CLOCK_REF),
+    ("walrus used inside its own setcomp", """
+        import time
+
+        _U = {(time := time.sleep(0.30)) for _ in range(1)}
+    """, RULE_CLOCK_REF),
+    ("walrus used inside its own dictcomp", """
+        import time
+
+        _U = {i: (time := time.sleep(0.30)) for i in range(1)}
+    """, RULE_CLOCK_REF),
+    ("walrus used inside its own genexp", """
+        import time
+
+        _U = tuple((time := time.sleep(0.30)) for _ in range(1))
+    """, RULE_CLOCK_REF),
+    ("walrus used inside a comprehension's `if` clause", """
+        import time
+
+        _U = [x for x in range(1) if (time := time.sleep(0.30)) is None]
+    """, RULE_CLOCK_REF),
+    ("walrus used inside its own comprehension, in function scope", """
+        def go():
+            import time
+            return [(time := time.sleep(0.30)) for _ in range(1)]
+    """, RULE_CLOCK_REF),
+    # PIN for the nested-scope stop in _walrus_targets, whose docstring asserts
+    # that nested function and class scopes are not crossed. Nothing proved it.
+    # A walrus inside a LAMBDA belongs to the lambda, so it must NOT leak out
+    # and pop the module-level `time` — remove the guard and the genuine
+    # `time.sleep(1)` below goes clean. Currently passes; that is the point.
+    ("walrus inside a lambda nested in a comprehension does not leak", """
+        import time
+
+        _U = [(lambda: (time := 1))() for _ in range(1)]
+
+
+        def pause():
+            time.sleep(1)
     """, RULE_CLOCK_REF),
     ("match-capture (module scope)", """
         import time
@@ -928,21 +1014,24 @@ CLEAN_CASES = [
                 # unexamined shape.
                 return time.monotonic()
     """),
-    # Twin of "global (function body ...)" in BINDING_STANDS_CASES. `nonlocal` can
-    # only bind an ENCLOSING FUNCTION's local, never a module-level import, so
-    # it can never reach the stdlib and must stay clean. That asymmetry with
-    # `global` is the whole content of the pair.
-    ("nonlocal (function body)", """
-        import time
-
-
+    # CORRECTED 2026-08-25. This case previously read `import time` at module
+    # scope with `time = None` in `outer`, and was justified as "`nonlocal` can
+    # only bind an enclosing function's local, never an import, so it can never
+    # reach the stdlib." The premise is true and the conclusion does not follow:
+    # an `import` INSIDE a function creates a function-local binding whose value
+    # IS the module, so `nonlocal` can reach one. That shape is now a violation
+    # in BINDING_STANDS_CASES; this control keeps the genuinely-clean half so
+    # the pair pins the distinction instead of deleting it.
+    #
+    # Here the enclosing local is NOT an import — it is a caller's Timer — so
+    # nothing resolves to the stdlib and `.monotonic()` is that object's own API.
+    ("nonlocal onto a NON-import enclosing local (function body)", """
         def outer():
-            time = None
+            time = Timer()
 
             def inner():
                 nonlocal time
-                time = object()
-                return time
+                return time.monotonic()
 
             return inner
     """),
@@ -1420,22 +1509,25 @@ PACKAGE_RELATIVE_CLEAN_TREES = [
 # re-route a message without breaking a test. That design is structurally blind
 # to one thing: the SAME violation reported twice.
 #
-# Two blocks in the lint exist only to deduplicate. A comprehension's outermost
-# iterable and a parameter's annotation are each reachable by two paths through
-# the scanner, and each block suppresses the second. Delete either and the lint
+# THREE blocks in the lint exist only to deduplicate — this said "two" until a
+# third, the Store-context filter, was found unpinned by exactly the gap this
+# comment was written to close. A comprehension's outermost iterable, a
+# parameter's annotation, and an alias capture's Store target are each reachable
+# by two paths through the scanner, and each block suppresses the second. Delete
+# any of them and the lint
 # stays correct about WHAT is wrong while printing it twice — so no existence
 # check moves, the ablation scores the block as dead, and the next person
 # removes it. The only symptom is doubled output that nobody traces back. That
 # is the same unverified-purpose failure this lane has spent its length
 # closing, with a cosmetic blast radius instead of a correctness one.
 #
-# SCOPE, deliberately narrow (ruled 2026-08-25): these two minimal snippets
-# assert DEDUPLICATION, not a general contract on error counts. Each is chosen
-# to produce exactly one violation by exactly one rule, so the count is
+# SCOPE, deliberately narrow (ruled 2026-08-25): these minimal snippets assert
+# DEDUPLICATION, not a general contract on error counts. Each is chosen to
+# produce exactly one violation by exactly one rule, so the count is
 # unambiguous. If a future rule legitimately fires twice on one of these
-# snippets, the right fix is to update THESE TWO CASES deliberately — not to
-# loosen them back to existence checks, and not to freeze counts anywhere else
-# in this file.
+# snippets, the right fix is to update THESE CASES deliberately — not to loosen
+# them back to existence checks, and not to freeze counts anywhere else in this
+# file.
 DEDUP_CASES = [
     ("comprehension's outermost iterable, reported once", """
         import time
@@ -1450,6 +1542,15 @@ DEDUP_CASES = [
 
         def f(x: time.time = None):
             pass
+    """, 1),
+    # The third block: the Store-context filter. Without it the alias's Store
+    # target is scanned too, resolves through alias propagation to time.sleep,
+    # and the same violation is reported twice. Measured 1 -> 2. (A chained
+    # `_a = _b = time.sleep` does NOT double, so it would not pin this.)
+    ("alias capture, reported once", """
+        import time
+
+        _sleep = time.sleep
     """, 1),
 ]
 

--- a/tests/test_check_purity.py
+++ b/tests/test_check_purity.py
@@ -1,20 +1,28 @@
 """The purity lint's own negative controls (issue #43).
 
-`scripts/check_purity.py` enforces CLAUDE.md invariant 3, but it matches on the
-literal source text of a call's base and only ever looks at `ast.Import` /
-`ast.ImportFrom` nodes. A file can therefore import `anthropic` and read the
-wall clock while the lint reports `clean`. Each entry in EVASION_CASES below is
-a snippet that the lint must flag and today does not.
+`scripts/check_purity.py` enforces CLAUDE.md invariant 3. A lint whose negative
+control also passes is not a lint, so every table here is one half of a pair:
+something the lint must catch, and the legitimate code next door it must not.
 
-The two tables that follow are the other half: DETECTED_CASES are the
-violations the lint already catches and must keep catching, and CLEAN_CASES are
-correct code — above all `self._clock.now()`, the injected-Clock pattern the
-invariant exists to *require*. A rewrite that resolves bindings instead of
-source text will over-fire without them.
+Round one covered the source-spelling evasions (aliased bindings, dynamic
+imports, unlisted clock spellings, `market/`). Round two adds four groups:
 
-SLACKKIT_INIT_VIOLATIONS covers the third boundary: `slackkit` goes in neither
-list, and instead `slackkit/__init__.py` must stay import-free — the mechanism
-that lets orchestrator import `slackkit.outbox` without pulling in `slack_sdk`.
+* MASTER_REGRESSION_CASES — violations master flagged that the binding rewrite
+  stopped flagging. A lint that gets looser is worse than one that never moved.
+* COLLISION_CASES — an import binding colliding with a rebinding *in the same
+  scope* is a violation, not a shadow. Popping the name on any rebinding makes
+  `import time` + `if False: time = None` a working, silent bypass.
+* CALLABLE_CAPTURE_CASES — only a call on an attribute chain was matched, so
+  `_sleep = time.sleep` defeated the check while reading as careful seam code.
+* SLACKKIT_* — option (d): lint `slackkit/` as a pure package with `real.py`
+  excluded, and forbid pure packages from importing `slackkit.real`. That last
+  rule needs *dotted-prefix* matching: `FORBIDDEN_IMPORTS` is compared against
+  `name.split(".")[0]`, so the string "slackkit.real" added to it would match
+  nothing, forever. The ablation below is what proves the matcher changed.
+
+CLEAN_CASES is the load-bearing half — above all `self._clock.now()`, the
+injected-Clock pattern the invariant exists to *require*. A lint that flags
+correct code is the failure mode that gets a lint deleted.
 
 Zero dependencies: plain no-arg `def test_*` functions and stdlib `tempfile`,
 so it runs under pytest (what CI and `make test` invoke) and under the
@@ -136,7 +144,235 @@ UNLISTED_CLOCK_CALL_CASES = [
     """),
 ]
 
-EVASION_CASES = DYNAMIC_IMPORT_CASES + ALIASED_BINDING_CASES + UNLISTED_CLOCK_CALL_CASES
+# --- round two -------------------------------------------------------------
+
+# Violations MASTER flags that the binding rewrite stopped flagging. Each one
+# is a place where the scope model pops a name that Python does not actually
+# rebind, or fails to bind one it does.
+MASTER_REGRESSION_CASES = [
+    ("class-body binding leaking into a method scope", """
+        from datetime import date
+
+
+        class Row:
+            # An ordinary pydantic/dataclass field. Class scope is NOT visible
+            # inside methods, so `date` below is still the stdlib import —
+            # state/models.py:8 already does `from datetime import date`.
+            date: date = None
+
+            def stamp(self):
+                return date.today()
+    """),
+    ("star-import binds the literal name '*'", """
+        from datetime import *
+
+
+        def stamp():
+            return datetime.now()
+    """),
+    ("comprehension target folded into the parent scope", """
+        import time
+
+        # A comprehension target is invisible outside the comprehension, so
+        # folding it into module scope buys nothing and silences the file.
+        _UNUSED = [None for time in ()]
+
+
+        def pause():
+            time.sleep(1)
+    """),
+]
+
+# An import binding rebound in the SAME scope is incoherent code, not a shadow.
+# The current pop is position- and condition-independent, so each of these
+# silences the whole scope while looking like a no-op.
+COLLISION_CASES = [
+    ("`if False: time = None` at module scope", """
+        import time
+
+        if False:
+            time = None
+
+
+        def pause():
+            time.sleep(1)
+    """),
+    ("`time = time` self-assignment on the last line", """
+        import time
+
+
+        def pause():
+            time.sleep(1)
+
+
+        time = time
+    """),
+    ("`except Exception as time:` at module scope", """
+        import time
+
+        try:
+            pass
+        except Exception as time:
+            pass
+
+
+        def pause():
+            time.sleep(1)
+    """),
+    ("`with open(...) as time:` at module scope", """
+        import time
+
+        with open("/dev/null") as time:
+            pass
+
+
+        def pause():
+            time.sleep(1)
+    """),
+    ("walrus `if (time := None):` at module scope", """
+        import time
+
+        if (time := None):
+            pass
+
+
+        def pause():
+            time.sleep(1)
+    """),
+    ("same-scope rebind placed after the use", """
+        import time
+
+        time.sleep(1)
+        time = None
+    """),
+]
+
+# Same clock, one spelling away from the listed one.
+CLOCK_SPELLING_CASES = [
+    ("datetime.today() — date.today is listed, datetime.today is not", """
+        from datetime import datetime
+
+
+        def stamp():
+            return datetime.today()
+    """),
+    ("time.time_ns()", """
+        import time
+
+
+        def stamp():
+            return time.time_ns()
+    """),
+    ("time.monotonic_ns()", """
+        import time
+
+
+        def stamp():
+            return time.monotonic_ns()
+    """),
+    ("time.perf_counter_ns()", """
+        import time
+
+
+        def stamp():
+            return time.perf_counter_ns()
+    """),
+    ("time.process_time()", """
+        import time
+
+
+        def stamp():
+            return time.process_time()
+    """),
+    ("time.localtime()", """
+        import time
+
+
+        def stamp():
+            return time.localtime()
+    """),
+    ("time.gmtime()", """
+        import time
+
+
+        def stamp():
+            return time.gmtime()
+    """),
+]
+
+# Rebindings of the dynamic-import builtins. Master misses these too — they are
+# still-open evasions, not regressions.
+DYNAMIC_IMPORT_SPELLING_CASES = [
+    ("from builtins import __import__", """
+        from builtins import __import__
+
+
+        def sdk():
+            return __import__("anthropic")
+    """),
+    ("_imp = __import__, then _imp(...)", """
+        _imp = __import__
+
+
+        def sdk():
+            return _imp("anthropic")
+    """),
+]
+
+# Capturing the callable instead of calling it. These read as conscientious
+# Clock-protocol code while being exactly the wall-clock dependency invariant 3
+# bans — the reviewers rated this the most realistic gap of the set.
+CALLABLE_CAPTURE_CASES = [
+    ("module-level seam alias `_sleep = time.sleep`", """
+        import time
+
+        _sleep = time.sleep
+    """),
+    ("dispatch table holding datetime.utcnow", """
+        from datetime import datetime
+
+        _FIELDS = {"ts": datetime.utcnow}
+    """),
+    ("adapter class whose attributes are the clock functions", """
+        import time
+        from datetime import datetime
+
+
+        class SystemClock:
+            now = datetime.now
+            sleep = time.sleep
+    """),
+    ("default-argument fallback `_fallback=time.monotonic`", """
+        import time
+
+
+        class Runner:
+            def __init__(self, clock=None, _fallback=time.monotonic):
+                self._clock = clock
+                self._fallback = _fallback
+    """),
+    ("intermediate module alias `_clock_mod = time`", """
+        import time
+
+        _clock_mod = time
+
+
+        def pause():
+            _clock_mod.sleep(1)
+    """),
+    ("getattr(time, \"sleep\")() — house style at market/source_alpaca.py:33", """
+        import time
+
+
+        def pause():
+            getattr(time, "sleep")()
+    """),
+]
+
+EVASION_CASES = (DYNAMIC_IMPORT_CASES + ALIASED_BINDING_CASES
+                 + UNLISTED_CLOCK_CALL_CASES + MASTER_REGRESSION_CASES
+                 + COLLISION_CASES + CLOCK_SPELLING_CASES
+                 + DYNAMIC_IMPORT_SPELLING_CASES + CALLABLE_CAPTURE_CASES)
 
 # Already caught today. These must survive the rewrite.
 DETECTED_CASES = [
@@ -199,6 +435,34 @@ CLEAN_CASES = [
             # The feed's own API; nothing to do with the wall clock.
             return feed.now()
     """),
+    # --- round two ---
+    # The hinge of the collision rule: a shadow is legitimate precisely when
+    # the name is bound by something other than an import. The two cases above
+    # (`def elapsed(time)`, `datetime = Formatter(rows)`) are green because
+    # their files never import the shadowed name at all. This one is green for
+    # the harder reason — the file DOES import `time`, and the parameter is a
+    # different scope, which Python resolves to the parameter. Delete the
+    # scope/shadow logic and this case goes red, which is the point of it.
+    ("module-level `import time` + a parameter named `time` (different scope)", """
+        import time
+
+
+        def elapsed(time):
+            # The caller's Timer. Python binds this to the parameter inside
+            # this scope; the module-level import is not visible here.
+            return time.perf_counter()
+    """),
+    ("match/case capture pattern is a binding", """
+        import time
+
+
+        def handle(event):
+            match event:
+                case {"clock": time}:
+                    # `time` is the captured dict value, not the module.
+                    return time.monotonic()
+            return None
+    """),
 ]
 
 CLEAN_FILE = """
@@ -209,14 +473,19 @@ CLEAN_FILE = """
         return gross - fees
 """
 
-# --- slackkit: the empty __init__.py is a load-bearing boundary -------------
+# --- slackkit, option (d) ---------------------------------------------------
 #
-# `slackkit` belongs in NEITHER PURE_PACKAGES nor FORBIDDEN_IMPORTS — both
-# redden legitimate code. What makes `orchestrator/daily.py:24`'s
-# `from slackkit.outbox import ...` safe is that `slackkit/__init__.py` is
-# empty, so importing a submodule pulls in no `slack_sdk`. `slackkit/real.py`
-# says it "must stay empty"; today nothing enforces that. These are the
-# enforcement. Trees are {relative path: source}, run through main().
+# Lint `slackkit/` as a pure package with `real.py` EXCLUDED, and forbid pure
+# packages from importing `slackkit.real`. Keep the import-free `__init__.py`
+# check. Trees are {relative path: source}, run through main().
+#
+# The half that is easy to get wrong: `FORBIDDEN_IMPORTS` is matched on the
+# ROOT module only — `alias.name.split(".")[0]` and
+# `(node.module or "").split(".")[0]`. Putting the string "slackkit.real" in
+# that tuple can never match, because `root` is "slackkit". It would sit in the
+# source looking like a rule and catch nothing, forever. So what is required is
+# dotted-prefix semantics, and SLACKKIT_ABLATION_CLEAN is what proves the
+# matcher actually moved rather than the constant.
 
 SLACKKIT_INIT_VIOLATIONS = [
     ("__init__.py re-exports the real port", {
@@ -233,8 +502,48 @@ SLACKKIT_INIT_VIOLATIONS = [
     }),
 ]
 
-SLACKKIT_CLEAN_TREES = [
-    ("empty __init__.py, real.py holds the SDK", {
+SLACKKIT_REAL_VIOLATIONS = [
+    ("pure package does `from slackkit.real import RealSlack`", {
+        "slackkit/__init__.py": "",
+        "orchestrator/daily.py": "from slackkit.real import RealSlack\n",
+    }),
+    ("pure package does `import slackkit.real`", {
+        "slackkit/__init__.py": "",
+        "orchestrator/daily.py": "import slackkit.real\n",
+    }),
+    ("dotted prefix reaches subpackages: slackkit.real.helpers", {
+        "slackkit/__init__.py": "",
+        "orchestrator/daily.py": "from slackkit.real.helpers import retry\n",
+    }),
+    ("wall clock parked in slackkit/outbox.py", {
+        # The better half of (d): outbox/render/fake/port are orchestrator's
+        # live dependency and are completely unlinted today, so a clock read
+        # here breaks sim-day determinism silently.
+        "slackkit/__init__.py": "",
+        "slackkit/outbox.py": """
+            import time
+
+
+            def append_event(path, event):
+                return time.time()
+        """,
+    }),
+    ("slack_sdk imported by slackkit/outbox.py", {
+        "slackkit/__init__.py": "",
+        "slackkit/outbox.py": "import slack_sdk\n",
+    }),
+]
+
+# The ablation. Without it, "the matcher was changed" is only the word of
+# whoever changed it — which is exactly what `PURITY LINT: clean, exit 0` said
+# the last two times.
+SLACKKIT_ABLATION_CLEAN = [
+    ("pure package does `from slackkit.outbox import append_alert`", {
+        # Real code: orchestrator/{daily,preconditions,protection,reconcile}.py.
+        "slackkit/__init__.py": "",
+        "orchestrator/daily.py": "from slackkit.outbox import append_alert\n",
+    }),
+    ("slackkit/real.py holds the SDK — excluded from the pure scan", {
         "slackkit/__init__.py": "",
         "slackkit/real.py": """
             import slack_sdk
@@ -244,6 +553,10 @@ SLACKKIT_CLEAN_TREES = [
                 def __init__(self, token):
                     self._client = slack_sdk.WebClient(token=token)
         """,
+    }),
+    ("`slackkit.realtime` is not `slackkit.real` — dotted, not string, prefix", {
+        "slackkit/__init__.py": "",
+        "orchestrator/daily.py": "from slackkit.realtime import stream\n",
     }),
     ("empty __init__.py, outbox.py is plain stdlib", {
         "slackkit/__init__.py": "",
@@ -329,15 +642,47 @@ def test_market_is_linted():
     assert code != 0, "a forbidden import in market/ left the lint exit 0"
 
 
+def test_master_regressions_stay_flagged():
+    """Master flagged all three. A binding rewrite that loses them has made
+    the lint looser than the thing it replaced."""
+    _assert_all_flagged(MASTER_REGRESSION_CASES, "regression vs master")
+
+
+def test_import_colliding_with_a_rebinding_is_flagged():
+    """Popping a name on any rebinding, anywhere in the scope, regardless of
+    whether the branch can execute, is a one-line silencer for a whole file."""
+    _assert_all_flagged(COLLISION_CASES, "same-scope collision")
+
+
+def test_clock_spellings_are_flagged():
+    _assert_all_flagged(CLOCK_SPELLING_CASES, "clock spelling")
+
+
+def test_dynamic_import_spellings_are_flagged():
+    _assert_all_flagged(DYNAMIC_IMPORT_SPELLING_CASES, "dynamic import spelling")
+
+
+def test_captured_callables_are_flagged():
+    """Capturing the function instead of calling it. Reads as careful seam
+    code; is the banned dependency."""
+    _assert_all_flagged(CALLABLE_CAPTURE_CASES, "callable capture")
+
+
 def test_slackkit_init_must_stay_import_free():
     _assert_trees_rejected(SLACKKIT_INIT_VIOLATIONS, "slackkit/__init__.py")
 
 
-def test_slackkit_submodules_may_hold_the_sdk():
-    """The boundary, not a ban: real.py is *supposed* to import slack_sdk.
-    A check that lints all of slackkit/ instead of just __init__.py fails
-    here."""
-    _assert_trees_accepted(SLACKKIT_CLEAN_TREES, "slackkit submodule")
+def test_slackkit_real_is_out_of_bounds_for_pure_packages():
+    _assert_trees_rejected(SLACKKIT_REAL_VIOLATIONS, "slackkit.real")
+
+
+def test_slackkit_ablation():
+    """Required, not optional. Every case here is legitimate code that the
+    `slackkit.real` rule must leave alone — the outbox import four orchestrator
+    modules really make, real.py's SDK, and the dotted-vs-string prefix. A rule
+    that reddens these is worse than the gap it closes; a rule that reddens
+    nothing at all is the defect this whole lane is named after."""
+    _assert_trees_accepted(SLACKKIT_ABLATION_CLEAN, "slackkit ablation")
 
 
 def test_the_real_slackkit_init_is_empty():

--- a/tests/test_check_purity.py
+++ b/tests/test_check_purity.py
@@ -28,10 +28,32 @@ injected-Clock pattern the invariant exists to *require*. A lint that flags
 correct code is the failure mode that gets a lint deleted.
 
 HOW EVERY EVASION IN THIS BRANCH WAS FOUND, and the one thing to know before
-adding a case. Six evasions shipped past a green suite. Not one was found by
-reasoning about a case; every one was found by CROSSING TWO AXES nobody had
-crossed — enclosing-shadow x declaration-kind, nested-scope-kind x where-the-
-read-sits, walrus x alias. The reason is structural:
+adding a case. Six evasions shipped past a green suite. All six were settled by
+EXECUTION and none by argument — but the method that FOUND them was mostly not
+an instrument:
+
+    #  evasion                                   found by
+    1  nonlocal onto an enclosing import         hand counterexample, falsifying
+                                                 a written claim
+    2  walrus self-use in its own comprehension  hand counterexample, falsifying
+                                                 the KNOWN AND DELIBERATE note
+    3  global past an enclosing shadow           ablation
+    4  global with no assignment                 hand attack (generator missed)
+    5  function-local import under global        generated gate (A2 x A3)
+    6  walrus alias not propagated               hand attack (generator missed)
+
+FOUR OF SIX CAME FROM READING A SPECIFIC CLAIM AND TRYING TO BREAK IT. Two came
+from an instrument, and every instrument in play missed at least one that a
+hand-built counterexample caught. Generators confirmed and BOUNDED the
+findings; claim-falsification FOUND most of them — and it is also what produced
+all four vacuous guards below. So the first move on this file is not to build a
+generator: it is to read what the code and the comments claim about themselves
+and attack the claim.
+
+What the instruments contributed was the axis discipline, which is what makes a
+sweep worth running once you have a claim to bound — enclosing-shadow x
+declaration-kind, nested-scope-kind x where-the-read-sits, walrus x alias. The
+reason those pairs were where the bugs lived is structural:
 
     EVERY CASE FIXES ONE VALUE OF EVERY AXIS IT DOES NOT NAME.
 

--- a/tests/test_check_purity.py
+++ b/tests/test_check_purity.py
@@ -349,6 +349,24 @@ MASTER_REGRESSION_CASES = [
 # Each module-scope entry below pairs with a function-body twin in CLEAN_CASES
 # under the same name. Same shape, different scope, opposite verdict — that
 # pairing IS the rule, so keep the names matched if you touch either table.
+#
+# WARNING ABOUT THE `global` BLOCK — read before adding or pruning a case there.
+# It has produced THREE separate evasions, and each one was invisible to the
+# case written for the one before it. Measured, not recalled: reverting the fix
+# for evasion N leaves the case for evasion N-1 red, every time.
+#
+#     evasion          the case that existed             pinned it?
+#     enclosing shadow  (none)                            -
+#     no assignment     global + assignment               NO, stayed red
+#     local import      global +/- assignment (both)      NO, both stayed red
+#
+# So a case here that "already covers global" almost certainly covers one
+# INSTANCE of the rule. That is the general trap: a case pinning one instance
+# reads exactly like a case pinning the rule, and an ablation cannot separate
+# them either, because deleting the block fails both. The only defence is
+# another case that varies the axis the first one silently fixed — which is
+# also why the axes a table names are a CLAIM about what it covers, and an axis
+# list that overstates coverage is the same defect as an unfalsifiable guard.
 BINDING_STANDS_CASES = [
     ("`if False: time = None` at module scope", """
         import time
@@ -483,6 +501,35 @@ BINDING_STANDS_CASES = [
                 return time.sleep(0.30)
 
             return inner
+    """, RULE_CLOCK_REF),
+    # THIRD `global` shape, and again neither case above could catch it. Under
+    # `global x`, a function-local `import x` binds the MODULE's x to the module
+    # object, so this scope's own import must win over whatever module scope
+    # held. The fix for the previous evasion overwrote that binding
+    # unconditionally and clobbered the import.
+    #
+    # Deletion-check (standing rule): revert the `not in imported` guard on a
+    # copy and THIS case goes clean while BOTH cases above stay red —
+    #     global + function-local import   FLAG -> clean   (this case)
+    #     global, WITH assignment          FLAG -> FLAG    (cannot pin it)
+    #     global, NO assignment            FLAG -> FLAG    (cannot pin it)
+    # so the two existing cases are not merely redundant here, they are blind.
+    #
+    # Verified: probe() blocks 0.302s; the same shape without the inner
+    # `import time` raises NameError, proving the inner import is the
+    # precondition; the same shape with no sleep reports 0.001s (executor
+    # control). Passes today — a pin, not a red case.
+    ("global + a function-local import of the same name", """
+        def outer():
+            import time
+            time = None
+
+            def probe():
+                global time
+                import time
+                return time.sleep(0.30)
+
+            return probe
     """, RULE_CLOCK_REF),
     # PIN for the nested-scope stop in _walrus_targets, whose docstring asserts
     # that nested function and class scopes are not crossed. Found by generating

--- a/tests/test_check_purity.py
+++ b/tests/test_check_purity.py
@@ -9,9 +9,12 @@ imports, unlisted clock spellings, `market/`). Round two adds four groups:
 
 * MASTER_REGRESSION_CASES — violations master flagged that the binding rewrite
   stopped flagging. A lint that gets looser is worse than one that never moved.
-* COLLISION_CASES — an import binding colliding with a rebinding *in the same
-  scope* is a violation, not a shadow. Popping the name on any rebinding makes
-  `import time` + `if False: time = None` a working, silent bypass.
+* COLLISION_CASES — an import binding colliding with a rebinding is a
+  violation, not a shadow, wherever a use site can still reach the import.
+  Popping the name on any rebinding makes `import time` + `if False: time =
+  None` a working, silent bypass. The discriminator that decides which
+  positions qualify, and the history of the three cases that moved across it,
+  are documented on that table.
 * CALLABLE_CAPTURE_CASES — only a call on an attribute chain was matched, so
   `_sleep = time.sleep` defeated the check while reading as careful seam code.
 * SLACKKIT_* — option (d): lint `slackkit/` as a pure package with `real.py`
@@ -225,9 +228,66 @@ MASTER_REGRESSION_CASES = [
     """, RULE_CLOCK_REF),
 ]
 
-# An import binding rebound in the SAME scope is incoherent code, not a shadow.
-# The current pop is position- and condition-independent, so each of these
-# silences the whole scope while looking like a no-op.
+# THE COLLISION DISCRIMINATOR. One question decides every shadowing case in
+# this file:
+#
+#     Can the rebinding make a use site resolve to the import?
+#
+# The rows fall out of the question; the question cannot be re-derived from the
+# rows, which is why it is written here and not as a list of scope kinds.
+#
+#   module scope ................................. YES, rebind and use share
+#       one namespace. Verified: with `import time` above it, a use placed
+#       before an `except ... as time` / `with ... as time` / `case {...: time}`
+#       returns a real 145616.61 timestamp, and afterwards the name is the
+#       caught object (or deleted, for except-as).
+#   class body ................................... YES, LOAD_NAME with a global
+#       fallback: `a = time.time()` on the line ABOVE `time = None` is real.
+#   defaults, decorators, annotations, base-class
+#       lists, a genexp's outermost iterable ..... YES, evaluated in the
+#       ENCLOSING scope, before the shadow exists.
+#   function body ................................ NO. Binding a name ANYWHERE
+#       in a function makes it local for the whole body, so a use before the
+#       binding raises UnboundLocalError and never reaches the module. This
+#       covers parameters, `except ... as`, and `match`/`case` captures alike —
+#       all three verified by execution.
+#   comprehension target ......................... NO, Python 3 scopes it and
+#       it does not leak.
+#
+# Rareness and suspiciousness are NOT the test; reachability is. A rule that
+# flags code which cannot produce the harm is the failure mode that gets lints
+# deleted, which this lane has now established twice.
+#
+# ASSERTION HISTORY — inverted, then reverted in two steps. Every move ruled
+# and approved by the coordinator, 2026-08-25. Recorded so the next reader
+# files this as a decision rather than churn and does not re-litigate it:
+#
+#   1. The parameter / except-as / match-capture cases asserted CLEAN, and were
+#      INVERTED to assert a VIOLATION under a rule of "a collision at EVERY
+#      scope". That was a TIGHTENING — a stricter claim about what the lint
+#      must catch — never a weakening to make a failing test pass, which
+#      CLAUDE.md forbids. No expected value was edited to match an
+#      implementation's output; the encoded rule changed.
+#   2. The rule was revised to the discriminator above and the PARAMETER case
+#      was reverted to CLEAN. The revert was deliberately partial.
+#   3. The two remaining cases were then reverted as well, once execution
+#      showed the justification for keeping them was wrong: an `except ... as`
+#      target and a `match` capture are exactly as private as a parameter, so
+#      the discriminator answers NO for all three. A carve-out for "conditional
+#      or partial bindings are suspicious" was offered and explicitly rejected.
+#      The table that held them (INVERTED_SHADOW_CASES) was retired rather than
+#      left as a husk; this comment is the durable artefact, not that table.
+#
+# The background to move 1 stands: the shadow rule was deleted because it
+# protected nothing. Monkeypatching `_bound_names` to return set() left every
+# injected-Clock shape clean, orchestrator/clock.py included, because the real
+# mechanism is that `self` is unresolvable. A sweep of all 45 pure-package
+# files found ZERO parameters or locals named time/date/datetime/asyncio/
+# importlib. It cost ~10 looser-than-master rows and enabled a regression.
+#
+# Each module-scope entry below pairs with a function-body twin in CLEAN_CASES
+# under the same name. Same shape, different scope, opposite verdict — that
+# pairing IS the rule, so keep the names matched if you touch either table.
 COLLISION_CASES = [
     ("`if False: time = None` at module scope", """
         import time
@@ -249,7 +309,7 @@ COLLISION_CASES = [
 
         time = time
     """, RULE_COLLISION),
-    ("`except Exception as time:` at module scope", """
+    ("except-as (module scope)", """
         import time
 
         try:
@@ -261,7 +321,7 @@ COLLISION_CASES = [
         def pause():
             time.sleep(1)
     """, RULE_COLLISION),
-    ("`with open(...) as time:` at module scope", """
+    ("with-as (module scope)", """
         import time
 
         with open("/dev/null") as time:
@@ -270,6 +330,18 @@ COLLISION_CASES = [
 
         def pause():
             time.sleep(1)
+    """, RULE_COLLISION),
+    # Added when the function-body twin moved to CLEAN_CASES, so the pair is
+    # complete on both sides. Verified at module scope: the use above returns a
+    # real timestamp and `time` afterwards is the captured value.
+    ("match-capture (module scope)", """
+        import time
+
+        _NOW = time.monotonic()
+
+        match {"clock": 1}:
+            case {"clock": time}:
+                pass
     """, RULE_COLLISION),
     ("walrus `if (time := None):` at module scope", """
         import time
@@ -483,66 +555,6 @@ CALLABLE_CAPTURE_CASES = [
 
 # --- round three ------------------------------------------------------------
 
-# THE COLLISION DISCRIMINATOR. One question decides every case in this file:
-#
-#     Can the rebinding make a use site resolve to the import?
-#
-# The rows fall out of the question; the question cannot be re-derived from the
-# rows, which is why it is written here and not as a list of scope kinds.
-# Module scope: yes, rebind and use share one namespace. Class body: yes —
-# LOAD_NAME with a global fallback, so `a = time.time()` on the line ABOVE
-# `time = None` returns a real timestamp. Defaults, decorators, annotations,
-# base-class lists, a genexp's outermost iterable: yes, all evaluated in the
-# ENCLOSING scope, before the shadow exists. Function body: no, Python
-# guarantees the binding is private for the whole body. Comprehension target:
-# no, Python 3 scopes it and it does not leak (verified by execution).
-#
-# ASSERTION HISTORY — inverted, then PARTIALLY reverted. Both moves ruled and
-# approved by the coordinator, 2026-08-25, recorded so the next reader files
-# this as a decision rather than churn and does not re-litigate it:
-#
-#   1. Round three: these cases asserted CLEAN and were INVERTED to assert a
-#      VIOLATION, when the rule was "a collision at EVERY scope". That was a
-#      tightening — a stricter claim about what the lint must catch — never a
-#      weakening to make a failing test pass, which CLAUDE.md forbids. No
-#      expected value was edited to match an implementation's output.
-#   2. Round four: the "every scope" rule was revised to the discriminator
-#      above, and the parameter case was REVERTED to CLEAN — a parameter can
-#      never make a use site resolve to the import. It now lives in
-#      CLEAN_CASES. The revert is partial ON PURPOSE: `except ... as` and
-#      `match/case` capture stay violations. Blanket-undoing the inversion
-#      would have been the easy edit and would have quietly re-opened two
-#      shapes.
-#
-# The background to move 1 stands: the shadow rule was deleted because it
-# protected nothing. Monkeypatching `_bound_names` to return set() left every
-# injected-Clock shape clean, orchestrator/clock.py included, because the real
-# mechanism is that `self` is unresolvable. A sweep of all 45 pure-package
-# files found ZERO parameters or locals named time/date/datetime/asyncio/
-# importlib. It cost ~10 looser-than-master rows and enabled a regression.
-INVERTED_SHADOW_CASES = [
-    ("import time + `except TimeoutError as time`", """
-        import time
-
-
-        def deadline(fn):
-            try:
-                return fn()
-            except TimeoutError as time:
-                return time.time
-    """, RULE_COLLISION),
-    ("import time + a match/case capture named `time`", """
-        import time
-
-
-        def handle(event):
-            match event:
-                case {"clock": time}:
-                    return time.monotonic()
-            return None
-    """, RULE_COLLISION),
-]
-
 # The "yes" rows of the discriminator above: positions evaluated in the
 # ENCLOSING scope, where a later rebinding does not shadow the import, plus
 # class bodies whose LOAD_NAME falls back to the global. The earlier ruling —
@@ -618,7 +630,7 @@ EVASION_CASES = (DYNAMIC_IMPORT_CASES + ALIASED_BINDING_CASES
                  + UNLISTED_CLOCK_CALL_CASES + MASTER_REGRESSION_CASES
                  + COLLISION_CASES + CLOCK_SPELLING_CASES
                  + DYNAMIC_IMPORT_SPELLING_CASES + CALLABLE_CAPTURE_CASES
-                 + INVERTED_SHADOW_CASES + ENCLOSING_SCOPE_CASES)
+                 + ENCLOSING_SCOPE_CASES)
 
 # Already caught today. These must survive the rewrite.
 DETECTED_CASES = [
@@ -695,14 +707,21 @@ CLEAN_CASES = [
             # `time` is a Timer passed in by the caller, not the stdlib module.
             return time.perf_counter()
     """),
-    # PARTIALLY REVERTED 2026-08-25 (see the note on INVERTED_SHADOW_CASES).
-    # This case was inverted to a violation under the "collision at every
-    # scope" rule, then reverted here when that rule was revised to the
-    # discriminator: a parameter is private to the whole function body, so it
-    # can never make a use site resolve to the import. Unlike the two cases
-    # above it, this file DOES import `time` — which is exactly why it is the
-    # one that pins the function-body row of the discriminator.
-    ("module-level `import time` + a parameter named `time`", """
+    # --- the function-body row of the discriminator -----------------------
+    # These three pin it, and each is the twin of an identically-named entry in
+    # COLLISION_CASES that differs ONLY in scope. Same shape, module scope =
+    # violation; same shape, function body = clean. That pairing IS the rule,
+    # so keep the names matched if you touch either table.
+    #
+    # All three were inverted to violations under the superseded "collision at
+    # every scope" rule and reverted here — the parameter first, then the other
+    # two once execution showed an `except ... as` target and a `match` capture
+    # are exactly as private as a parameter. Full history on COLLISION_CASES.
+    #
+    # Unlike the shadow cases further up, every file here DOES import the name,
+    # which is what makes them pins rather than trivia: with no import there is
+    # no binding to collide with and the case proves nothing.
+    ("parameter (function body)", """
         import time
 
 
@@ -710,6 +729,41 @@ CLEAN_CASES = [
             # Python binds this to the parameter for the entire body; the
             # module-level import is unreachable from here.
             return time.perf_counter()
+    """),
+    ("except-as (function body)", """
+        import time
+
+
+        def deadline(fn):
+            try:
+                return fn()
+            except TimeoutError as time:
+                # Binding `time` anywhere in this function makes it local for
+                # the WHOLE body — a use above would raise UnboundLocalError,
+                # never reach the module. Verified by execution.
+                return time.time
+    """),
+    ("match-capture (function body)", """
+        import time
+
+
+        def handle(event):
+            match event:
+                case {"clock": time}:
+                    # Same as except-as: local for the whole body.
+                    return time.monotonic()
+            return None
+    """),
+    ("with-as (function body)", """
+        import time
+
+
+        def pause(ctx):
+            with ctx as time:
+                # Completes the matrix: every shape in COLLISION_CASES has a
+                # function-body twin here. A gap in the pairing reads as an
+                # unexamined shape.
+                return time.monotonic()
     """),
     ("local variable named `datetime` shadowing the class", """
         def label(rows):
@@ -1107,16 +1161,6 @@ def test_captured_callables_are_flagged():
     """Capturing the function instead of calling it. Reads as careful seam
     code; is the banned dependency."""
     _assert_all_flagged(CALLABLE_CAPTURE_CASES, "callable capture")
-
-
-def test_shadowing_an_import_where_a_use_can_still_reach_it():
-    """Assertions here were deliberately INVERTED from clean to violation, then
-    PARTIALLY reverted, both ruled and approved 2026-08-25 — see the note on
-    INVERTED_SHADOW_CASES. A tightening, never a weakening to make a test pass.
-    Renamed from ..._is_a_collision_at_any_scope: "any scope" was the rule that
-    got revised, and a test name outliving its rule is how the next reader
-    learns the wrong one."""
-    _assert_all_flagged(INVERTED_SHADOW_CASES, "inverted shadow")
 
 
 def test_enclosing_scope_positions_are_flagged():

--- a/tests/test_check_purity.py
+++ b/tests/test_check_purity.py
@@ -32,7 +32,9 @@ so it runs under pytest (what CI and `make test` invoke) and under the
 
 from __future__ import annotations
 
+import contextlib
 import importlib.util
+import io
 import subprocess
 import sys
 import tempfile
@@ -59,8 +61,10 @@ def _errors_for(source: str) -> list[str]:
         return _load().check_file(path)
 
 
-def _lint_exit_code_for_tree(files: dict[str, str]) -> int:
-    """main() against a scratch ROOT built from {relative path: source}."""
+def _lint_run_tree(files: dict[str, str]) -> tuple[int, str]:
+    """main() against a scratch ROOT built from {relative path: source},
+    returning (exit code, everything it printed). The output is what lets a
+    tree case assert WHICH rule fired, not merely that the exit was non-zero."""
     with tempfile.TemporaryDirectory() as tmp:
         for rel, source in files.items():
             path = Path(tmp) / rel
@@ -68,15 +72,42 @@ def _lint_exit_code_for_tree(files: dict[str, str]) -> int:
             path.write_text(dedent(source))
         lint = _load()
         lint.ROOT = Path(tmp)
-        return lint.main()
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            code = lint.main()
+        return code, buf.getvalue()
 
 
-def _lint_exit_code(pkg: str, source: str) -> int:
-    """main() against a scratch ROOT whose only content is `pkg/sample.py`."""
-    return _lint_exit_code_for_tree({f"{pkg}/sample.py": source})
+def _lint_exit_code_for_tree(files: dict[str, str]) -> int:
+    return _lint_run_tree(files)[0]
 
 
-# --- (case name, source) tables -------------------------------------------
+# --- rule fragments: deliberate contract, do not loosen ---------------------
+#
+# Every violation case below is (name, source, RULE) and asserts that the
+# named rule is the one that fired — not merely that *something* did.
+#
+# This is not belt-and-braces. `except Exception as time:` stayed red for a
+# whole round with the collision rule deleted, because the reference check
+# flagged `time.sleep` instead and a truthiness assertion cannot tell the two
+# apart. The test reported a plausible verdict while measuring something other
+# than what it claimed, which is the defect in issue #43's own title arriving
+# inside the suite meant to close it. A bare `assert errors` scores a deleted
+# rule as covered.
+#
+# The fragments are deliberately the MINIMUM that identifies a rule, so an
+# implementer stays free to reword any message without breaking a test. Do not
+# extend them toward the full text (that freezes prose), and do not simplify
+# them back to a truthiness check (that reopens the hole).
+
+RULE_FORBIDDEN_IMPORT = "forbidden import"
+RULE_DYNAMIC_IMPORT = "dynamic import"
+RULE_CLOCK_REF = "wall-clock/sleep reference"
+RULE_COLLISION = "imported and rebound"
+RULE_SLACKKIT_INIT = "must stay import-free"
+
+
+# --- (case name, source, expected rule) tables -----------------------------
 
 # Dynamic imports: an ast.Call, never an ast.Import, so the import branch
 # never sees them.
@@ -86,11 +117,11 @@ DYNAMIC_IMPORT_CASES = [
 
         def sdk():
             return importlib.import_module("claude" + "_agent_sdk")
-    """),
+    """, RULE_DYNAMIC_IMPORT),
     ("__import__ builtin", """
         def sdk():
             return __import__("anthropic")
-    """),
+    """, RULE_DYNAMIC_IMPORT),
 ]
 
 # Aliased bindings: FORBIDDEN_CALLS keys on the base's literal source text
@@ -101,19 +132,19 @@ ALIASED_BINDING_CASES = [
 
         def pause():
             _t.sleep(1)
-    """),
+    """, RULE_CLOCK_REF),
     ("from datetime import datetime as _dt, then _dt.now()", """
         from datetime import datetime as _dt
 
         def stamp():
             return _dt.now()
-    """),
+    """, RULE_CLOCK_REF),
     ("from time import sleep, then a bare sleep(1)", """
         from time import sleep
 
         def pause():
             sleep(1)
-    """),
+    """, RULE_CLOCK_REF),
 ]
 
 # Clock/blocking calls absent from FORBIDDEN_CALLS entirely.
@@ -123,25 +154,25 @@ UNLISTED_CLOCK_CALL_CASES = [
 
         def stamp():
             return time.time()
-    """),
+    """, RULE_CLOCK_REF),
     ("time.monotonic()", """
         import time
 
         def stamp():
             return time.monotonic()
-    """),
+    """, RULE_CLOCK_REF),
     ("time.perf_counter()", """
         import time
 
         def stamp():
             return time.perf_counter()
-    """),
+    """, RULE_CLOCK_REF),
     ("asyncio.sleep()", """
         import asyncio
 
         async def pause():
             await asyncio.sleep(0.1)
-    """),
+    """, RULE_CLOCK_REF),
 ]
 
 # --- round two -------------------------------------------------------------
@@ -162,14 +193,14 @@ MASTER_REGRESSION_CASES = [
 
             def stamp(self):
                 return date.today()
-    """),
+    """, RULE_CLOCK_REF),
     ("star-import binds the literal name '*'", """
         from datetime import *
 
 
         def stamp():
             return datetime.now()
-    """),
+    """, RULE_CLOCK_REF),
     ("comprehension target folded into the parent scope", """
         import time
 
@@ -180,7 +211,7 @@ MASTER_REGRESSION_CASES = [
 
         def pause():
             time.sleep(1)
-    """),
+    """, RULE_CLOCK_REF),
 ]
 
 # An import binding rebound in the SAME scope is incoherent code, not a shadow.
@@ -196,7 +227,7 @@ COLLISION_CASES = [
 
         def pause():
             time.sleep(1)
-    """),
+    """, RULE_COLLISION),
     ("`time = time` self-assignment on the last line", """
         import time
 
@@ -206,7 +237,7 @@ COLLISION_CASES = [
 
 
         time = time
-    """),
+    """, RULE_COLLISION),
     ("`except Exception as time:` at module scope", """
         import time
 
@@ -218,7 +249,7 @@ COLLISION_CASES = [
 
         def pause():
             time.sleep(1)
-    """),
+    """, RULE_COLLISION),
     ("`with open(...) as time:` at module scope", """
         import time
 
@@ -228,7 +259,7 @@ COLLISION_CASES = [
 
         def pause():
             time.sleep(1)
-    """),
+    """, RULE_COLLISION),
     ("walrus `if (time := None):` at module scope", """
         import time
 
@@ -238,13 +269,13 @@ COLLISION_CASES = [
 
         def pause():
             time.sleep(1)
-    """),
+    """, RULE_COLLISION),
     ("same-scope rebind placed after the use", """
         import time
 
         time.sleep(1)
         time = None
-    """),
+    """, RULE_COLLISION),
 ]
 
 # Same clock, one spelling away from the listed one.
@@ -255,49 +286,49 @@ CLOCK_SPELLING_CASES = [
 
         def stamp():
             return datetime.today()
-    """),
+    """, RULE_CLOCK_REF),
     ("time.time_ns()", """
         import time
 
 
         def stamp():
             return time.time_ns()
-    """),
+    """, RULE_CLOCK_REF),
     ("time.monotonic_ns()", """
         import time
 
 
         def stamp():
             return time.monotonic_ns()
-    """),
+    """, RULE_CLOCK_REF),
     ("time.perf_counter_ns()", """
         import time
 
 
         def stamp():
             return time.perf_counter_ns()
-    """),
+    """, RULE_CLOCK_REF),
     ("time.process_time()", """
         import time
 
 
         def stamp():
             return time.process_time()
-    """),
+    """, RULE_CLOCK_REF),
     ("time.localtime()", """
         import time
 
 
         def stamp():
             return time.localtime()
-    """),
+    """, RULE_CLOCK_REF),
     ("time.gmtime()", """
         import time
 
 
         def stamp():
             return time.gmtime()
-    """),
+    """, RULE_CLOCK_REF),
 ]
 
 # Rebindings of the dynamic-import builtins. Master misses these too — they are
@@ -309,14 +340,14 @@ DYNAMIC_IMPORT_SPELLING_CASES = [
 
         def sdk():
             return __import__("anthropic")
-    """),
+    """, RULE_DYNAMIC_IMPORT),
     ("_imp = __import__, then _imp(...)", """
         _imp = __import__
 
 
         def sdk():
             return _imp("anthropic")
-    """),
+    """, RULE_DYNAMIC_IMPORT),
 ]
 
 # Capturing the callable instead of calling it. These read as conscientious
@@ -327,12 +358,12 @@ CALLABLE_CAPTURE_CASES = [
         import time
 
         _sleep = time.sleep
-    """),
+    """, RULE_CLOCK_REF),
     ("dispatch table holding datetime.utcnow", """
         from datetime import datetime
 
         _FIELDS = {"ts": datetime.utcnow}
-    """),
+    """, RULE_CLOCK_REF),
     ("adapter class whose attributes are the clock functions", """
         import time
         from datetime import datetime
@@ -341,7 +372,7 @@ CALLABLE_CAPTURE_CASES = [
         class SystemClock:
             now = datetime.now
             sleep = time.sleep
-    """),
+    """, RULE_CLOCK_REF),
     ("default-argument fallback `_fallback=time.monotonic`", """
         import time
 
@@ -350,7 +381,7 @@ CALLABLE_CAPTURE_CASES = [
             def __init__(self, clock=None, _fallback=time.monotonic):
                 self._clock = clock
                 self._fallback = _fallback
-    """),
+    """, RULE_CLOCK_REF),
     ("intermediate module alias `_clock_mod = time`", """
         import time
 
@@ -359,14 +390,14 @@ CALLABLE_CAPTURE_CASES = [
 
         def pause():
             _clock_mod.sleep(1)
-    """),
+    """, RULE_CLOCK_REF),
     ("getattr(time, \"sleep\")() — house style at market/source_alpaca.py:33", """
         import time
 
 
         def pause():
             getattr(time, "sleep")()
-    """),
+    """, RULE_CLOCK_REF),
 ]
 
 EVASION_CASES = (DYNAMIC_IMPORT_CASES + ALIASED_BINDING_CASES
@@ -378,25 +409,25 @@ EVASION_CASES = (DYNAMIC_IMPORT_CASES + ALIASED_BINDING_CASES
 DETECTED_CASES = [
     ("plain import anthropic", """
         import anthropic
-    """),
+    """, RULE_FORBIDDEN_IMPORT),
     ("from claude_agent_sdk import query", """
         from claude_agent_sdk import query
-    """),
+    """, RULE_FORBIDDEN_IMPORT),
     ("import agents.runtime", """
         import agents.runtime
-    """),
+    """, RULE_FORBIDDEN_IMPORT),
     ("plain datetime.now()", """
         from datetime import datetime
 
         def stamp():
             return datetime.now()
-    """),
+    """, RULE_CLOCK_REF),
     ("plain time.sleep(1)", """
         import time
 
         def pause():
             time.sleep(1)
-    """),
+    """, RULE_CLOCK_REF),
 ]
 
 # Correct code. Flagging any of these would make the lint forbid the very
@@ -543,37 +574,37 @@ SLACKKIT_INIT_VIOLATIONS = [
     ("__init__.py re-exports the real port", {
         "slackkit/__init__.py": "from .real import RealSlack\n",
         "slackkit/real.py": "import slack_sdk\n",
-    }),
+    }, RULE_SLACKKIT_INIT),
     ("__init__.py imports slack_sdk directly", {
         "slackkit/__init__.py": "import slack_sdk\n",
-    }),
+    }, RULE_SLACKKIT_INIT),
     ("__init__.py imports anything at all, even stdlib", {
         # Not about *what* is imported: an __init__ that executes imports is a
         # package that can grow one, which is how the boundary erodes.
         "slackkit/__init__.py": "import os\n",
-    }),
+    }, RULE_SLACKKIT_INIT),
 ]
 
 SLACKKIT_REAL_VIOLATIONS = [
     ("pure package does `from slackkit.real import RealSlack`", {
         "slackkit/__init__.py": "",
         "orchestrator/daily.py": "from slackkit.real import RealSlack\n",
-    }),
+    }, RULE_FORBIDDEN_IMPORT),
     ("pure package does `import slackkit.real`", {
         "slackkit/__init__.py": "",
         "orchestrator/daily.py": "import slackkit.real\n",
-    }),
+    }, RULE_FORBIDDEN_IMPORT),
     ("dotted prefix reaches subpackages: slackkit.real.helpers", {
         "slackkit/__init__.py": "",
         "orchestrator/daily.py": "from slackkit.real.helpers import retry\n",
-    }),
+    }, RULE_FORBIDDEN_IMPORT),
     ("`from slackkit import real` — the module is the package, not the name", {
         # The other three spellings all put "slackkit.real" in `node.module`,
         # so they never reach the per-alias check. This one is the natural way
         # to write it and is the only case that exercises that branch.
         "slackkit/__init__.py": "",
         "orchestrator/daily.py": "from slackkit import real\n",
-    }),
+    }, RULE_FORBIDDEN_IMPORT),
     ("wall clock parked in slackkit/outbox.py", {
         # The better half of (d): outbox/render/fake/port are orchestrator's
         # live dependency and are completely unlinted today, so a clock read
@@ -586,11 +617,11 @@ SLACKKIT_REAL_VIOLATIONS = [
             def append_event(path, event):
                 return time.time()
         """,
-    }),
+    }, RULE_CLOCK_REF),
     ("slack_sdk imported by slackkit/outbox.py", {
         "slackkit/__init__.py": "",
         "slackkit/outbox.py": "import slack_sdk\n",
-    }),
+    }, RULE_FORBIDDEN_IMPORT),
 ]
 
 # The ablation. Without it, "the matcher was changed" is only the word of
@@ -633,17 +664,41 @@ SLACKKIT_ABLATION_CLEAN = [
 # --- assertions ------------------------------------------------------------
 
 def _assert_all_flagged(cases, label):
-    missed = [name for name, src in cases if not _errors_for(src)]
-    assert not missed, (
-        f"{label}: purity lint reported clean for {len(missed)} of {len(cases)} "
-        f"case(s) it must flag: " + "; ".join(missed))
+    """Each case is (name, source, rule). Reports "not caught at all" and
+    "caught by the wrong rule" separately — they are different bugs, and
+    collapsing them is what let a deleted rule score as covered."""
+    missed, wrong = [], []
+    for name, src, rule in cases:
+        errors = _errors_for(src)
+        if not errors:
+            missed.append(name)
+        elif not any(rule in e for e in errors):
+            wrong.append(f"{name} -> wanted {rule!r}, got {errors}")
+    assert not (missed or wrong), "; ".join(filter(None, [
+        (f"{label}: reported CLEAN for {len(missed)} of {len(cases)} case(s): "
+         + "; ".join(missed)) if missed else "",
+        (f"{label}: flagged by the WRONG RULE for {len(wrong)} of {len(cases)} "
+         f"case(s) — the violation was caught, but not by the rule under test, "
+         f"so deleting that rule would not turn this red: " + "; ".join(wrong))
+        if wrong else "",
+    ]))
 
 
 def _assert_trees_rejected(cases, label):
-    passed = [name for name, tree in cases if _lint_exit_code_for_tree(tree) == 0]
-    assert not passed, (
-        f"{label}: purity lint exited 0 for {len(passed)} of {len(cases)} "
-        f"tree(s) it must reject: " + "; ".join(passed))
+    """Each case is (name, tree, rule). Same two-way split as above."""
+    passed, wrong = [], []
+    for name, tree, rule in cases:
+        code, out = _lint_run_tree(tree)
+        if code == 0:
+            passed.append(name)
+        elif rule not in out:
+            wrong.append(f"{name} -> wanted {rule!r}, got: {out.strip()}")
+    assert not (passed or wrong), "; ".join(filter(None, [
+        (f"{label}: exited 0 for {len(passed)} of {len(cases)} tree(s): "
+         + "; ".join(passed)) if passed else "",
+        (f"{label}: flagged by the WRONG RULE for {len(wrong)} of {len(cases)} "
+         f"tree(s): " + "; ".join(wrong)) if wrong else "",
+    ]))
 
 
 def _assert_trees_accepted(cases, label):
@@ -689,16 +744,20 @@ def test_clean_file_yields_no_errors():
 
 def test_an_evasion_exits_nonzero():
     """The issue's headline repro: gate/evade.py, `clean`, exit 0."""
-    for name, source in EVASION_CASES:
-        code = _lint_exit_code("gate", source)
+    for name, source, rule in EVASION_CASES:
+        code, out = _lint_run_tree({"gate/sample.py": source})
         assert code != 0, f"gate/ evasion '{name}' left the lint exit 0"
+        assert rule in out, (
+            f"gate/ evasion '{name}' exited non-zero but not via {rule!r}: {out.strip()}")
 
 
 def test_market_is_linted():
     """market/ computes the gate's own inputs; it is currently unlinted."""
     assert (ROOT / "market").is_dir(), "market/ is gone — retarget this test"
-    code = _lint_exit_code("market", "import anthropic\n")
+    code, out = _lint_run_tree({"market/sample.py": "import anthropic\n"})
     assert code != 0, "a forbidden import in market/ left the lint exit 0"
+    assert RULE_FORBIDDEN_IMPORT in out, (
+        f"market/ was scanned but not via {RULE_FORBIDDEN_IMPORT!r}: {out.strip()}")
 
 
 def test_master_regressions_stay_flagged():

--- a/tests/test_check_purity.py
+++ b/tests/test_check_purity.py
@@ -1,0 +1,357 @@
+"""The purity lint's own negative controls (issue #43).
+
+`scripts/check_purity.py` enforces CLAUDE.md invariant 3, but it matches on the
+literal source text of a call's base and only ever looks at `ast.Import` /
+`ast.ImportFrom` nodes. A file can therefore import `anthropic` and read the
+wall clock while the lint reports `clean`. Each entry in EVASION_CASES below is
+a snippet that the lint must flag and today does not.
+
+The two tables that follow are the other half: DETECTED_CASES are the
+violations the lint already catches and must keep catching, and CLEAN_CASES are
+correct code — above all `self._clock.now()`, the injected-Clock pattern the
+invariant exists to *require*. A rewrite that resolves bindings instead of
+source text will over-fire without them.
+
+SLACKKIT_INIT_VIOLATIONS covers the third boundary: `slackkit` goes in neither
+list, and instead `slackkit/__init__.py` must stay import-free — the mechanism
+that lets orchestrator import `slackkit.outbox` without pulling in `slack_sdk`.
+
+Zero dependencies: plain no-arg `def test_*` functions and stdlib `tempfile`,
+so it runs under pytest (what CI and `make test` invoke) and under the
+`tests/run_tests.py` fallback runner alike. Scratch trees are built under
+`tempfile`; nothing is ever written into the real packages.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from textwrap import dedent
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "check_purity.py"
+
+
+def _load():
+    """A fresh copy of the lint. Never shared — _lint_exit_code rebinds ROOT."""
+    spec = importlib.util.spec_from_file_location("check_purity_under_test", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _errors_for(source: str) -> list[str]:
+    """check_file() against a scratch file holding `source`."""
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "sample.py"
+        path.write_text(dedent(source))
+        return _load().check_file(path)
+
+
+def _lint_exit_code_for_tree(files: dict[str, str]) -> int:
+    """main() against a scratch ROOT built from {relative path: source}."""
+    with tempfile.TemporaryDirectory() as tmp:
+        for rel, source in files.items():
+            path = Path(tmp) / rel
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(dedent(source))
+        lint = _load()
+        lint.ROOT = Path(tmp)
+        return lint.main()
+
+
+def _lint_exit_code(pkg: str, source: str) -> int:
+    """main() against a scratch ROOT whose only content is `pkg/sample.py`."""
+    return _lint_exit_code_for_tree({f"{pkg}/sample.py": source})
+
+
+# --- (case name, source) tables -------------------------------------------
+
+# Dynamic imports: an ast.Call, never an ast.Import, so the import branch
+# never sees them.
+DYNAMIC_IMPORT_CASES = [
+    ("importlib.import_module with a concatenated name", """
+        import importlib
+
+        def sdk():
+            return importlib.import_module("claude" + "_agent_sdk")
+    """),
+    ("__import__ builtin", """
+        def sdk():
+            return __import__("anthropic")
+    """),
+]
+
+# Aliased bindings: FORBIDDEN_CALLS keys on the base's literal source text
+# (check_purity.py:47-48), so renaming the binding walks straight past it.
+ALIASED_BINDING_CASES = [
+    ("import time as _t, then _t.sleep(1)", """
+        import time as _t
+
+        def pause():
+            _t.sleep(1)
+    """),
+    ("from datetime import datetime as _dt, then _dt.now()", """
+        from datetime import datetime as _dt
+
+        def stamp():
+            return _dt.now()
+    """),
+    ("from time import sleep, then a bare sleep(1)", """
+        from time import sleep
+
+        def pause():
+            sleep(1)
+    """),
+]
+
+# Clock/blocking calls absent from FORBIDDEN_CALLS entirely.
+UNLISTED_CLOCK_CALL_CASES = [
+    ("time.time()", """
+        import time
+
+        def stamp():
+            return time.time()
+    """),
+    ("time.monotonic()", """
+        import time
+
+        def stamp():
+            return time.monotonic()
+    """),
+    ("time.perf_counter()", """
+        import time
+
+        def stamp():
+            return time.perf_counter()
+    """),
+    ("asyncio.sleep()", """
+        import asyncio
+
+        async def pause():
+            await asyncio.sleep(0.1)
+    """),
+]
+
+EVASION_CASES = DYNAMIC_IMPORT_CASES + ALIASED_BINDING_CASES + UNLISTED_CLOCK_CALL_CASES
+
+# Already caught today. These must survive the rewrite.
+DETECTED_CASES = [
+    ("plain import anthropic", """
+        import anthropic
+    """),
+    ("from claude_agent_sdk import query", """
+        from claude_agent_sdk import query
+    """),
+    ("import agents.runtime", """
+        import agents.runtime
+    """),
+    ("plain datetime.now()", """
+        from datetime import datetime
+
+        def stamp():
+            return datetime.now()
+    """),
+    ("plain time.sleep(1)", """
+        import time
+
+        def pause():
+            time.sleep(1)
+    """),
+]
+
+# Correct code. Flagging any of these would make the lint forbid the very
+# pattern invariant 3 mandates.
+CLEAN_CASES = [
+    ("self._clock.now() — the injected Clock", """
+        class Stage:
+            def __init__(self, clock):
+                self._clock = clock
+
+            def stamp(self):
+                return self._clock.now()
+    """),
+    ("clock.now() on an injected parameter", """
+        def stamp(clock):
+            return clock.now()
+    """),
+    ("parameter named `time` shadowing the module", """
+        def elapsed(time):
+            # `time` is a Timer passed in by the caller, not the stdlib module.
+            return time.perf_counter()
+    """),
+    ("local variable named `datetime` shadowing the class", """
+        def label(rows):
+            datetime = Formatter(rows)
+            return datetime.now()
+    """),
+    ("from datetime import timedelta (market/source_alpaca.py:6)", """
+        from datetime import timedelta
+
+        def window():
+            return timedelta(days=1)
+    """),
+    (".now() on an unrelated object", """
+        def price(feed):
+            # The feed's own API; nothing to do with the wall clock.
+            return feed.now()
+    """),
+]
+
+CLEAN_FILE = """
+    from __future__ import annotations
+
+
+    def net(gross: float, fees: float) -> float:
+        return gross - fees
+"""
+
+# --- slackkit: the empty __init__.py is a load-bearing boundary -------------
+#
+# `slackkit` belongs in NEITHER PURE_PACKAGES nor FORBIDDEN_IMPORTS — both
+# redden legitimate code. What makes `orchestrator/daily.py:24`'s
+# `from slackkit.outbox import ...` safe is that `slackkit/__init__.py` is
+# empty, so importing a submodule pulls in no `slack_sdk`. `slackkit/real.py`
+# says it "must stay empty"; today nothing enforces that. These are the
+# enforcement. Trees are {relative path: source}, run through main().
+
+SLACKKIT_INIT_VIOLATIONS = [
+    ("__init__.py re-exports the real port", {
+        "slackkit/__init__.py": "from .real import RealSlack\n",
+        "slackkit/real.py": "import slack_sdk\n",
+    }),
+    ("__init__.py imports slack_sdk directly", {
+        "slackkit/__init__.py": "import slack_sdk\n",
+    }),
+    ("__init__.py imports anything at all, even stdlib", {
+        # Not about *what* is imported: an __init__ that executes imports is a
+        # package that can grow one, which is how the boundary erodes.
+        "slackkit/__init__.py": "import os\n",
+    }),
+]
+
+SLACKKIT_CLEAN_TREES = [
+    ("empty __init__.py, real.py holds the SDK", {
+        "slackkit/__init__.py": "",
+        "slackkit/real.py": """
+            import slack_sdk
+
+
+            class RealSlack:
+                def __init__(self, token):
+                    self._client = slack_sdk.WebClient(token=token)
+        """,
+    }),
+    ("empty __init__.py, outbox.py is plain stdlib", {
+        "slackkit/__init__.py": "",
+        "slackkit/outbox.py": """
+            import json
+
+
+            def append_event(path, event):
+                return json.dumps(event)
+        """,
+    }),
+]
+
+
+# --- assertions ------------------------------------------------------------
+
+def _assert_all_flagged(cases, label):
+    missed = [name for name, src in cases if not _errors_for(src)]
+    assert not missed, (
+        f"{label}: purity lint reported clean for {len(missed)} of {len(cases)} "
+        f"case(s) it must flag: " + "; ".join(missed))
+
+
+def _assert_trees_rejected(cases, label):
+    passed = [name for name, tree in cases if _lint_exit_code_for_tree(tree) == 0]
+    assert not passed, (
+        f"{label}: purity lint exited 0 for {len(passed)} of {len(cases)} "
+        f"tree(s) it must reject: " + "; ".join(passed))
+
+
+def _assert_trees_accepted(cases, label):
+    rejected = [name for name, tree in cases if _lint_exit_code_for_tree(tree) != 0]
+    assert not rejected, (
+        f"{label}: purity lint exited non-zero for {len(rejected)} of "
+        f"{len(cases)} legitimate tree(s): " + "; ".join(rejected))
+
+
+def _assert_none_flagged(cases, label):
+    fired = [(name, errs) for name, src in cases if (errs := _errors_for(src))]
+    assert not fired, (
+        f"{label}: purity lint false-positived on {len(fired)} of {len(cases)} "
+        f"case(s): " + "; ".join(f"{name} -> {errs}" for name, errs in fired))
+
+
+# --- tests -----------------------------------------------------------------
+
+def test_dynamic_imports_are_flagged():
+    _assert_all_flagged(DYNAMIC_IMPORT_CASES, "dynamic import")
+
+
+def test_aliased_bindings_are_flagged():
+    _assert_all_flagged(ALIASED_BINDING_CASES, "aliased binding")
+
+
+def test_unlisted_clock_calls_are_flagged():
+    _assert_all_flagged(UNLISTED_CLOCK_CALL_CASES, "unlisted clock call")
+
+
+def test_known_violations_stay_flagged():
+    _assert_all_flagged(DETECTED_CASES, "regression")
+
+
+def test_correct_patterns_are_not_flagged():
+    _assert_none_flagged(CLEAN_CASES, "false positive")
+
+
+def test_clean_file_yields_no_errors():
+    errors = _errors_for(CLEAN_FILE)
+    assert errors == [], f"clean file produced errors: {errors}"
+
+
+def test_an_evasion_exits_nonzero():
+    """The issue's headline repro: gate/evade.py, `clean`, exit 0."""
+    for name, source in EVASION_CASES:
+        code = _lint_exit_code("gate", source)
+        assert code != 0, f"gate/ evasion '{name}' left the lint exit 0"
+
+
+def test_market_is_linted():
+    """market/ computes the gate's own inputs; it is currently unlinted."""
+    assert (ROOT / "market").is_dir(), "market/ is gone — retarget this test"
+    code = _lint_exit_code("market", "import anthropic\n")
+    assert code != 0, "a forbidden import in market/ left the lint exit 0"
+
+
+def test_slackkit_init_must_stay_import_free():
+    _assert_trees_rejected(SLACKKIT_INIT_VIOLATIONS, "slackkit/__init__.py")
+
+
+def test_slackkit_submodules_may_hold_the_sdk():
+    """The boundary, not a ban: real.py is *supposed* to import slack_sdk.
+    A check that lints all of slackkit/ instead of just __init__.py fails
+    here."""
+    _assert_trees_accepted(SLACKKIT_CLEAN_TREES, "slackkit submodule")
+
+
+def test_the_real_slackkit_init_is_empty():
+    """The premise of the two tests above, verified rather than assumed."""
+    init = ROOT / "slackkit" / "__init__.py"
+    assert init.is_file(), f"{init} is gone — retarget these tests"
+    assert init.read_text().strip() == "", (
+        f"{init} is no longer empty, which breaks the boundary "
+        f"slackkit/real.py:1-3 documents:\n{init.read_text()}")
+
+
+def test_the_real_tree_stays_clean():
+    """No fix may turn the repo red — every pure package is clean today."""
+    proc = subprocess.run([sys.executable, str(SCRIPT)], cwd=ROOT,
+                          capture_output=True, text=True)
+    assert proc.returncode == 0, (
+        f"purity lint failed on the real tree:\n{proc.stdout}{proc.stderr}")

--- a/tests/test_check_purity.py
+++ b/tests/test_check_purity.py
@@ -1169,6 +1169,46 @@ PACKAGE_RELATIVE_CLEAN_TREES = [
     }),
 ]
 
+# --- deduplication: the ONLY count assertions in this file -----------------
+#
+# Every other assertion here is existence-based — "did rule X fire" — which is
+# deliberate and must stay that way, because it lets an implementer reword or
+# re-route a message without breaking a test. That design is structurally blind
+# to one thing: the SAME violation reported twice.
+#
+# Two blocks in the lint exist only to deduplicate. A comprehension's outermost
+# iterable and a parameter's annotation are each reachable by two paths through
+# the scanner, and each block suppresses the second. Delete either and the lint
+# stays correct about WHAT is wrong while printing it twice — so no existence
+# check moves, the ablation scores the block as dead, and the next person
+# removes it. The only symptom is doubled output that nobody traces back. That
+# is the same unverified-purpose failure this lane has spent its length
+# closing, with a cosmetic blast radius instead of a correctness one.
+#
+# SCOPE, deliberately narrow (ruled 2026-08-25): these two minimal snippets
+# assert DEDUPLICATION, not a general contract on error counts. Each is chosen
+# to produce exactly one violation by exactly one rule, so the count is
+# unambiguous. If a future rule legitimately fires twice on one of these
+# snippets, the right fix is to update THESE TWO CASES deliberately — not to
+# loosen them back to existence checks, and not to freeze counts anywhere else
+# in this file.
+DEDUP_CASES = [
+    ("comprehension's outermost iterable, reported once", """
+        import time
+
+
+        class C:
+            vals = [x for x in time.time()]
+    """, 1),
+    ("parameter annotation, reported once", """
+        import time
+
+
+        def f(x: time.time = None):
+            pass
+    """, 1),
+]
+
 
 # --- assertions ------------------------------------------------------------
 
@@ -1215,6 +1255,20 @@ def _assert_trees_accepted(cases, label):
     assert not rejected, (
         f"{label}: purity lint exited non-zero for {len(rejected)} of "
         f"{len(cases)} legitimate tree(s): " + "; ".join(rejected))
+
+
+def _assert_error_count(cases, label):
+    """Exact error counts. Used ONLY by DEDUP_CASES — see the scope note there
+    before adding a caller."""
+    wrong = []
+    for name, src, want in cases:
+        errors = _errors_for(src)
+        if len(errors) != want:
+            wrong.append(f"{name} -> wanted {want}, got {len(errors)}: {errors}")
+    assert not wrong, (
+        f"{label}: {len(wrong)} of {len(cases)} case(s) reported the wrong "
+        f"number of errors. The same violation reported twice is a dedup "
+        f"block gone missing, not a new violation: " + "; ".join(wrong))
 
 
 def _assert_none_flagged(cases, label):
@@ -1307,6 +1361,12 @@ def test_slackkit_init_must_stay_import_free():
 
 def test_slackkit_real_is_out_of_bounds_for_pure_packages():
     _assert_trees_rejected(SLACKKIT_REAL_VIOLATIONS, "slackkit.real")
+
+
+def test_one_violation_is_reported_once():
+    """Pins the two deduplication blocks, which no existence check can reach.
+    Read the scope note on DEDUP_CASES before changing either number."""
+    _assert_error_count(DEDUP_CASES, "deduplication")
 
 
 def test_relative_and_class_body_imports_are_not_the_stdlib():

--- a/tests/test_check_purity.py
+++ b/tests/test_check_purity.py
@@ -9,12 +9,12 @@ imports, unlisted clock spellings, `market/`). Round two adds four groups:
 
 * MASTER_REGRESSION_CASES — violations master flagged that the binding rewrite
   stopped flagging. A lint that gets looser is worse than one that never moved.
-* COLLISION_CASES — an import binding colliding with a rebinding is a
-  violation, not a shadow, wherever a use site can still reach the import.
-  Popping the name on any rebinding makes `import time` + `if False: time =
-  None` a working, silent bypass. The discriminator that decides which
-  positions qualify, and the history of the three cases that moved across it,
-  are documented on that table.
+* BINDING_STANDS_CASES — where a rebinding cannot hide the import from a use
+  site the binding STANDS rather than being popped, which is what lets the
+  reference check resolve `time.sleep` through `import time` + `if False: time
+  = None`. The collision REPORT that once lived here was deleted; the
+  discriminator that decides where the binding stands, and the history of every
+  case that moved, are documented on that table.
 * CALLABLE_CAPTURE_CASES — only a call on an attribute chain was matched, so
   `_sleep = time.sleep` defeated the check while reading as careful seam code.
 * SLACKKIT_* — option (d): lint `slackkit/` as a pure package with `real.py`
@@ -106,7 +106,6 @@ def _lint_exit_code_for_tree(files: dict[str, str]) -> int:
 RULE_FORBIDDEN_IMPORT = "forbidden import"
 RULE_DYNAMIC_IMPORT = "dynamic import"
 RULE_CLOCK_REF = "wall-clock/sleep reference"
-RULE_COLLISION = "imported and rebound"
 RULE_SLACKKIT_INIT = "must stay import-free"
 
 
@@ -240,8 +239,34 @@ MASTER_REGRESSION_CASES = [
     """, RULE_CLOCK_REF),
 ]
 
-# THE COLLISION DISCRIMINATOR. One question decides every shadowing case in
-# this file:
+# WHAT THIS TABLE PINS: the binding STANDS. Not that a collision is reported —
+# that report was deleted (see below). Where a rebinding cannot hide the import
+# from a use site, the import binding is left in place instead of being popped,
+# and that is what lets the REFERENCE check still resolve `time.sleep` through
+# the rebind. Every case here is a violation caught by the reference check;
+# delete binding-stands and they all go clean, which is the whole point.
+#
+# THE COLLISION REPORT WAS DELETED — ruled and approved 2026-08-25 after final
+# review. Ablating the report (keeping binding-stands) over the whole corpus of
+# 104 unique snippets lost ZERO purity detections; independently reproduced
+# here, across every violation table, lost 0. Six violations disappeared and
+# every one of them SHOULD have:
+#
+#   * four were false positives on class-body fields that never use the name —
+#     `@dataclass date: str`, `NamedTuple time: str`, an Enum member `time`, a
+#     method named `date`. Losing those IS the fix; they are guards in
+#     CLEAN_CASES now.
+#   * two were not purity violations at all: `class Stamp(datetime.datetime):
+#     datetime = None` and `class Bar(BaseModel): date: date`. In both the use
+#     reaches the import but the use is NOT a forbidden target — no clock is
+#     read. A use that cannot reach a forbidden target is not a purity concern.
+#     Both are now clean cases; see the note on each.
+#
+# What the report uniquely caught was shadowing HYGIENE, not purity, which is
+# not this lint's job. What is load-bearing, and stays, is binding-stands.
+#
+# THE DISCRIMINATOR STAYS — it now decides where the BINDING stands rather than
+# where a report fires. One question decides every shadowing case in this file:
 #
 #     Can the rebinding make a use site resolve to the import?
 #
@@ -289,6 +314,12 @@ MASTER_REGRESSION_CASES = [
 #      or partial bindings are suspicious" was offered and explicitly rejected.
 #      The table that held them (INVERTED_SHADOW_CASES) was retired rather than
 #      left as a husk; this comment is the durable artefact, not that table.
+#   4. The collision REPORT was deleted outright and every case here was
+#      re-measured against an ablated copy rather than reassigned by
+#      assumption. Seven stayed violations under the reference check and their
+#      rule moved from the deleted RULE_COLLISION to RULE_CLOCK_REF; `global`
+#      stayed red for a different reason (see its case); two moved to
+#      CLEAN_CASES. RULE_COLLISION was removed because nothing asserts it.
 #
 # The background to move 1 stands: the shadow rule was deleted because it
 # protected nothing. Monkeypatching `_bound_names` to return set() left every
@@ -300,7 +331,7 @@ MASTER_REGRESSION_CASES = [
 # Each module-scope entry below pairs with a function-body twin in CLEAN_CASES
 # under the same name. Same shape, different scope, opposite verdict — that
 # pairing IS the rule, so keep the names matched if you touch either table.
-COLLISION_CASES = [
+BINDING_STANDS_CASES = [
     ("`if False: time = None` at module scope", """
         import time
 
@@ -310,7 +341,7 @@ COLLISION_CASES = [
 
         def pause():
             time.sleep(1)
-    """, RULE_COLLISION),
+    """, RULE_CLOCK_REF),
     ("`time = time` self-assignment on the last line", """
         import time
 
@@ -320,7 +351,7 @@ COLLISION_CASES = [
 
 
         time = time
-    """, RULE_COLLISION),
+    """, RULE_CLOCK_REF),
     ("except-as (module scope)", """
         import time
 
@@ -332,7 +363,7 @@ COLLISION_CASES = [
 
         def pause():
             time.sleep(1)
-    """, RULE_COLLISION),
+    """, RULE_CLOCK_REF),
     ("with-as (module scope)", """
         import time
 
@@ -342,18 +373,26 @@ COLLISION_CASES = [
 
         def pause():
             time.sleep(1)
-    """, RULE_COLLISION),
+    """, RULE_CLOCK_REF),
     # Added when the function-body twin moved to CLEAN_CASES, so the pair is
     # complete on both sides. Verified at module scope: the use above returns a
     # real timestamp and `time` afterwards is the captured value.
     # `global` defeats the function-body exemption: the declared binding is the
     # MODULE's, so the privacy guarantee the discriminator's function-body row
     # rests on does not apply — the read below reaches the real module and
-    # returns a live timestamp rather than raising UnboundLocalError. Twin of
-    # "nonlocal (function body)" in CLEAN_CASES, which cannot reach an import
-    # at all. Low reachability: no `global` or `nonlocal` statement exists
-    # anywhere in this repo today. It is written because the discriminator's
-    # own comment is false for it, not because anyone is about to write it.
+    # returns a live timestamp rather than raising UnboundLocalError.
+    #
+    # With the collision report deleted, the fix is in the BINDING logic, not in
+    # a report: a name declared `global` must not shadow, so the import binding
+    # stands and the reference check sees `time.time`. Measured against an
+    # ablated copy rather than assumed — it is clean both with and without the
+    # report, which is what shows the report was never what caught it.
+    #
+    # Twin of "nonlocal (function body)" in CLEAN_CASES, which cannot reach an
+    # import at all. Low reachability: no `global` or `nonlocal` statement
+    # exists anywhere in this repo today. It is written because the
+    # discriminator's own comment is false for it, not because anyone is about
+    # to write it.
     ("global (function body declaring a module binding)", """
         import time
 
@@ -363,7 +402,7 @@ COLLISION_CASES = [
             grabbed = time.time
             time = None
             return grabbed
-    """, RULE_COLLISION),
+    """, RULE_CLOCK_REF),
     ("match-capture (module scope)", """
         import time
 
@@ -372,7 +411,7 @@ COLLISION_CASES = [
         match {"clock": 1}:
             case {"clock": time}:
                 pass
-    """, RULE_COLLISION),
+    """, RULE_CLOCK_REF),
     ("walrus `if (time := None):` at module scope", """
         import time
 
@@ -382,13 +421,13 @@ COLLISION_CASES = [
 
         def pause():
             time.sleep(1)
-    """, RULE_COLLISION),
+    """, RULE_CLOCK_REF),
     ("same-scope rebind placed after the use", """
         import time
 
         time.sleep(1)
         time = None
-    """, RULE_COLLISION),
+    """, RULE_CLOCK_REF),
 ]
 
 # Same clock, one spelling away from the listed one.
@@ -644,7 +683,8 @@ ENCLOSING_SCOPE_CASES = [
             clock = staticmethod(time.time)
             time = None
     """, RULE_CLOCK_REF),
-    # RULE CHANGED from RULE_COLLISION to RULE_CLOCK_REF when the "every
+    # RULE CHANGED from the since-deleted RULE_COLLISION to RULE_CLOCK_REF
+    # when the "every
     # scope" rule was revised: the parameter is private to the body, so the
     # collision rule no longer fires here. What makes this a violation is that
     # the DEFAULT is evaluated in the enclosing scope, so the parameter really
@@ -686,16 +726,6 @@ ENCLOSING_SCOPE_CASES = [
             clock: time.time = None
             time = None
     """, RULE_CLOCK_REF),
-    # The base list resolves to the module attribute, which is not itself
-    # forbidden — so what must fire here is the collision on the class-body
-    # rebinding, which the shadow rule currently swallows.
-    ("base-class list is evaluated in the enclosing scope", """
-        import datetime
-
-
-        class Stamp(datetime.datetime):
-            datetime = None
-    """, RULE_COLLISION),
     # --- the outer expression ALONE, with nothing else in the file ---------
     # The cases above pair an outer expression with a rebinding, so a rule that
     # only ever looked at the rebinding would still pass them. These four strip
@@ -736,22 +766,11 @@ ENCLOSING_SCOPE_CASES = [
         class C(time.sleep):
             pass
     """, RULE_CLOCK_REF),
-    # Twin of "class-body field with NO use (GUARD)" in CLEAN_CASES. The whole
-    # difference is the annotation: `date: date` evaluates the annotation to
-    # the import and only then rebinds, on the same line, so a use really does
-    # reach the import. `date: str` does not. Keep the pair named together.
-    ("class-body field annotated with the import itself (use, then rebind)", """
-        from datetime import date
-
-
-        class Bar(BaseModel):
-            date: date
-    """, RULE_COLLISION),
 ]
 
 EVASION_CASES = (DYNAMIC_IMPORT_CASES + ALIASED_BINDING_CASES
                  + UNLISTED_CLOCK_CALL_CASES + MASTER_REGRESSION_CASES
-                 + COLLISION_CASES + CLOCK_SPELLING_CASES
+                 + BINDING_STANDS_CASES + CLOCK_SPELLING_CASES
                  + DYNAMIC_IMPORT_SPELLING_CASES + CALLABLE_CAPTURE_CASES
                  + ENCLOSING_SCOPE_CASES)
 
@@ -832,14 +851,14 @@ CLEAN_CASES = [
     """),
     # --- the function-body row of the discriminator -----------------------
     # These three pin it, and each is the twin of an identically-named entry in
-    # COLLISION_CASES that differs ONLY in scope. Same shape, module scope =
+    # BINDING_STANDS_CASES that differs ONLY in scope. Same shape, module scope =
     # violation; same shape, function body = clean. That pairing IS the rule,
     # so keep the names matched if you touch either table.
     #
     # All three were inverted to violations under the superseded "collision at
     # every scope" rule and reverted here — the parameter first, then the other
     # two once execution showed an `except ... as` target and a `match` capture
-    # are exactly as private as a parameter. Full history on COLLISION_CASES.
+    # are exactly as private as a parameter. History on BINDING_STANDS_CASES.
     #
     # Unlike the shadow cases further up, every file here DOES import the name,
     # which is what makes them pins rather than trivia: with no import there is
@@ -883,12 +902,12 @@ CLEAN_CASES = [
 
         def pause(ctx):
             with ctx as time:
-                # Completes the matrix: every shape in COLLISION_CASES has a
+                # Completes the matrix: every shape in BINDING_STANDS_CASES
                 # function-body twin here. A gap in the pairing reads as an
                 # unexamined shape.
                 return time.monotonic()
     """),
-    # Twin of "global (function body ...)" in COLLISION_CASES. `nonlocal` can
+    # Twin of "global (function body ...)" in BINDING_STANDS_CASES. `nonlocal` can
     # only bind an ENCLOSING FUNCTION's local, never a module-level import, so
     # it can never reach the stdlib and must stay clean. That asymmetry with
     # `global` is the whole content of the pair.
@@ -1127,6 +1146,34 @@ CLEAN_CASES = [
     ("class-body control: date: str with no import of `date`", """
         class Bar:
             date: str
+    """),
+    # --- a use that cannot reach a forbidden target is not a purity concern --
+    # RECLASSIFIED from violation to clean, ruled 2026-08-25 when the collision
+    # report was deleted. In both of these the use DOES reach the import — the
+    # base list and the annotation are evaluated in the enclosing scope, before
+    # the rebinding, exactly as the discriminator says. What the earlier
+    # specification got wrong is the step after that: the thing reached is
+    # `datetime.datetime` / `date`, which is not a forbidden target. No clock is
+    # read, so there is no purity violation to report. The mechanism was right
+    # and the consequence was wrong.
+    #
+    # The second was previously pinned as a violation on the reasoning "an
+    # annotation is a use". It is ordinary pydantic. Meeting it as a corrected
+    # decision is the point of this note — without it a future reader
+    # rediscovers the argument and re-files it as a bug.
+    ("base-class list reaches the import but not a forbidden target", """
+        import datetime
+
+
+        class Stamp(datetime.datetime):
+            datetime = None
+    """),
+    ("ordinary pydantic: `date: date` (was mis-specified as a violation)", """
+        from datetime import date
+
+
+        class Bar(BaseModel):
+            date: date
     """),
     # --- round four: two FALSE-POSITIVE GUARDS ----------------------------
     # Both of these read at a glance like violations — a name spelled `time`
@@ -1479,10 +1526,10 @@ def test_master_regressions_stay_flagged():
     _assert_all_flagged(MASTER_REGRESSION_CASES, "regression vs master")
 
 
-def test_import_colliding_with_a_rebinding_is_flagged():
+def test_a_rebound_import_still_resolves_for_the_reference_check():
     """Popping a name on any rebinding, anywhere in the scope, regardless of
     whether the branch can execute, is a one-line silencer for a whole file."""
-    _assert_all_flagged(COLLISION_CASES, "same-scope collision")
+    _assert_all_flagged(BINDING_STANDS_CASES, "binding stands")
 
 
 def test_clock_spellings_are_flagged():

--- a/tests/test_check_purity.py
+++ b/tests/test_check_purity.py
@@ -148,6 +148,18 @@ ALIASED_BINDING_CASES = [
         def pause():
             sleep(1)
     """, RULE_CLOCK_REF),
+    # Twin of "star-import (name bound to a parameter)" in CLEAN_CASES: same
+    # file, but nothing binds `sleep`, so the star module's own prefix is the
+    # only thing that can resolve it. WATCHED_BASES cannot reach a leaf
+    # function on its own — it holds `time`, not `time.sleep` — so this is the
+    # case that pins the star-module prefix guess.
+    ("star-import (name unbound)", """
+        from time import *
+
+
+        def pause():
+            sleep(1)
+    """, RULE_CLOCK_REF),
 ]
 
 # Clock/blocking calls absent from FORBIDDEN_CALLS entirely.
@@ -561,6 +573,26 @@ CALLABLE_CAPTURE_CASES = [
 # "a function-local rebinding makes the name local for the whole body, so it
 # can never silently resolve to the stdlib" — is true for function BODIES only.
 # Each of these was confirmed by executing it.
+#
+# KNOWN SHAPE, ruled deliberate 2026-08-25 — the most likely future false
+# positive in this change, documented so it is met as a decision and not as a
+# surprise CI failure. A class body reports a collision for ANY watched
+# rebinding, so a pydantic/dataclass model with a field named `date` in a file
+# doing `from datetime import date` reddens:
+#
+#     from datetime import date
+#     class Row:
+#         date: date = None          # <- collision reported here
+#
+# state/models.py:8 is exactly that import and holds the models; there are zero
+# such fields today. It is a TRUE positive under the discriminator — in a class
+# body a use above the field genuinely reaches the module, which is the
+# ambiguity the rule exists to name — and it is consistent with narrowing
+# `numpy` out, since `date` IS a watched base and `numpy` is not. The remedy
+# for a developer who hits it is to rename the field, or to import the module
+# (`import datetime`) rather than the name. Do not "fix" it by exempting class
+# bodies: that would delete the class-body row of the discriminator, which
+# four cases below depend on.
 ENCLOSING_SCOPE_CASES = [
     ("class body: LOAD_NAME falls back to the global import", """
         import time
@@ -624,6 +656,46 @@ ENCLOSING_SCOPE_CASES = [
         class Stamp(datetime.datetime):
             datetime = None
     """, RULE_COLLISION),
+    # --- the outer expression ALONE, with nothing else in the file ---------
+    # The cases above pair an outer expression with a rebinding, so a rule that
+    # only ever looked at the rebinding would still pass them. These four strip
+    # that away: nothing is rebound, the function is never called, and in the
+    # first three the name is never referenced in the body either.
+    #
+    # "Unused" is the whole point. A default, a decorator, an annotation and a
+    # base list are all evaluated in the ENCLOSING scope at definition time —
+    # `def f(x=time.sleep)` captures the real time.sleep the moment the def
+    # executes, whether or not anything ever calls f. Each of these pins one
+    # arm of _outer_exprs; delete that arm and the case goes silent.
+    ("outer position alone: unused default argument", """
+        import time
+
+
+        def f(x=time.sleep):
+            pass
+    """, RULE_CLOCK_REF),
+    ("outer position alone: decorator", """
+        import time
+
+
+        @time.sleep
+        def f():
+            pass
+    """, RULE_CLOCK_REF),
+    ("outer position alone: parameter annotation", """
+        import time
+
+
+        def f(x: time.sleep):
+            pass
+    """, RULE_CLOCK_REF),
+    ("outer position alone: base-class list", """
+        import time
+
+
+        class C(time.sleep):
+            pass
+    """, RULE_CLOCK_REF),
 ]
 
 EVASION_CASES = (DYNAMIC_IMPORT_CASES + ALIASED_BINDING_CASES
@@ -814,7 +886,10 @@ CLEAN_CASES = [
 
         _KEYS = tuple(json for json in ("a", "b"))
     """),
-    ("a name bound to a local must not fall through to a star-import", """
+    # Twin of "star-import (name unbound)" in ALIASED_BINDING_CASES. Same file
+    # shape, one difference: here the name IS bound, by a parameter. Bound ->
+    # clean, unbound -> violation. Keep the pair named together.
+    ("star-import (name bound to a parameter)", """
         from time import *
 
 
@@ -902,6 +977,36 @@ CLEAN_CASES = [
 
         def at(value):
             return pd.Timestamp(value)
+    """),
+    # --- round four: two FALSE-POSITIVE GUARDS ----------------------------
+    # Both of these read at a glance like violations — a name spelled `time`
+    # with `.time()` called on it. They are not, and the lint reports 1 error
+    # instead of 0 if either supporting block is removed. Named as guards on
+    # purpose: the failure mode is a later reader "fixing" the lint to flag
+    # them.
+    #
+    # GUARD 1. A sibling module named `time` is not the stdlib. An unresolved
+    # relative import must bind the name to *nothing*, so it resolves to
+    # nothing. Bind it to the bare alias instead and `time.time()` reads as
+    # the stdlib clock, which is a false positive on ordinary package code.
+    ("relative import of a sibling named `time` is not the stdlib (GUARD)", """
+        from . import time
+
+
+        def stamp():
+            return time.time()
+    """),
+    # GUARD 2. Class scope is genuinely invisible to methods, so the method's
+    # `time` is NOT the class's import — it is an unbound global. The same
+    # rule that makes `class Row: date = None` fail to shadow a module-level
+    # `from datetime import date` has to cut this way too, or the lint claims
+    # a resolution Python does not perform.
+    ("a class-body import is invisible to its own methods (GUARD)", """
+        class C:
+            import time
+
+            def stamp(self):
+                return time.time()
     """),
 ]
 
@@ -1033,6 +1138,33 @@ SLACKKIT_ABLATION_CLEAN = [
 
             def append_event(path, event):
                 return json.dumps(event)
+        """,
+    }),
+]
+
+# The relative-import guard again, this time through main() so the file sits in
+# a REAL package and the import resolves to `state.time` rather than to
+# nothing. The CLEAN_CASES twin covers the unresolved (package-unknown) half;
+# this covers the resolved half, which is the spelling a contributor writes.
+PACKAGE_RELATIVE_CLEAN_TREES = [
+    ("sibling module named `time` imported relatively (GUARD)", {
+        "state/__init__.py": "",
+        "state/helpers.py": """
+            from . import time
+
+
+            def stamp():
+                return time.time()
+        """,
+    }),
+    ("class-body import inside a real package (GUARD)", {
+        "state/__init__.py": "",
+        "state/helpers.py": """
+            class C:
+                import time
+
+                def stamp(self):
+                    return time.time()
         """,
     }),
 ]
@@ -1175,6 +1307,12 @@ def test_slackkit_init_must_stay_import_free():
 
 def test_slackkit_real_is_out_of_bounds_for_pure_packages():
     _assert_trees_rejected(SLACKKIT_REAL_VIOLATIONS, "slackkit.real")
+
+
+def test_relative_and_class_body_imports_are_not_the_stdlib():
+    """False-positive guards, through main() so package resolution is real.
+    Both shapes look like violations and are not."""
+    _assert_trees_accepted(PACKAGE_RELATIVE_CLEAN_TREES, "package-relative guard")
 
 
 def test_slackkit_ablation():

--- a/tests/test_check_purity.py
+++ b/tests/test_check_purity.py
@@ -346,6 +346,24 @@ COLLISION_CASES = [
     # Added when the function-body twin moved to CLEAN_CASES, so the pair is
     # complete on both sides. Verified at module scope: the use above returns a
     # real timestamp and `time` afterwards is the captured value.
+    # `global` defeats the function-body exemption: the declared binding is the
+    # MODULE's, so the privacy guarantee the discriminator's function-body row
+    # rests on does not apply — the read below reaches the real module and
+    # returns a live timestamp rather than raising UnboundLocalError. Twin of
+    # "nonlocal (function body)" in CLEAN_CASES, which cannot reach an import
+    # at all. Low reachability: no `global` or `nonlocal` statement exists
+    # anywhere in this repo today. It is written because the discriminator's
+    # own comment is false for it, not because anyone is about to write it.
+    ("global (function body declaring a module binding)", """
+        import time
+
+
+        def capture():
+            global time
+            grabbed = time.time
+            time = None
+            return grabbed
+    """, RULE_COLLISION),
     ("match-capture (module scope)", """
         import time
 
@@ -574,25 +592,47 @@ CALLABLE_CAPTURE_CASES = [
 # can never silently resolve to the stdlib" — is true for function BODIES only.
 # Each of these was confirmed by executing it.
 #
-# KNOWN SHAPE, ruled deliberate 2026-08-25 — the most likely future false
-# positive in this change, documented so it is met as a decision and not as a
-# surprise CI failure. A class body reports a collision for ANY watched
-# rebinding, so a pydantic/dataclass model with a field named `date` in a file
-# doing `from datetime import date` reddens:
+# KNOWN SHAPE, ruled deliberate 2026-08-25 and NARROWED the same day in final
+# review. Documented so it is met as a decision, not as a surprise CI failure.
+#
+# THE RULING, as it now stands. A class-body rebinding of a watched name is a
+# collision ONLY WHERE A USE ACTUALLY REACHES THE IMPORT. This one is a true
+# positive and must stay flagged:
 #
 #     from datetime import date
-#     class Row:
-#         date: date = None          # <- collision reported here
+#     class Bar(BaseModel):
+#         date: date            # <- annotation evaluates to the import, THEN rebinds
+#
+# THE NARROWING, and why it was needed. The rule originally fired on the mere
+# EXISTENCE of an import/rebind pair, never checking that a use PRECEDES the
+# rebinding — so it also reddened all of these, none of which use the name at
+# all, making the error message ("a use above the rebinding still resolves to
+# it") literally false:
+#
+#     @dataclass                      class Bar(NamedTuple):
+#     class Bar:                          time: str
+#         date: str
+#     class Kind(Enum):               class Bar:
+#         time = 1                        def date(self): ...
+#
+# A position where the code and the discriminator disagree is exactly what the
+# discriminator exists to prevent, so these are fixed rather than documented.
+# The ruling stands for the case that HAS a use; it never should have covered
+# the case that has none.
+#
+# THE NUANCE THE FIX MUST NOT LOSE: an annotation IS a use. `date: date`
+# evaluates the annotation — resolving to the import — and only then rebinds,
+# on the SAME line. A naive "report only if a Load appears at a strictly lower
+# lineno" would wrongly clear it. The two shapes are written below and in
+# CLEAN_CASES as a matched pair so the boundary is pinned from both sides.
 #
 # state/models.py:8 is exactly that import and holds the models; there are zero
-# such fields today. It is a TRUE positive under the discriminator — in a class
-# body a use above the field genuinely reaches the module, which is the
-# ambiguity the rule exists to name — and it is consistent with narrowing
-# `numpy` out, since `date` IS a watched base and `numpy` is not. The remedy
-# for a developer who hits it is to rename the field, or to import the module
-# (`import datetime`) rather than the name. Do not "fix" it by exempting class
-# bodies: that would delete the class-body row of the discriminator, which
-# four cases below depend on.
+# uses of either shape today. Consistency with narrowing `numpy` out is
+# unchanged: `date` IS a watched base and `numpy` is not. The remedy for a
+# developer who hits the true positive is to rename the field, or to import the
+# module (`import datetime`) rather than the name. Do not "fix" it by exempting
+# class bodies: that would delete the class-body row of the discriminator,
+# which four cases below depend on.
 ENCLOSING_SCOPE_CASES = [
     ("class body: LOAD_NAME falls back to the global import", """
         import time
@@ -696,6 +736,17 @@ ENCLOSING_SCOPE_CASES = [
         class C(time.sleep):
             pass
     """, RULE_CLOCK_REF),
+    # Twin of "class-body field with NO use (GUARD)" in CLEAN_CASES. The whole
+    # difference is the annotation: `date: date` evaluates the annotation to
+    # the import and only then rebinds, on the same line, so a use really does
+    # reach the import. `date: str` does not. Keep the pair named together.
+    ("class-body field annotated with the import itself (use, then rebind)", """
+        from datetime import date
+
+
+        class Bar(BaseModel):
+            date: date
+    """, RULE_COLLISION),
 ]
 
 EVASION_CASES = (DYNAMIC_IMPORT_CASES + ALIASED_BINDING_CASES
@@ -837,6 +888,24 @@ CLEAN_CASES = [
                 # unexamined shape.
                 return time.monotonic()
     """),
+    # Twin of "global (function body ...)" in COLLISION_CASES. `nonlocal` can
+    # only bind an ENCLOSING FUNCTION's local, never a module-level import, so
+    # it can never reach the stdlib and must stay clean. That asymmetry with
+    # `global` is the whole content of the pair.
+    ("nonlocal (function body)", """
+        import time
+
+
+        def outer():
+            time = None
+
+            def inner():
+                nonlocal time
+                time = object()
+                return time
+
+            return inner
+    """),
     ("local variable named `datetime` shadowing the class", """
         def label(rows):
             datetime = Formatter(rows)
@@ -977,6 +1046,87 @@ CLEAN_CASES = [
 
         def at(value):
             return pd.Timestamp(value)
+    """),
+    # gmtime and localtime belong to the same arity family as ctime/asctime —
+    # they read the clock ONLY with no argument — but sat unconditionally in
+    # the forbidden refs. The third case is the docstring's own justifying
+    # example, which failed on itself: strftime with two args is correctly
+    # pure, while the gmtime(0) feeding it was flagged, so the inconsistency
+    # was visible in a single line. Twins of the bare `time.gmtime()` /
+    # `time.localtime()` violations in CLOCK_SPELLING_CASES.
+    ("time.gmtime(epoch) is a pure converter", """
+        import time
+
+
+        def stamp():
+            return time.gmtime(0)
+    """),
+    ("time.localtime(epoch) is a pure converter", """
+        import time
+
+
+        def stamp(epoch):
+            return time.localtime(epoch)
+    """),
+    ("time.strftime('%Y', time.gmtime(0)) — the docstring's own example", """
+        import time
+
+
+        def year():
+            return time.strftime("%Y", time.gmtime(0))
+    """),
+    # --- round five: class-body fields that never USE the name -------------
+    # Four shapes that reddened on the mere existence of an import/rebind pair.
+    # None of them uses the name, so nothing resolves to the import and the
+    # collision message is false. Twin of "class-body field annotated with the
+    # import itself" in ENCLOSING_SCOPE_CASES, which DOES use it and stays a
+    # violation — the annotation is the whole difference.
+    ("class-body field with NO use (GUARD): @dataclass date: str", """
+        from dataclasses import dataclass
+        from datetime import date
+
+
+        @dataclass
+        class Bar:
+            date: str
+    """),
+    ("class-body field with NO use (GUARD): NamedTuple time: str", """
+        import time
+        from typing import NamedTuple
+
+
+        class Bar(NamedTuple):
+            time: str
+    """),
+    ("class-body field with NO use (GUARD): Enum member named time", """
+        import time
+        from enum import Enum
+
+
+        class Kind(Enum):
+            time = 1
+    """),
+    ("class-body field with NO use (GUARD): method named date", """
+        from datetime import date
+
+
+        class Bar:
+            def date(self):
+                return None
+    """),
+    # Controls: these two were already clean and must stay so. The first is an
+    # unwatched name, the second has no import to collide with — together they
+    # keep the fix from being "stop checking class bodies".
+    ("class-body control: run_date: str is an unwatched name", """
+        from datetime import date
+
+
+        class Bar:
+            run_date: str
+    """),
+    ("class-body control: date: str with no import of `date`", """
+        class Bar:
+            date: str
     """),
     # --- round four: two FALSE-POSITIVE GUARDS ----------------------------
     # Both of these read at a glance like violations — a name spelled `time`

--- a/tests/test_check_purity.py
+++ b/tests/test_check_purity.py
@@ -434,7 +434,7 @@ BINDING_STANDS_CASES = [
     # without the sleep reports 0.001s). Deleting the `module_bindings`
     # threading on a copy turns this case clean, so it pins that block and not
     # something adjacent.
-    ("global reaches the module past an enclosing shadow", """
+    ("global reaches the module past an enclosing shadow (WITH assignment)", """
         import time
 
 
@@ -448,6 +448,57 @@ BINDING_STANDS_CASES = [
                 return v
 
             return inner
+    """, RULE_CLOCK_REF),
+    # THIS CASE EXISTS BECAUSE THE ONE ABOVE PINNED THE INSTANCE, NOT THE CLASS.
+    # It is not duplication — deleting it re-opens a live evasion.
+    #
+    # The case above carries `time = None` inside `inner`, and that assignment
+    # is load-bearing for the wrong reason: the `declared_global` branch sits
+    # inside `for name in rebound`, so a function that declares `global time`
+    # and never ASSIGNS `time` never enters `rebound` and the module binding is
+    # never consulted. Delete that one line from the case above and it goes
+    # clean. So the case asserted "`global` reaches the module when the function
+    # also assigns the name" while reading like "`global` reaches the module" —
+    # which is why fixing the third evasion left this fourth one, one line away,
+    # untouched.
+    #
+    # The general shape of that mistake is worth more than this case: A CASE
+    # THAT PINS ONE INSTANCE OF A RULE READS EXACTLY LIKE A CASE THAT PINS THE
+    # RULE, and an ablation cannot separate them either, because deleting the
+    # block fails both. The only defence is a second case that varies the axis
+    # the first one silently fixed.
+    #
+    # Verified: inner() blocks 0.304s; the same shape with the `global` line
+    # removed raises AttributeError, proving the `global` is what reaches the
+    # module; the same shape with no sleep reports 0.001s (executor control).
+    ("global reaches the module past an enclosing shadow (NO assignment)", """
+        import time
+
+
+        def outer():
+            time = None
+
+            def inner():
+                global time
+                return time.sleep(0.30)
+
+            return inner
+    """, RULE_CLOCK_REF),
+    # PIN for the nested-scope stop in _walrus_targets, whose docstring asserts
+    # that nested function and class scopes are not crossed. Found by generating
+    # across four axes (nested-scope kind x what the walrus binds x where the
+    # read sits x containing scope): of 24 snippets only this shape and its
+    # near-twin distinguish the guard, and none of the three shapes written by
+    # hand did. The walrus belongs to the LAMBDA, so it must not leak out and
+    # pop the comprehension's `time`; remove the stop and the genuine
+    # `time.monotonic()` beside it goes clean. Verified: go() returns a real
+    # float off the module clock. Passes today — that is the point.
+    ("walrus inside a lambda inside a comprehension does not leak out", """
+        import time
+
+
+        def go():
+            return [((lambda: (time := 1))(), time.monotonic()) for _ in range(1)]
     """, RULE_CLOCK_REF),
     # `nonlocal` onto an enclosing function's IMPORT. Twin of "nonlocal onto a
     # NON-import enclosing local" in CLEAN_CASES, and the difference between
@@ -510,20 +561,13 @@ BINDING_STANDS_CASES = [
             import time
             return [(time := time.sleep(0.30)) for _ in range(1)]
     """, RULE_CLOCK_REF),
-    # PIN for the nested-scope stop in _walrus_targets, whose docstring asserts
-    # that nested function and class scopes are not crossed. Nothing proved it.
-    # A walrus inside a LAMBDA belongs to the lambda, so it must NOT leak out
-    # and pop the module-level `time` — remove the guard and the genuine
-    # `time.sleep(1)` below goes clean. Currently passes; that is the point.
-    ("walrus inside a lambda nested in a comprehension does not leak", """
-        import time
-
-        _U = [(lambda: (time := 1))() for _ in range(1)]
-
-
-        def pause():
-            time.sleep(1)
-    """, RULE_CLOCK_REF),
+    # REMOVED: a case here claimed to pin the _walrus_targets nested-scope stop
+    # with the read in a separate `def pause()` at module scope. Measured, it
+    # flags identically with and without the guard (binding-stands keeps the
+    # module binding either way), so it pinned nothing and its comment was
+    # false. The real pin is above, in the entry that puts the read INSIDE the
+    # comprehension. Left as a note because a fourth unfalsifiable guard is
+    # worth recording, not silently deleting.
     ("match-capture (module scope)", """
         import time
 
@@ -1583,6 +1627,48 @@ DEDUP_CASES = [
 ]
 
 
+# --- KNOWN FALSE POSITIVES: accepted wrong verdicts, not guards -------------
+#
+# READ THIS BEFORE ASSUMING ANYTHING HERE IS CORRECT BEHAVIOUR. Every case in
+# this table asserts a verdict the lint currently gives and that we have ruled
+# is WRONG. They are here so the cost is visible and so that the day the
+# precondition becomes reachable, these are the cases that must change. They
+# are deliberately NOT in CLEAN_CASES or in any violation table — a case that
+# pins an accepted defect must not be mistakable for one that pins correct
+# behaviour.
+#
+# KFP-1: the function-body import exception is not flow-sensitive. An `import
+# time` in one branch binds `time` for the whole body, so a LATER, unrelated
+# `time = clock` is read as still holding the module — and the lint flags the
+# injected Clock, the one thing this lint exists to require. `master=clean,
+# candidate=FLAG`. Two errors are reported: `time.time` is a true positive,
+# `time.monotonic` is the false one.
+#
+# RULED: accept it; do NOT make the exception flow-sensitive. Not because the
+# shape is contrived — that argument was rejected — but because the precondition
+# cannot arrive silently. Checked against the tree, not reasoned: there are ZERO
+# function-body imports of time/datetime/random/os across all six pure packages,
+# and the real idiom here binds the RESULT (`now = clock.now()`), never a
+# module-shadowing name. The false positive is unreachable without a
+# function-body import of a forbidden module, and that import is itself an event
+# the lint already flags or excepts.
+#
+# THE REMEDY, if it ever becomes reachable: make the function-body import
+# exception flow-sensitive, so a binding established after the import supersedes
+# it. Verified precondition — the identical function with the function-body
+# import removed is clean, so the import is what triggers it.
+KNOWN_FALSE_POSITIVE_CASES = [
+    ("KFP-1: function-body import flags a later injected Clock", """
+        def render(clock, fmt):
+            if fmt == "epoch":
+                import time
+                return time.time()
+            time = clock
+            return time.monotonic()
+    """, RULE_CLOCK_REF),
+]
+
+
 # --- assertions ------------------------------------------------------------
 
 def _assert_all_flagged(cases, label):
@@ -1734,6 +1820,14 @@ def test_slackkit_init_must_stay_import_free():
 
 def test_slackkit_real_is_out_of_bounds_for_pure_packages():
     _assert_trees_rejected(SLACKKIT_REAL_VIOLATIONS, "slackkit.real")
+
+
+def test_known_false_positives_still_fire():
+    """NOT a correctness test. These are accepted WRONG verdicts, kept visible
+    so their cost is legible and so the fix has a home if the precondition ever
+    becomes reachable. If one of these starts passing, the lint improved —
+    move the case, do not delete it. Read KNOWN_FALSE_POSITIVE_CASES first."""
+    _assert_all_flagged(KNOWN_FALSE_POSITIVE_CASES, "known false positive")
 
 
 def test_one_violation_is_reported_once():

--- a/tests/test_check_purity.py
+++ b/tests/test_check_purity.py
@@ -421,6 +421,34 @@ BINDING_STANDS_CASES = [
             time = None
             return grabbed
     """, RULE_CLOCK_REF),
+    # Twin of the case above, and the pair states the rule that was never
+    # written down: `global` means the MODULE's binding, regardless of what any
+    # enclosing scope bound. Above there is no enclosing shadow; here `outer`
+    # binds `time = None` and `global` in `inner` reaches straight past it to
+    # the module anyway.
+    #
+    # Resolution used to follow the ENCLOSING scope, so the shadow silenced the
+    # check and this executed a real clock read while the lint said clean. It is
+    # a pin, not a red case — it passes today and must keep passing.
+    # Verified: inner() blocks 0.304s (executor controlled — the same shape
+    # without the sleep reports 0.001s). Deleting the `module_bindings`
+    # threading on a copy turns this case clean, so it pins that block and not
+    # something adjacent.
+    ("global reaches the module past an enclosing shadow", """
+        import time
+
+
+        def outer():
+            time = None
+
+            def inner():
+                global time
+                v = time.sleep(0.30)
+                time = None
+                return v
+
+            return inner
+    """, RULE_CLOCK_REF),
     # `nonlocal` onto an enclosing function's IMPORT. Twin of "nonlocal onto a
     # NON-import enclosing local" in CLEAN_CASES, and the difference between
     # them is the whole rule: an `import` inside a function is a function-local

--- a/tests/test_check_purity.py
+++ b/tests/test_check_purity.py
@@ -212,6 +212,17 @@ MASTER_REGRESSION_CASES = [
         def pause():
             time.sleep(1)
     """, RULE_CLOCK_REF),
+    # D5. Master flags this by source text; the branch launders it through the
+    # star import. Resolvable WITHIN the file — a star import means the name
+    # could have come from anywhere, so an otherwise-unbound `datetime.now`
+    # under one must stay a candidate. No cross-module following required.
+    ("star-import laundering of datetime.now()", """
+        from state.helpers import *
+
+
+        def stamp():
+            return datetime.now()
+    """, RULE_CLOCK_REF),
 ]
 
 # An import binding rebound in the SAME scope is incoherent code, not a shadow.
@@ -329,6 +340,76 @@ CLOCK_SPELLING_CASES = [
         def stamp():
             return time.gmtime()
     """, RULE_CLOCK_REF),
+    # --- round three: the docstring says "the time module's clock and sleep
+    # functions"; these are all of that and all currently clean. The three
+    # no-arg formatters read the wall clock; their with-argument forms are
+    # pure and are guarded in CLEAN_CASES.
+    ("time.clock_gettime()", """
+        import time
+
+
+        def stamp():
+            return time.clock_gettime(0)
+    """, RULE_CLOCK_REF),
+    ("time.clock_gettime_ns()", """
+        import time
+
+
+        def stamp():
+            return time.clock_gettime_ns(0)
+    """, RULE_CLOCK_REF),
+    ("time.thread_time()", """
+        import time
+
+
+        def stamp():
+            return time.thread_time()
+    """, RULE_CLOCK_REF),
+    ("time.thread_time_ns()", """
+        import time
+
+
+        def stamp():
+            return time.thread_time_ns()
+    """, RULE_CLOCK_REF),
+    ("time.strftime() with no time tuple reads localtime", """
+        import time
+
+
+        def stamp():
+            return time.strftime("%Y-%m-%d")
+    """, RULE_CLOCK_REF),
+    ("time.asctime() with no argument", """
+        import time
+
+
+        def stamp():
+            return time.asctime()
+    """, RULE_CLOCK_REF),
+    ("time.ctime() with no argument", """
+        import time
+
+
+        def stamp():
+            return time.ctime()
+    """, RULE_CLOCK_REF),
+    # pandas is a real dependency of fundbt/. Verified 2026-08-25: the real
+    # tree contains ZERO Timestamp.now() call sites, so adding this reddens
+    # nothing that exists.
+    ("pd.Timestamp.now()", """
+        import pandas as pd
+
+
+        def stamp():
+            return pd.Timestamp.now()
+    """, RULE_CLOCK_REF),
+    ("from pandas import Timestamp, then Timestamp.now()", """
+        from pandas import Timestamp
+
+
+        def stamp():
+            return Timestamp.now()
+    """, RULE_CLOCK_REF),
 ]
 
 # Rebindings of the dynamic-import builtins. Master misses these too — they are
@@ -400,10 +481,129 @@ CALLABLE_CAPTURE_CASES = [
     """, RULE_CLOCK_REF),
 ]
 
+# --- round three ------------------------------------------------------------
+
+# DELIBERATE ASSERTION INVERSION — approved 2026-08-25, ruled by the
+# coordinator, recorded here so nobody later mistakes it for the forbidden move.
+#
+# These three cases asserted CLEAN in rounds two and three-minus-one. They now
+# assert a VIOLATION. That is a TIGHTENING — a new, stricter claim about what
+# the lint must catch — not a weakening to make a failing test pass, which is
+# what CLAUDE.md's test invariants forbid. No expected value was edited to
+# match an implementation's output; the rule the tests encode changed.
+#
+# Why: the shadow rule is being deleted. Ablation showed it protects nothing —
+# monkeypatching `_bound_names` to return set() left every injected-Clock shape
+# clean, including orchestrator/clock.py verbatim, because the real mechanism
+# is that `self` is unresolvable, not that shadowing is tracked. A sweep of all
+# 45 pure-package files found ZERO parameters or locals named time/date/
+# datetime/asyncio/importlib. It protected nothing, cost ~10 looser-than-master
+# rows, and enabled a regression.
+#
+# The rule is now uniform: a rebinding that collides with an import binding is
+# an error at ANY scope. A rebinding with no colliding import binds nothing and
+# stays clean — that hinge is unchanged, and the CLEAN_CASES entries for files
+# that never import the shadowed name are still correct and still green.
+INVERTED_SHADOW_CASES = [
+    ("import time + a parameter named `time`", """
+        import time
+
+
+        def elapsed(time):
+            return time.perf_counter()
+    """, RULE_COLLISION),
+    ("import time + `except TimeoutError as time`", """
+        import time
+
+
+        def deadline(fn):
+            try:
+                return fn()
+            except TimeoutError as time:
+                return time.time
+    """, RULE_COLLISION),
+    ("import time + a match/case capture named `time`", """
+        import time
+
+
+        def handle(event):
+            match event:
+                case {"clock": time}:
+                    return time.monotonic()
+            return None
+    """, RULE_COLLISION),
+]
+
+# Positions evaluated in the ENCLOSING scope, where a later rebinding does not
+# shadow the import. The earlier ruling — "a function-local rebinding makes the
+# name local for the whole body, so it can never silently resolve to the
+# stdlib" — is true for function bodies ONLY. Class bodies compile to LOAD_NAME
+# with a global fallback, and defaults/annotations/base lists are evaluated
+# where the statement sits, not inside the new scope. Each was confirmed by
+# executing it.
+ENCLOSING_SCOPE_CASES = [
+    ("class body: LOAD_NAME falls back to the global import", """
+        import time
+
+
+        class C:
+            # C.clock() really returns the wall clock: the class-level
+            # `time = None` below has not executed yet at this point.
+            clock = staticmethod(time.time)
+            time = None
+    """, RULE_CLOCK_REF),
+    ("default argument is evaluated in the enclosing scope", """
+        from datetime import datetime
+
+
+        def stamp(datetime=datetime):
+            # The default IS the datetime class, so this reads the wall clock.
+            return datetime.now()
+    """, RULE_COLLISION),
+    ("class nested in a function", """
+        import time
+
+
+        def make():
+            class C:
+                clock = staticmethod(time.time)
+                time = None
+            return C
+    """, RULE_CLOCK_REF),
+    ("class nested in a class", """
+        import time
+
+
+        class Outer:
+            class Inner:
+                clock = staticmethod(time.time)
+                time = None
+    """, RULE_CLOCK_REF),
+    ("annotation is evaluated in the enclosing scope", """
+        import time
+
+
+        class C:
+            clock: time.time = None
+            time = None
+    """, RULE_CLOCK_REF),
+    # The base list resolves to the module attribute, which is not itself
+    # forbidden — so what must fire here is the collision on the class-body
+    # rebinding, which the shadow rule currently swallows.
+    ("base-class list is evaluated in the enclosing scope", """
+        import datetime
+
+
+        class Stamp(datetime.datetime):
+            datetime = None
+    """, RULE_COLLISION),
+]
+
 EVASION_CASES = (DYNAMIC_IMPORT_CASES + ALIASED_BINDING_CASES
                  + UNLISTED_CLOCK_CALL_CASES + MASTER_REGRESSION_CASES
                  + COLLISION_CASES + CLOCK_SPELLING_CASES
-                 + DYNAMIC_IMPORT_SPELLING_CASES + CALLABLE_CAPTURE_CASES)
+                 + DYNAMIC_IMPORT_SPELLING_CASES + CALLABLE_CAPTURE_CASES
+                 + INVERTED_SHADOW_CASES + ENCLOSING_SCOPE_CASES)
 
 # Already caught today. These must survive the rewrite.
 DETECTED_CASES = [
@@ -427,6 +627,36 @@ DETECTED_CASES = [
 
         def pause():
             time.sleep(1)
+    """, RULE_CLOCK_REF),
+    # --- round three: enclosing-scope shapes ALREADY caught. Measured, not
+    # assumed — these three of the nine positions need no new work, and
+    # locking them in stops the shadow-rule deletion from disturbing them.
+    ("decorator in a class body, rebind after", """
+        import time
+
+
+        class C:
+            @time.sleep
+            def pause(self):
+                pass
+
+            time = None
+    """, RULE_CLOCK_REF),
+    ("comprehension's outermost iterable", """
+        import time
+
+
+        class C:
+            vals = [x for x in time.time()]
+            time = None
+    """, RULE_CLOCK_REF),
+    ("lambda default argument", """
+        import time
+
+
+        class C:
+            f = lambda _t=time.time: _t()
+            time = None
     """, RULE_CLOCK_REF),
 ]
 
@@ -467,40 +697,18 @@ CLEAN_CASES = [
             return feed.now()
     """),
     # --- round two ---
-    # The hinge of the collision rule: a shadow is legitimate precisely when
-    # the name is bound by something other than an import. The two cases above
-    # (`def elapsed(time)`, `datetime = Formatter(rows)`) are green because
-    # their files never import the shadowed name at all. This one is green for
-    # the harder reason — the file DOES import `time`, and the parameter is a
-    # different scope, which Python resolves to the parameter. Delete the
-    # scope/shadow logic and this case goes red, which is the point of it.
-    ("module-level `import time` + a parameter named `time` (different scope)", """
-        import time
-
-
-        def elapsed(time):
-            # The caller's Timer. Python binds this to the parameter inside
-            # this scope; the module-level import is not visible here.
-            return time.perf_counter()
-    """),
-    ("match/case capture pattern is a binding", """
-        import time
-
-
-        def handle(event):
-            match event:
-                case {"clock": time}:
-                    # `time` is the captured dict value, not the module.
-                    return time.monotonic()
-            return None
-    """),
-    # Comprehension scoping, guarded from the other side. The violation table
-    # has `[None for time in ()]` silencing a module, which the collision rule
-    # also happens to catch — so these are what actually pin the comprehension
-    # branch of _SCOPE_NODES. A comprehension target is scoped to the
+    # Comprehension scoping. A comprehension target is scoped to the
     # comprehension in Python 3: it rebinds nothing outside, so reusing an
-    # imported name is legal and must not read as a same-scope collision.
-    # The name is genuinely imported in the file — that is the hinge.
+    # imported name is legal. The `time` case below is the one that PINS the
+    # comprehension branch of _SCOPE_NODES under round three's rules — `time`
+    # is a watched base, so if the target folded into module scope the
+    # narrowed collision rule would fire. The `json` cases cover the same
+    # shape on an unwatched name.
+    ("comprehension target reusing an imported WATCHED name (pins the block)", """
+        import time
+
+        _UNUSED = [None for time in ()]
+    """),
     ("comprehension target reusing an imported name — list", """
         import json
 
@@ -521,21 +729,6 @@ CLEAN_CASES = [
 
         _KEYS = tuple(json for json in ("a", "b"))
     """),
-    # Same shape as the comprehension pair above, for two more blocks that the
-    # violation tables were catching by a different route and so left unpinned.
-    ("`except ... as time` binds the caught exception, not the module", """
-        import time
-
-
-        def deadline(fn):
-            try:
-                return fn()
-            except TimeoutError as time:
-                # The caught exception carries its own .time; the module is
-                # shadowed inside this handler. A nested scope, so not a
-                # collision — and not the stdlib clock either.
-                return time.time
-    """),
     ("a name bound to a local must not fall through to a star-import", """
         from time import *
 
@@ -545,6 +738,85 @@ CLEAN_CASES = [
             # would have supplied. Resolving to nothing must mean nothing —
             # never "guess the star module".
             sleep(1)
+    """),
+    # --- round three: the narrowed collision rule -------------------------
+    # The collision rule fires only when the rebound name's resolved target is
+    # a forbidden-import root, or the base of a FORBIDDEN_CALLS pattern
+    # (datetime.now, date.today, time.sleep, ...). NOT "came from a watched
+    # module" — `from datetime import UTC` resolves to `datetime.UTC`, which
+    # IS under `datetime`, so the loose wording reddens the first case below
+    # while passing all the others. That case is this rule's ablation, the
+    # same role `slackkit.realtime` plays for the dotted-prefix matcher.
+    #
+    # Every one of these is ordinary defensive Python whose rebound name can
+    # reach nothing forbidden. The current error text claims the rebinding
+    # "disables the purity check silently", which is false for all five — a
+    # rule whose own message is false on most of its firings is over-firing
+    # by construction.
+    ("`from datetime import UTC` + fallback rebind (rule ablation)", """
+        try:
+            from datetime import UTC
+        except ImportError:
+            from datetime import timezone
+            UTC = timezone.utc
+    """),
+    ("TYPE_CHECKING import with a runtime fallback", """
+        from typing import TYPE_CHECKING
+
+        if TYPE_CHECKING:
+            from decimal import Decimal
+        else:
+            Decimal = float
+    """),
+    ("`import logging` then `logging = logging.getLogger(__name__)`", """
+        import logging
+
+        logging = logging.getLogger(__name__)
+    """),
+    ("`from __future__ import annotations` + a variable named annotations", """
+        from __future__ import annotations
+
+        annotations = {"a": 1}
+    """),
+    ("optional dependency: `import numpy` / `numpy = None`", """
+        try:
+            import numpy
+        except ImportError:
+            numpy = None
+    """),
+    # --- round three: arity discriminates a clock read from a formatter ----
+    # time.strftime/asctime/ctime read the wall clock ONLY in their no-arg
+    # form. Given a time tuple or an epoch they are pure formatters, and
+    # flagging those would forbid ordinary rendering code. This is the
+    # ablation for the arity check: an implementation that adds the names to
+    # FORBIDDEN_REFS without looking at the call reddens all three.
+    ("time.strftime WITH a time tuple is a pure formatter", """
+        import time
+
+
+        def render(struct):
+            return time.strftime("%Y-%m-%d", struct)
+    """),
+    ("time.asctime WITH a time tuple is a pure formatter", """
+        import time
+
+
+        def render(struct):
+            return time.asctime(struct)
+    """),
+    ("time.ctime WITH an epoch argument is a pure formatter", """
+        import time
+
+
+        def render(secs):
+            return time.ctime(secs)
+    """),
+    ("pd.Timestamp(value) constructs, it does not read the clock", """
+        import pandas as pd
+
+
+        def at(value):
+            return pd.Timestamp(value)
     """),
 ]
 
@@ -621,6 +893,26 @@ SLACKKIT_REAL_VIOLATIONS = [
     ("slack_sdk imported by slackkit/outbox.py", {
         "slackkit/__init__.py": "",
         "slackkit/outbox.py": "import slack_sdk\n",
+    }, RULE_FORBIDDEN_IMPORT),
+    # D1 — prioritised. check_file skips `node.level != 0`, so a RELATIVE
+    # import of .real is exempt. Every intra-package import in the real
+    # slackkit/ is relative (outbox.py:13-14, fake.py:6, real.py:10), so the
+    # exempted spelling is the only one a contributor would actually write.
+    # A rule that catches the form nobody writes and misses the form everybody
+    # writes has never been tested against the code it guards.
+    ("D1: `from .real import RealSlack` inside slackkit/", {
+        "slackkit/__init__.py": "",
+        "slackkit/outbox.py": "from .real import RealSlack\n",
+    }, RULE_FORBIDDEN_IMPORT),
+    ("D2: `import slackkit` then slackkit.real.RealSlack()", {
+        "slackkit/__init__.py": "",
+        "orchestrator/daily.py": """
+            import slackkit
+
+
+            def post():
+                return slackkit.real.RealSlack()
+        """,
     }, RULE_FORBIDDEN_IMPORT),
 ]
 
@@ -784,6 +1076,19 @@ def test_captured_callables_are_flagged():
     """Capturing the function instead of calling it. Reads as careful seam
     code; is the banned dependency."""
     _assert_all_flagged(CALLABLE_CAPTURE_CASES, "callable capture")
+
+
+def test_shadowing_an_import_is_a_collision_at_any_scope():
+    """Assertions here were deliberately INVERTED from clean to violation on
+    2026-08-25 — see the note on INVERTED_SHADOW_CASES. A tightening, ruled
+    and approved, not a weakening to make a test pass."""
+    _assert_all_flagged(INVERTED_SHADOW_CASES, "inverted shadow")
+
+
+def test_enclosing_scope_positions_are_flagged():
+    """Class bodies, defaults, annotations and base lists are evaluated in the
+    enclosing scope, so a later rebinding does not shadow the import."""
+    _assert_all_flagged(ENCLOSING_SCOPE_CASES, "enclosing scope")
 
 
 def test_slackkit_init_must_stay_import_free():

--- a/tests/test_check_purity.py
+++ b/tests/test_check_purity.py
@@ -463,6 +463,58 @@ CLEAN_CASES = [
                     return time.monotonic()
             return None
     """),
+    # Comprehension scoping, guarded from the other side. The violation table
+    # has `[None for time in ()]` silencing a module, which the collision rule
+    # also happens to catch — so these are what actually pin the comprehension
+    # branch of _SCOPE_NODES. A comprehension target is scoped to the
+    # comprehension in Python 3: it rebinds nothing outside, so reusing an
+    # imported name is legal and must not read as a same-scope collision.
+    # The name is genuinely imported in the file — that is the hinge.
+    ("comprehension target reusing an imported name — list", """
+        import json
+
+        _KEYS = [json for json in ("a", "b")]
+    """),
+    ("comprehension target reusing an imported name — set", """
+        import json
+
+        _KEYS = {json for json in ("a", "b")}
+    """),
+    ("comprehension target reusing an imported name — dict", """
+        import json
+
+        _KEYS = {json: 1 for json in ("a", "b")}
+    """),
+    ("comprehension target reusing an imported name — generator", """
+        import json
+
+        _KEYS = tuple(json for json in ("a", "b"))
+    """),
+    # Same shape as the comprehension pair above, for two more blocks that the
+    # violation tables were catching by a different route and so left unpinned.
+    ("`except ... as time` binds the caught exception, not the module", """
+        import time
+
+
+        def deadline(fn):
+            try:
+                return fn()
+            except TimeoutError as time:
+                # The caught exception carries its own .time; the module is
+                # shadowed inside this handler. A nested scope, so not a
+                # collision — and not the stdlib clock either.
+                return time.time
+    """),
+    ("a name bound to a local must not fall through to a star-import", """
+        from time import *
+
+
+        def run(sleep):
+            # `sleep` is the injected callable, not the one the star import
+            # would have supplied. Resolving to nothing must mean nothing —
+            # never "guess the star module".
+            sleep(1)
+    """),
 ]
 
 CLEAN_FILE = """
@@ -514,6 +566,13 @@ SLACKKIT_REAL_VIOLATIONS = [
     ("dotted prefix reaches subpackages: slackkit.real.helpers", {
         "slackkit/__init__.py": "",
         "orchestrator/daily.py": "from slackkit.real.helpers import retry\n",
+    }),
+    ("`from slackkit import real` — the module is the package, not the name", {
+        # The other three spellings all put "slackkit.real" in `node.module`,
+        # so they never reach the per-alias check. This one is the natural way
+        # to write it and is the only case that exercises that branch.
+        "slackkit/__init__.py": "",
+        "orchestrator/daily.py": "from slackkit import real\n",
     }),
     ("wall clock parked in slackkit/outbox.py", {
         # The better half of (d): outbox/render/fake/port are orchestrator's

--- a/tests/test_check_purity.py
+++ b/tests/test_check_purity.py
@@ -27,6 +27,27 @@ CLEAN_CASES is the load-bearing half — above all `self._clock.now()`, the
 injected-Clock pattern the invariant exists to *require*. A lint that flags
 correct code is the failure mode that gets a lint deleted.
 
+HOW EVERY EVASION IN THIS BRANCH WAS FOUND, and the one thing to know before
+adding a case. Six evasions shipped past a green suite. Not one was found by
+reasoning about a case; every one was found by CROSSING TWO AXES nobody had
+crossed — enclosing-shadow x declaration-kind, nested-scope-kind x where-the-
+read-sits, walrus x alias. The reason is structural:
+
+    EVERY CASE FIXES ONE VALUE OF EVERY AXIS IT DOES NOT NAME.
+
+A case pinning one instance of a rule reads exactly like a case pinning the
+rule, and an ablation cannot tell them apart either, because deleting the block
+fails both. So the axes a table names are a CLAIM about what it covers, and an
+axis list that overstates coverage is the same defect as an unfalsifiable
+guard — of which this file has now retired four (`numpy`, the old `nonlocal`,
+a dead walrus pin, and a `global` case that could not catch the shape beside
+it). Before adding a case, ask what it holds fixed, not what it varies.
+
+Oracles are subject to the same rule. Prefer an EXACT probe — swap the callable
+for a recorder and count calls — over timing. A 0.06s threshold once scored a
+one-off `import asyncio` as an evasion; a noisy oracle is an overstated axis
+list wearing a number.
+
 Zero dependencies: plain no-arg `def test_*` functions and stdlib `tempfile`,
 so it runs under pytest (what CI and `make test` invoke) and under the
 `tests/run_tests.py` fallback runner alike. Scratch trees are built under
@@ -831,6 +852,89 @@ CALLABLE_CAPTURE_CASES = [
 
         def pause():
             getattr(time, "sleep")()
+    """, RULE_CLOCK_REF),
+    # --- WALRUS x ALIAS: two families that had never been crossed ----------
+    # Open since 11d7b54 — the whole branch — and not a regression from any
+    # recent work. The alias pass has always been `ast.Assign`-only, and
+    # `ast.NamedExpr` appears in the lint exactly once, inside _walrus_targets,
+    # purely for SCOPING. So a walrus is registered as a BINDER — it pops or
+    # stands the name — while the module it names is thrown away.
+    #
+    # Every walrus case elsewhere in this file binds its target to a VALUE
+    # (`_F()`, `1`, `r`, `time.sleep(...)`); not one binds it to a module or
+    # class ALIAS. Every alias case above binds with `=`; not one binds with
+    # `:=`. Neither family is wrong and neither covers this, because the axis
+    # that separates them was never varied.
+    #
+    # Verified by EXACT PROBE, not timing: `time.sleep` is swapped for a
+    # recorder, so "the clock path ran" is a call count. All six below report
+    # `sleep called 1x` while the lint reports clean. The plain-assign control
+    # (`time = _src`) FLAGS, which is what identifies the walrus as the thing
+    # doing the hiding. Timing was rejected as the oracle after a 0.06s
+    # threshold scored a one-off `import asyncio` as an evasion — a noisy
+    # oracle is the same defect class as an overstated axis list.
+    ("walrus alias, function scope", """
+        import time as _src
+
+
+        def f():
+            _w = (time := _src)
+            return time.sleep(0.30)
+    """, RULE_CLOCK_REF),
+    ("walrus alias, module scope", """
+        import time as _src
+
+        _w = (time := _src)
+        _R = time.sleep(0.30)
+    """, RULE_CLOCK_REF),
+    # Class scope resolves through `inherited` rather than `bindings` for its
+    # children, so it is its own arm of the mechanism rather than a third
+    # spelling of the two above.
+    ("walrus alias, class scope", """
+        import time as _src
+
+
+        class C:
+            _w = (time := _src)
+            _R = time.sleep(0.30)
+    """, RULE_CLOCK_REF),
+    # Transitivity: the walrus alias must itself be resolvable as the SOURCE of
+    # a second walrus alias. Master misses this one too, so it is a still-open
+    # evasion rather than a regression.
+    ("chained walrus alias", """
+        import time as _src
+
+
+        def f():
+            _a = (_x := _src)
+            _b = (_y := _x)
+            return _y.sleep(0.30)
+    """, RULE_CLOCK_REF),
+    # DISTINCT MECHANISM, and the one an obvious fix would miss: here the
+    # walrus sits in no `ast.Assign` at all. Extending the alias pass by
+    # walking `Assign.value` for a NamedExpr fixes the three above and leaves
+    # this red. The `if` and `while` condition shapes were measured and are the
+    # same mechanism as this one — documented rather than duplicated, since
+    # three spellings of one arm is volume, not coverage. Master misses it too:
+    # its `_dotted` cannot take a NamedExpr as an attribute base.
+    ("walrus alias in a return expression (no enclosing Assign)", """
+        import time as _src
+
+
+        def f():
+            return (time := _src).sleep(0.30)
+    """, RULE_CLOCK_REF),
+    # A non-`time` target, to keep the family from being pinned to one module.
+    # Proved by identity rather than a call recorder: f() returns a real
+    # datetime.datetime instance, so the walrus really did bind the imported
+    # class. Master flags this one.
+    ("walrus alias, datetime target", """
+        from datetime import datetime as _dt
+
+
+        def f():
+            _w = (datetime := _dt)
+            return datetime.now()
     """, RULE_CLOCK_REF),
 ]
 

--- a/tests/test_check_purity.py
+++ b/tests/test_check_purity.py
@@ -483,35 +483,44 @@ CALLABLE_CAPTURE_CASES = [
 
 # --- round three ------------------------------------------------------------
 
-# DELIBERATE ASSERTION INVERSION — approved 2026-08-25, ruled by the
-# coordinator, recorded here so nobody later mistakes it for the forbidden move.
+# THE COLLISION DISCRIMINATOR. One question decides every case in this file:
 #
-# These three cases asserted CLEAN in rounds two and three-minus-one. They now
-# assert a VIOLATION. That is a TIGHTENING — a new, stricter claim about what
-# the lint must catch — not a weakening to make a failing test pass, which is
-# what CLAUDE.md's test invariants forbid. No expected value was edited to
-# match an implementation's output; the rule the tests encode changed.
+#     Can the rebinding make a use site resolve to the import?
 #
-# Why: the shadow rule is being deleted. Ablation showed it protects nothing —
-# monkeypatching `_bound_names` to return set() left every injected-Clock shape
-# clean, including orchestrator/clock.py verbatim, because the real mechanism
-# is that `self` is unresolvable, not that shadowing is tracked. A sweep of all
-# 45 pure-package files found ZERO parameters or locals named time/date/
-# datetime/asyncio/importlib. It protected nothing, cost ~10 looser-than-master
-# rows, and enabled a regression.
+# The rows fall out of the question; the question cannot be re-derived from the
+# rows, which is why it is written here and not as a list of scope kinds.
+# Module scope: yes, rebind and use share one namespace. Class body: yes —
+# LOAD_NAME with a global fallback, so `a = time.time()` on the line ABOVE
+# `time = None` returns a real timestamp. Defaults, decorators, annotations,
+# base-class lists, a genexp's outermost iterable: yes, all evaluated in the
+# ENCLOSING scope, before the shadow exists. Function body: no, Python
+# guarantees the binding is private for the whole body. Comprehension target:
+# no, Python 3 scopes it and it does not leak (verified by execution).
 #
-# The rule is now uniform: a rebinding that collides with an import binding is
-# an error at ANY scope. A rebinding with no colliding import binds nothing and
-# stays clean — that hinge is unchanged, and the CLEAN_CASES entries for files
-# that never import the shadowed name are still correct and still green.
+# ASSERTION HISTORY — inverted, then PARTIALLY reverted. Both moves ruled and
+# approved by the coordinator, 2026-08-25, recorded so the next reader files
+# this as a decision rather than churn and does not re-litigate it:
+#
+#   1. Round three: these cases asserted CLEAN and were INVERTED to assert a
+#      VIOLATION, when the rule was "a collision at EVERY scope". That was a
+#      tightening — a stricter claim about what the lint must catch — never a
+#      weakening to make a failing test pass, which CLAUDE.md forbids. No
+#      expected value was edited to match an implementation's output.
+#   2. Round four: the "every scope" rule was revised to the discriminator
+#      above, and the parameter case was REVERTED to CLEAN — a parameter can
+#      never make a use site resolve to the import. It now lives in
+#      CLEAN_CASES. The revert is partial ON PURPOSE: `except ... as` and
+#      `match/case` capture stay violations. Blanket-undoing the inversion
+#      would have been the easy edit and would have quietly re-opened two
+#      shapes.
+#
+# The background to move 1 stands: the shadow rule was deleted because it
+# protected nothing. Monkeypatching `_bound_names` to return set() left every
+# injected-Clock shape clean, orchestrator/clock.py included, because the real
+# mechanism is that `self` is unresolvable. A sweep of all 45 pure-package
+# files found ZERO parameters or locals named time/date/datetime/asyncio/
+# importlib. It cost ~10 looser-than-master rows and enabled a regression.
 INVERTED_SHADOW_CASES = [
-    ("import time + a parameter named `time`", """
-        import time
-
-
-        def elapsed(time):
-            return time.perf_counter()
-    """, RULE_COLLISION),
     ("import time + `except TimeoutError as time`", """
         import time
 
@@ -534,13 +543,12 @@ INVERTED_SHADOW_CASES = [
     """, RULE_COLLISION),
 ]
 
-# Positions evaluated in the ENCLOSING scope, where a later rebinding does not
-# shadow the import. The earlier ruling — "a function-local rebinding makes the
-# name local for the whole body, so it can never silently resolve to the
-# stdlib" — is true for function bodies ONLY. Class bodies compile to LOAD_NAME
-# with a global fallback, and defaults/annotations/base lists are evaluated
-# where the statement sits, not inside the new scope. Each was confirmed by
-# executing it.
+# The "yes" rows of the discriminator above: positions evaluated in the
+# ENCLOSING scope, where a later rebinding does not shadow the import, plus
+# class bodies whose LOAD_NAME falls back to the global. The earlier ruling —
+# "a function-local rebinding makes the name local for the whole body, so it
+# can never silently resolve to the stdlib" — is true for function BODIES only.
+# Each of these was confirmed by executing it.
 ENCLOSING_SCOPE_CASES = [
     ("class body: LOAD_NAME falls back to the global import", """
         import time
@@ -552,6 +560,13 @@ ENCLOSING_SCOPE_CASES = [
             clock = staticmethod(time.time)
             time = None
     """, RULE_CLOCK_REF),
+    # RULE CHANGED from RULE_COLLISION to RULE_CLOCK_REF when the "every
+    # scope" rule was revised: the parameter is private to the body, so the
+    # collision rule no longer fires here. What makes this a violation is that
+    # the DEFAULT is evaluated in the enclosing scope, so the parameter really
+    # holds the imported class and `datetime.now()` resolves through it to
+    # datetime.datetime.now. Catching it means propagating a default into the
+    # parameter's binding — the alias-propagation family, not the collision one.
     ("default argument is evaluated in the enclosing scope", """
         from datetime import datetime
 
@@ -559,7 +574,7 @@ ENCLOSING_SCOPE_CASES = [
         def stamp(datetime=datetime):
             # The default IS the datetime class, so this reads the wall clock.
             return datetime.now()
-    """, RULE_COLLISION),
+    """, RULE_CLOCK_REF),
     ("class nested in a function", """
         import time
 
@@ -678,6 +693,22 @@ CLEAN_CASES = [
     ("parameter named `time` shadowing the module", """
         def elapsed(time):
             # `time` is a Timer passed in by the caller, not the stdlib module.
+            return time.perf_counter()
+    """),
+    # PARTIALLY REVERTED 2026-08-25 (see the note on INVERTED_SHADOW_CASES).
+    # This case was inverted to a violation under the "collision at every
+    # scope" rule, then reverted here when that rule was revised to the
+    # discriminator: a parameter is private to the whole function body, so it
+    # can never make a use site resolve to the import. Unlike the two cases
+    # above it, this file DOES import `time` — which is exactly why it is the
+    # one that pins the function-body row of the discriminator.
+    ("module-level `import time` + a parameter named `time`", """
+        import time
+
+
+        def elapsed(time):
+            # Python binds this to the parameter for the entire body; the
+            # module-level import is unreachable from here.
             return time.perf_counter()
     """),
     ("local variable named `datetime` shadowing the class", """
@@ -1078,10 +1109,13 @@ def test_captured_callables_are_flagged():
     _assert_all_flagged(CALLABLE_CAPTURE_CASES, "callable capture")
 
 
-def test_shadowing_an_import_is_a_collision_at_any_scope():
-    """Assertions here were deliberately INVERTED from clean to violation on
-    2026-08-25 — see the note on INVERTED_SHADOW_CASES. A tightening, ruled
-    and approved, not a weakening to make a test pass."""
+def test_shadowing_an_import_where_a_use_can_still_reach_it():
+    """Assertions here were deliberately INVERTED from clean to violation, then
+    PARTIALLY reverted, both ruled and approved 2026-08-25 — see the note on
+    INVERTED_SHADOW_CASES. A tightening, never a weakening to make a test pass.
+    Renamed from ..._is_a_collision_at_any_scope: "any scope" was the rule that
+    got revised, and a test name outliving its rule is how the next reader
+    learns the wrong one."""
     _assert_all_flagged(INVERTED_SHADOW_CASES, "inverted shadow")
 
 

--- a/tests/test_check_purity.py
+++ b/tests/test_check_purity.py
@@ -933,12 +933,31 @@ CALLABLE_CAPTURE_CASES = [
             return _y.sleep(0.30)
     """, RULE_CLOCK_REF),
     # DISTINCT MECHANISM, and the one an obvious fix would miss: here the
-    # walrus sits in no `ast.Assign` at all. Extending the alias pass by
-    # walking `Assign.value` for a NamedExpr fixes the three above and leaves
-    # this red. The `if` and `while` condition shapes were measured and are the
-    # same mechanism as this one — documented rather than duplicated, since
-    # three spellings of one arm is volume, not coverage. Master misses it too:
-    # its `_dotted` cannot take a NamedExpr as an attribute base.
+    # walrus sits in no `ast.Assign` at all, and it is used directly as an
+    # ATTRIBUTE BASE. Extending the alias pass alone leaves this red. Master
+    # misses it too: its `_dotted` cannot take a NamedExpr as an attribute base.
+    #
+    # WHY `if`/`while` CONDITIONS ARE NOT HERE — corrected 2026-08-25, and the
+    # earlier reason was wrong. They are NOT this mechanism. Measured by
+    # ablating each arm of the fix separately:
+    #
+    #     shape             no _dotted arm   no alias arm   carried by
+    #     function scope    CLOCK            clean          alias
+    #     module scope      CLOCK            clean          alias
+    #     class scope       CLOCK            clean          alias
+    #     chained           CLOCK            clean          alias
+    #     datetime          CLOCK            clean          alias
+    #     IF condition      CLOCK            clean          alias
+    #     WHILE condition   CLOCK            clean          alias
+    #     RETURN expr       clean            CLOCK          _dotted
+    #
+    # So `if`/`while` ride the ALIAS arm, which the four cases above already
+    # pin, and only this case rides `_dotted`. The conclusion is unchanged —
+    # they need no separate cases — but the reason is the opposite of what was
+    # first written, and it matters: anyone deleting the alias arm believing
+    # `_dotted` covered `if`/`while` would be wrong on SEVEN of these eight
+    # rows. A right answer resting on a wrong mechanism is the failure this
+    # file exists to catch, so the table is recorded rather than the claim.
     ("walrus alias in a return expression (no enclosing Assign)", """
         import time as _src
 


### PR DESCRIPTION
Closes #43.

The purity lint enforcing `CLAUDE.md` invariant 3 caught only the naive spelling of everything it forbids. A synthetic `gate/evade.py` full of forbidden things returned `PURITY LINT: clean`, exit 0.

## Result

```
1202 passed, 1 skipped         lint exit 0, 45 files across 8 packages (3.12 and 3.14)
ablation 35 blocks, 34 pinned  survivor proven inert 4x (the "*" no-op)
AST case-body audit, 19 commits  zero silent test weakening
differential vs master         666 snippets: 0 evasions, 234 master false positives
```

All four holes #43 named are closed, plus `market/` coverage and the `slackkit` boundary.

**Now caught that master misses:** dynamic imports (`importlib.import_module`, `__import__`, `builtins.__import__`); aliased bindings; bare `ast.Name` calls; the clock family (`time_ns`, `monotonic_ns`, `process_time`, `datetime.today`, `pd.Timestamp.now`, arity-aware `gmtime`/`localtime`/`strftime`); callable capture (`_sleep = time.sleep`, dispatch tables, class attributes, default-arg fallbacks); `getattr` spellings; star-import laundering; relative imports inside a linted package; `slackkit.real` by import and by attribute; and the `global`/`nonlocal`/walrus binder family.

**Six further evasions were found during review and fixed** — each executed a real wall-clock read while the lint returned exit 0. Two blocks were called on this branch before it was allowed through.

## ⚠️ The surface is NOT claimed closed

**Alias propagation handles** plain/annotated assignment, assignment chains, parameter and lambda defaults, class attributes, and walrus. **It does not handle** tuple-unpacking, `for`/comprehension targets, or aliases established via `global`/`nonlocal` — 192 measured shapes. Master misses all of them too, so pre-existing rather than a regression. Filed as #82.

**Unswept by both generators used:** use-order x alias-form; binder-shadowing x alias-form; star and relative imports; nesting past two scopes; multiple simultaneous binders; class-in-function scopes; cross-module import following (#69).

**One false positive deliberately accepted and pinned** in `KNOWN_FALSE_POSITIVE_CASES` — a function that both imports `time` locally in one branch and binds an injected `Clock` to the same name in another. Unreachable without a function-body import of a forbidden module; there are zero such imports across the six pure packages, where the idiom is `now = clock.now()`. Remedy named in the case.

## How the holes were found

All six settled by execution, never by argument. **Four came from attacking a specific written claim in the source; two from an instrument.** No generator found more than a third of them, and two review instruments each shipped a false result. A clean sweep from these instruments is evidence about the instruments, not the surface. Four unfalsifiable guards were retired; every pin now carries its deletion-check result.

Tests-first throughout. Two test changes were deliberately authorised and documented in-file: one case inverted then reverted as the rule was corrected, and a table replaced when the `slackkit` decision moved from (c) to (d).
