### PR TITLE
fix: preflight opens the live DB read-only and reports its schema state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,8 +109,14 @@ surface-pin: deps
 # the eval suite is not — a live DB the code cannot run against should stop
 # the deploy before ~$$0.31 of real LLM turns, not after. Same uid and
 # EnvironmentFile as step 2: FUND_DB comes from /etc/fund/env, and the live DB
-# is owned by `fund`. Exit codes: 0 ok, 1 migrations pending, 2 unexplained
-# divergence, 3 cannot determine. Only 0 continues.
+# is owned by `fund`.
+#
+# The STEP's exit codes are 0 ok, 1 migrations pending, 2 unexplained
+# divergence, 3 cannot determine, and only 0 continues to step 2. They are not
+# this target's: make collapses any failed recipe line to its own exit 2, so
+# read which of the four it was off the step's stderr, never off `make`'s
+# status — a target exit 2 is make reporting failure, not "unexplained
+# divergence".
 preflight:
 	systemd-run --uid=fund --pipe --wait --quiet \
 	  --property=WorkingDirectory=/opt/fund \

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,23 @@ surface-pin: deps
 # evals/traces/ is tracked in git, so leftovers dirty the droplet checkout.
 # No `deps` prerequisite: this runs /opt/fund/.venv as the fund user, and
 # `deps` would sync the invoking user's checkout instead.
+#
+# Step 1 opens the LIVE database at $$FUND_DB and reports its schema state.
+# Read-only: it never calls state.db.connect(), which would APPLY the pending
+# migration it exists to report (#17). It runs FIRST because it is free and
+# the eval suite is not — a live DB the code cannot run against should stop
+# the deploy before ~$$0.31 of real LLM turns, not after. Same uid and
+# EnvironmentFile as step 2: FUND_DB comes from /etc/fund/env, and the live DB
+# is owned by `fund`. Exit codes: 0 ok, 1 migrations pending, 2 unexplained
+# divergence, 3 cannot determine. Only 0 continues.
 preflight:
+	systemd-run --uid=fund --pipe --wait --quiet \
+	  --property=WorkingDirectory=/opt/fund \
+	  --property=EnvironmentFile=/etc/fund/env \
+	  --property=Environment=PATH=/home/fund/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin \
+	  --property=Environment=HOME=/home/fund \
+	  --property=TimeoutStartSec=1min \
+	  /opt/fund/.venv/bin/python3 scripts/preflight_schema.py
 	systemd-run --uid=fund --pipe --wait --quiet \
 	  --property=WorkingDirectory=/opt/fund \
 	  --property=EnvironmentFile=/etc/fund/env \

--- a/ops/README.md
+++ b/ops/README.md
@@ -422,13 +422,18 @@ default is safe and idempotent; anything that drops, renames, rewrites or
 backfills a column is not a deploy step and needs planning on its own.
 Take a fresh backup immediately before the pull.
 
-**`make preflight` does NOT run the migration, and a green preflight is not
-evidence that it ran.** Preflight drives `eval_suite.py`, which builds a fresh
-per-trial DB under `evals/traces/` and never opens `$FUND_DB`. Measured on
-2026-08-19: after a clean pull and a green preflight, the live DB still had
-zero of the six new columns. Left there, the first `connect()` against it would
-have been the next 09:35 `run_day` — the schema changing unattended, mid-day,
-with a green preflight standing as false reassurance that it already had.
+**`make preflight` does NOT run the migration.** It now *reports* on the live
+DB — `scripts/preflight_schema.py` opens `$FUND_DB` read-only (never
+`connect()`, which would apply the migration it is reporting on) and exits 0
+ok, 1 migrations pending, 2 unexplained divergence, 3 cannot determine. So a
+green preflight is now evidence the schema is current, and a red one names
+which of those three it is. Until 2026-08-25 it drove `eval_suite.py` alone,
+which builds a fresh per-trial DB under `evals/traces/` and never opened
+`$FUND_DB`: measured on 2026-08-19, after a clean pull and a green preflight,
+the live DB still had zero of the six new columns. Left there, the first
+`connect()` against it would have been the next 09:35 `run_day` — the schema
+changing unattended, mid-day, with a green preflight standing as false
+reassurance that it already had.
 
 So fire it deliberately, while you are watching and the backup is fresh:
 

--- a/ops/README.md
+++ b/ops/README.md
@@ -425,9 +425,13 @@ Take a fresh backup immediately before the pull.
 **`make preflight` does NOT run the migration.** It now *reports* on the live
 DB — `scripts/preflight_schema.py` opens `$FUND_DB` read-only (never
 `connect()`, which would apply the migration it is reporting on) and exits 0
-ok, 1 migrations pending, 2 unexplained divergence, 3 cannot determine. So a
-green preflight is now evidence the schema is current, and a red one names
-which of those three it is. Until 2026-08-25 it drove `eval_suite.py` alone,
+ok, 1 migrations pending, 2 unexplained divergence, 3 cannot determine. Read
+which one off that step's stderr, not off `make`'s status: make collapses any
+recipe failure to its own exit 2. A green preflight is now evidence that every
+table and column `state/schema.sql` declares is present — **names only**, so
+types, `NOT NULL`, `CHECK` and `UNIQUE` are not compared and a constraint lost
+in a hand-edited table still reads green. Until 2026-08-25 it drove
+`eval_suite.py` alone,
 which builds a fresh per-trial DB under `evals/traces/` and never opened
 `$FUND_DB`: measured on 2026-08-19, after a clean pull and a green preflight,
 the live DB still had zero of the six new columns. Left there, the first

--- a/scripts/preflight_schema.py
+++ b/scripts/preflight_schema.py
@@ -219,33 +219,60 @@ def check(db_path: str | None) -> tuple[int, str]:
             f" pending.\n{_NAMES_ONLY}\n  db: {path}")
 
 
+# The two errors a read-only open gives when it cannot CREATE a sidecar. Used
+# only to choose which explanation to print — the exit code is
+# CANNOT_DETERMINE whatever the string says, so a future SQLite that reworded
+# these degrades to the generic message and never to a wrong exit code.
+_SIDECAR_ERRORS = ("unable to open database file",
+                   "attempt to write a readonly database")
+
+
 def _unreadable(path: Path, exc: sqlite3.Error) -> str:
     """Why a read-only open failed, without inventing a cause.
 
-    The comment here used to say a read-only open "refuses rather than
-    replaying the log" when the WAL needs recovery. Measured, that is false: a
-    `-wal` holding uncommitted-to-main data with no `-shm` beside it opens
-    fine and reads the WAL's contents, recreating the `-shm`. What actually
-    fails is a DIRECTORY this uid cannot write, because the sidecar cannot be
-    created there — reported as either "unable to open database file" or
-    "attempt to write a readonly database" depending on whether a `-wal`
-    exists. Naming WAL recovery on every sqlite3.Error sent an operator to
-    inspect a write-ahead log when FUND_DB simply pointed at the wrong file.
+    MEASURED, 4 database states x 2 directory modes. What fails is not the WAL
+    state and not the directory alone — it is SQLite needing to CREATE a
+    sidecar it cannot create:
+
+        sidecars on disk   writable dir   unwritable dir
+        -wal and -shm      opens          OPENS — nothing to create
+        -wal only          opens          "unable to open database file"
+        -shm only          opens          "attempt to write a readonly database"
+        neither            opens          "attempt to write a readonly database"
+
+    So a missing `-shm` beside a present `-wal` gives the first string and a
+    missing `-wal` gives the second. Two earlier readings of this were wrong in
+    opposite directions and both got written down as fact: "a WAL needing
+    replay refuses the open" (it does not — it opens and reads the WAL), and
+    "an unwritable directory fails the open" (not on its own — with both
+    sidecars already present it opens, even with the `-shm` file itself mode
+    444). The droplet's between-runs shape is a WAL-mode header with the
+    sidecars cleanly removed, which is the LAST row: it opens in a writable
+    directory and fails in an unwritable one.
+
+    A corrupt file is separate: "file is not a database" comes back the same in
+    either directory mode, so it never indicates a permission problem.
     """
     head = f"CANNOT DETERMINE: cannot read {path} — {exc}"
-    if not os.access(path.parent, os.W_OK):
+    tail = "  Preflight has NOT checked the live schema."
+    # Both halves must hold before blaming the directory. Testing os.access
+    # FIRST let a plain text file in an unwritable directory print the
+    # headline "file is not a database" over an explanation about directory
+    # permissions — headline and cause disagreeing, which is the same wrong
+    # turn at 09:30 as the WAL paragraph this replaced.
+    if (any(s in str(exc) for s in _SIDECAR_ERRORS)
+            and not os.access(path.parent, os.W_OK)):
         return (f"{head}\n"
-                f"  {path.parent} is not writable by this uid. A WAL database"
-                " needs its `-shm` sidecar beside the main file, and a"
-                " read-only open still has to create it — so an unwritable"
-                " DIRECTORY blocks the read. On the droplet this step runs as"
-                " uid `fund`, which owns /var/lib/fund.\n"
-                "  Preflight has NOT checked the live schema.")
+                f"  {path.parent} is not writable by this uid, and this"
+                " database needs a `-wal`/`-shm` sidecar created beside it"
+                " before it can be read — a read-only open still creates"
+                " those. Grant the directory to the uid running preflight; on"
+                " the droplet that is `fund`, which owns /var/lib/fund.\n"
+                f"{tail}")
     return (f"{head}\n"
             "  The file exists but SQLite would not read it: not a database,"
             " a truncated or corrupt one, or unreadable by this uid. Check"
-            " that FUND_DB names the fund's SQLite file.\n"
-            "  Preflight has NOT checked the live schema.")
+            f" that FUND_DB names the fund's SQLite file.\n{tail}")
 
 
 def main() -> int:

--- a/scripts/preflight_schema.py
+++ b/scripts/preflight_schema.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Report the LIVE database's schema state. Read-only; never migrates (#17).
+
+`make preflight` used to run eval_suite.py alone, which builds a fresh
+per-trial DB. Preflight therefore checked schema against a database it had
+created moments earlier and never opened `$FUND_DB` — so a green preflight said
+nothing about whether a pending migration had reached the droplet. On
+2026-08-19 the attribution columns were 0/6 on the live DB behind a green
+preflight, and the next connect() would have ALTERed production unattended, at
+09:35, mid trading day.
+
+WHY NOT state.db.connect(). connect() ends with _apply_migrations(), so the
+obvious way to open the DB is the one that silently applies the very thing
+being reported on. #17 puts that out of scope: "Preflight reports; a human
+decides when to migrate, with a backup." This opens `file:...?mode=ro`
+instead — and `mode=ro`, not `immutable=1`: the live DB is in WAL, and
+`immutable` bypasses the WAL to read a snapshot that can be torn.
+
+FOUR OUTCOMES, and the middle two are the point. A live database that has
+never run migrations.apply() genuinely differs from schema.sql, and that
+difference is expected and actionable. A difference no migration explains is a
+real failure. They get distinct exit codes and distinct headlines so an
+operator can tell "run the migration" from "something is wrong" without
+reading this file:
+
+    0  OK                      — every table present, nothing pending
+    1  MIGRATIONS PENDING      — behind, and a known migration closes the gap
+    2  UNEXPLAINED DIVERGENCE  — differs in a way no migration explains
+    3  CANNOT DETERMINE        — unset/missing/unreadable/WAL needs recovery
+
+Ambiguity is red, never green (invariant 4).
+
+EXPECTED SCHEMA IS state/schema.sql ALONE. migrations.py is the catch-up path
+TO that file, not a second source of truth; a union of a target and the
+mechanism for reaching it is just the target. Scope is `$FUND_DB` only —
+fundbt/registry.py's trial_registry/holdout_evaluations live in a separate
+database with its own DDL home, and expecting them here would fail every run.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+from pathlib import Path
+from urllib.request import pathname2url
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from state.migrations import MIGRATIONS, pending  # noqa: E402
+
+SCHEMA = ROOT / "state" / "schema.sql"
+
+OK = 0
+MIGRATIONS_PENDING = 1
+UNEXPLAINED_DIVERGENCE = 2
+CANNOT_DETERMINE = 3
+
+
+def expected_schema() -> dict[str, set[str]]:
+    """{table: columns} that schema.sql declares.
+
+    Built by running the DDL into an in-memory database rather than parsing
+    it: the parser that would be needed to get CHECK constraints and trailing
+    comments right is a second implementation of SQLite, and a schema file the
+    real engine accepts is the only definition of what the file means.
+    """
+    ref = sqlite3.connect(":memory:")
+    try:
+        ref.executescript(SCHEMA.read_text())
+        tables = [r[0] for r in ref.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+            " AND name NOT LIKE 'sqlite_%'")]
+        return {t: {r[1] for r in ref.execute(f"PRAGMA table_info({t})")}
+                for t in tables}
+    finally:
+        ref.close()
+
+
+def _open_readonly(db_path: str) -> sqlite3.Connection:
+    """Open `db_path` with no way to write it. Raises sqlite3.Error if it
+    cannot be read — a missing file, a non-database, or a WAL needing replay
+    all land here, and all mean 'cannot determine'."""
+    uri = f"file:{pathname2url(str(Path(db_path).resolve()))}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def check(db_path: str | None) -> tuple[int, str]:
+    """Report on the database at `db_path`. Returns (exit code, report).
+
+    Writes nothing, ever — including to the database it is reporting on.
+    """
+    if db_path is None or not db_path.strip():
+        return (CANNOT_DETERMINE,
+                "CANNOT DETERMINE: FUND_DB is unset or blank, so preflight has"
+                " not checked the live schema.\n"
+                "  A preflight that did not look is not a green one"
+                " (invariant 4). Set FUND_DB (it comes from"
+                " /etc/fund/env on the droplet) and re-run.")
+    path = Path(db_path.strip())
+    if not path.is_file():
+        return (CANNOT_DETERMINE,
+                f"CANNOT DETERMINE: no database file at {path}.\n"
+                "  Nothing was created: preflight opens the live DB read-only"
+                " and never brings one into existence. Check FUND_DB.")
+    try:
+        conn = _open_readonly(str(path))
+        try:
+            live_tables = {r["name"] for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+                " AND name NOT LIKE 'sqlite_%'")}
+            live_columns = {
+                t: {r["name"] for r in conn.execute(f"PRAGMA table_info({t})")}
+                for t in live_tables}
+            behind = pending(conn)
+        finally:
+            conn.close()
+    except sqlite3.Error as exc:
+        # A WAL that needs replaying reports SQLITE_READONLY_RECOVERY here
+        # rather than handing back a torn snapshot. Unreadable is red.
+        return (CANNOT_DETERMINE,
+                f"CANNOT DETERMINE: cannot read {path} — {exc}\n"
+                "  The live DB runs in WAL; a read-only open refuses rather"
+                " than replaying the log or reading a torn snapshot. Preflight"
+                " has NOT checked the live schema.")
+
+    expected = expected_schema()
+    missing_tables = sorted(set(expected) - live_tables)
+    missing_columns = sorted(
+        (t, c) for t, columns in expected.items() if t in live_tables
+        for c in columns - live_columns[t])
+    # A missing column is explained when a pending migration adds it. A
+    # missing TABLE never is: every migration is an additive ALTER, and
+    # nothing here creates a table.
+    explained = {pair for name in behind for pair in MIGRATIONS[name]}
+    unexplained = [pair for pair in missing_columns if pair not in explained]
+
+    if missing_tables or unexplained:
+        lines = ["UNEXPLAINED DIVERGENCE: the live schema differs from"
+                 " state/schema.sql in a way no migration explains."]
+        if missing_tables:
+            lines.append(f"  tables absent: {', '.join(missing_tables)}")
+        if unexplained:
+            lines.append("  columns absent: "
+                         + ", ".join(f"{t}.{c}" for t, c in unexplained))
+        lines.append(f"  db: {path}")
+        lines.append("  Running a migration will NOT fix this. Investigate"
+                     " before deploying — the live DB is not the database this"
+                     " code was written against.")
+        return UNEXPLAINED_DIVERGENCE, "\n".join(lines)
+
+    if behind:
+        return (MIGRATIONS_PENDING,
+                "MIGRATIONS PENDING: the live schema is behind"
+                " state/schema.sql.\n"
+                f"  pending: {', '.join(behind)}\n"
+                "  columns absent: "
+                + ", ".join(f"{t}.{c}" for t, c in missing_columns) + "\n"
+                f"  db: {path}\n"
+                "  Expected and actionable. Take a backup"
+                " (ops/backup.sh), then apply the migration deliberately —"
+                " preflight only reports, and a human decides when to"
+                " migrate. Left alone, the next connect() applies it"
+                " unattended at the first tool call of a trading day.")
+
+    return (OK,
+            f"OK: live schema matches state/schema.sql ({len(expected)} tables)"
+            f" and no migrations are pending.\n  db: {path}")
+
+
+def main() -> int:
+    code, report = check(os.environ.get("FUND_DB"))
+    print(report, file=sys.stdout if code == OK else sys.stderr)
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/preflight_schema.py
+++ b/scripts/preflight_schema.py
@@ -12,9 +12,30 @@ preflight, and the next connect() would have ALTERed production unattended, at
 WHY NOT state.db.connect(). connect() ends with _apply_migrations(), so the
 obvious way to open the DB is the one that silently applies the very thing
 being reported on. #17 puts that out of scope: "Preflight reports; a human
-decides when to migrate, with a backup." This opens `file:...?mode=ro`
-instead — and `mode=ro`, not `immutable=1`: the live DB is in WAL, and
-`immutable` bypasses the WAL to read a snapshot that can be torn.
+decides when to migrate, with a backup." This opens `file:...?mode=ro` instead.
+
+WHY mode=ro AND NOT immutable=1, measured rather than assumed. The live DB runs
+in WAL, so recent commits can live in the `-wal` file and not yet in the main
+one. Against a database whose whole DDL was still in an uncheckpointed `-wal`,
+`mode=ro` read all 11 tables and `immutable=1` raised "no such table: events" —
+it had skipped the WAL and read the stale snapshot behind it. `immutable=1`
+would therefore report a fully-migrated DB as empty.
+
+WHAT IS COMPARED — names only, and this is a deliberate limit, not an
+oversight. Table names and column names, via PRAGMA table_info. Types, NOT
+NULL, DEFAULT, CHECK and UNIQUE are NOT compared: a live DB whose columns were
+added by ALTER TABLE stores different `sqlite_master.sql` text than a fresh
+CREATE from schema.sql, so a text or constraint comparison would red-flag the
+normal post-migration database. Comparing constraints is a real check and a
+separate decision; until it is made, a `tickets` table missing its
+`UNIQUE (decision_id)` (the constraint behind invariant 5) passes here. Every
+message says so rather than implying a match it did not test.
+
+ONE DIRECTION. This asks "does the live DB have everything schema.sql
+declares", not "are the two identical". A live DB that is AHEAD — an extra
+table, an extra column — is green. That is deliberate: it keeps the code
+rollback at ops/README.md § Rollback green, since `git checkout <previous-sha>`
+leaves a database that already ran the newer migration.
 
 FOUR OUTCOMES, and the middle two are the point. A live database that has
 never run migrations.apply() genuinely differs from schema.sql, and that
@@ -23,12 +44,13 @@ real failure. They get distinct exit codes and distinct headlines so an
 operator can tell "run the migration" from "something is wrong" without
 reading this file:
 
-    0  OK                      — every table present, nothing pending
+    0  OK                      — every declared table and column is present
     1  MIGRATIONS PENDING      — behind, and a known migration closes the gap
     2  UNEXPLAINED DIVERGENCE  — differs in a way no migration explains
-    3  CANNOT DETERMINE        — unset/missing/unreadable/WAL needs recovery
+    3  CANNOT DETERMINE        — unset, missing, unreadable, not the fund DB,
+                                 or preflight itself failed
 
-Ambiguity is red, never green (invariant 4).
+Ambiguity is red, never green (invariant 4) — including a crash in this script.
 
 EXPECTED SCHEMA IS state/schema.sql ALONE. migrations.py is the catch-up path
 TO that file, not a second source of truth; a union of a target and the
@@ -42,6 +64,7 @@ from __future__ import annotations
 import os
 import sqlite3
 import sys
+import traceback
 from pathlib import Path
 from urllib.request import pathname2url
 
@@ -57,14 +80,19 @@ MIGRATIONS_PENDING = 1
 UNEXPLAINED_DIVERGENCE = 2
 CANNOT_DETERMINE = 3
 
+_NAMES_ONLY = ("  Names only: table and column names are compared, not types,"
+               " NOT NULL, DEFAULT, CHECK or UNIQUE.")
+
 
 def expected_schema() -> dict[str, set[str]]:
-    """{table: columns} that schema.sql declares.
+    """{table: column names} that schema.sql declares.
 
     Built by running the DDL into an in-memory database rather than parsing
-    it: the parser that would be needed to get CHECK constraints and trailing
-    comments right is a second implementation of SQLite, and a schema file the
-    real engine accepts is the only definition of what the file means.
+    it: the parser needed to get CHECK constraints, nested parentheses and
+    trailing comments right is a second implementation of SQLite, and a schema
+    file the real engine accepts is the only definition of what the file
+    means. Only names survive — see the module docstring on what that does and
+    does not catch.
     """
     ref = sqlite3.connect(":memory:")
     try:
@@ -78,11 +106,13 @@ def expected_schema() -> dict[str, set[str]]:
         ref.close()
 
 
-def _open_readonly(db_path: str) -> sqlite3.Connection:
-    """Open `db_path` with no way to write it. Raises sqlite3.Error if it
-    cannot be read — a missing file, a non-database, or a WAL needing replay
-    all land here, and all mean 'cannot determine'."""
-    uri = f"file:{pathname2url(str(Path(db_path).resolve()))}?mode=ro"
+def _open_readonly(db_path: Path) -> sqlite3.Connection:
+    """Open `db_path` with no way to write its contents.
+
+    Raises sqlite3.Error when it cannot be read at all — see check() for what
+    the failures actually mean.
+    """
+    uri = f"file:{pathname2url(str(db_path.resolve()))}?mode=ro"
     conn = sqlite3.connect(uri, uri=True)
     conn.row_factory = sqlite3.Row
     return conn
@@ -91,7 +121,12 @@ def _open_readonly(db_path: str) -> sqlite3.Connection:
 def check(db_path: str | None) -> tuple[int, str]:
     """Report on the database at `db_path`. Returns (exit code, report).
 
-    Writes nothing, ever — including to the database it is reporting on.
+    Never writes the database's CONTENTS — no row, no column, no schema, and
+    in particular no migration. It is not inert on the filesystem: opening a
+    WAL database read-only creates or refreshes the `-shm`/`-wal` sidecars
+    next to it, which is SQLite's own bookkeeping and cannot alter what the
+    database holds. Measured, not assumed: an ADD-COLUMN-pending DB still
+    reports pending after a run, with the main file's mtime unchanged.
     """
     if db_path is None or not db_path.strip():
         return (CANNOT_DETERMINE,
@@ -107,7 +142,7 @@ def check(db_path: str | None) -> tuple[int, str]:
                 "  Nothing was created: preflight opens the live DB read-only"
                 " and never brings one into existence. Check FUND_DB.")
     try:
-        conn = _open_readonly(str(path))
+        conn = _open_readonly(path)
         try:
             live_tables = {r["name"] for r in conn.execute(
                 "SELECT name FROM sqlite_master WHERE type='table'"
@@ -119,15 +154,23 @@ def check(db_path: str | None) -> tuple[int, str]:
         finally:
             conn.close()
     except sqlite3.Error as exc:
-        # A WAL that needs replaying reports SQLITE_READONLY_RECOVERY here
-        # rather than handing back a torn snapshot. Unreadable is red.
-        return (CANNOT_DETERMINE,
-                f"CANNOT DETERMINE: cannot read {path} — {exc}\n"
-                "  The live DB runs in WAL; a read-only open refuses rather"
-                " than replaying the log or reading a torn snapshot. Preflight"
-                " has NOT checked the live schema.")
+        return CANNOT_DETERMINE, _unreadable(path, exc)
 
     expected = expected_schema()
+    # NONE of the expected tables present is not drift, it is the wrong file
+    # or an uninitialized one — a zero-byte $FUND_DB, a path typo, or the
+    # separate fundbt registry DB. Reporting that as divergence would send an
+    # operator hunting a schema change that never happened.
+    if not (set(expected) & live_tables):
+        found = ", ".join(sorted(live_tables)) if live_tables else "none"
+        return (CANNOT_DETERMINE,
+                f"CANNOT DETERMINE: {path} holds none of the {len(expected)}"
+                " tables state/schema.sql declares.\n"
+                f"  tables found: {found}\n"
+                "  That is a wrong FUND_DB path or a database that was never"
+                " initialized, not schema drift — preflight cannot say"
+                " anything about the live schema from it.")
+
     missing_tables = sorted(set(expected) - live_tables)
     missing_columns = sorted(
         (t, c) for t, columns in expected.items() if t in live_tables
@@ -139,8 +182,8 @@ def check(db_path: str | None) -> tuple[int, str]:
     unexplained = [pair for pair in missing_columns if pair not in explained]
 
     if missing_tables or unexplained:
-        lines = ["UNEXPLAINED DIVERGENCE: the live schema differs from"
-                 " state/schema.sql in a way no migration explains."]
+        lines = ["UNEXPLAINED DIVERGENCE: the live schema is missing something"
+                 " state/schema.sql declares, and no migration adds it."]
         if missing_tables:
             lines.append(f"  tables absent: {', '.join(missing_tables)}")
         if unexplained:
@@ -153,26 +196,73 @@ def check(db_path: str | None) -> tuple[int, str]:
         return UNEXPLAINED_DIVERGENCE, "\n".join(lines)
 
     if behind:
-        return (MIGRATIONS_PENDING,
-                "MIGRATIONS PENDING: the live schema is behind"
-                " state/schema.sql.\n"
-                f"  pending: {', '.join(behind)}\n"
-                "  columns absent: "
-                + ", ".join(f"{t}.{c}" for t, c in missing_columns) + "\n"
-                f"  db: {path}\n"
-                "  Expected and actionable. Take a backup"
-                " (ops/backup.sh), then apply the migration deliberately —"
-                " preflight only reports, and a human decides when to"
-                " migrate. Left alone, the next connect() applies it"
-                " unattended at the first tool call of a trading day.")
+        lines = ["MIGRATIONS PENDING: the live schema is behind"
+                 " state/schema.sql.",
+                 f"  pending: {', '.join(behind)}"]
+        if missing_columns:
+            lines.append("  columns absent: "
+                         + ", ".join(f"{t}.{c}" for t, c in missing_columns))
+        lines += [
+            f"  db: {path}",
+            "  Expected and actionable. Take a backup (ops/backup.sh), then"
+            " apply the migration deliberately, following ops/README.md"
+            " § 'Deploy a code change' step 3 — which has the exact command"
+            " and the post-checks to run against the DB afterwards.",
+            "  Preflight only reports; a human decides when to migrate. Left"
+            " alone, the next connect() applies it unattended at the first"
+            " tool call of a trading day."]
+        return MIGRATIONS_PENDING, "\n".join(lines)
 
     return (OK,
-            f"OK: live schema matches state/schema.sql ({len(expected)} tables)"
-            f" and no migrations are pending.\n  db: {path}")
+            "OK: the live DB has every table and column state/schema.sql"
+            f" declares ({len(expected)} tables) and no migrations are"
+            f" pending.\n{_NAMES_ONLY}\n  db: {path}")
+
+
+def _unreadable(path: Path, exc: sqlite3.Error) -> str:
+    """Why a read-only open failed, without inventing a cause.
+
+    The comment here used to say a read-only open "refuses rather than
+    replaying the log" when the WAL needs recovery. Measured, that is false: a
+    `-wal` holding uncommitted-to-main data with no `-shm` beside it opens
+    fine and reads the WAL's contents, recreating the `-shm`. What actually
+    fails is a DIRECTORY this uid cannot write, because the sidecar cannot be
+    created there — reported as either "unable to open database file" or
+    "attempt to write a readonly database" depending on whether a `-wal`
+    exists. Naming WAL recovery on every sqlite3.Error sent an operator to
+    inspect a write-ahead log when FUND_DB simply pointed at the wrong file.
+    """
+    head = f"CANNOT DETERMINE: cannot read {path} — {exc}"
+    if not os.access(path.parent, os.W_OK):
+        return (f"{head}\n"
+                f"  {path.parent} is not writable by this uid. A WAL database"
+                " needs its `-shm` sidecar beside the main file, and a"
+                " read-only open still has to create it — so an unwritable"
+                " DIRECTORY blocks the read. On the droplet this step runs as"
+                " uid `fund`, which owns /var/lib/fund.\n"
+                "  Preflight has NOT checked the live schema.")
+    return (f"{head}\n"
+            "  The file exists but SQLite would not read it: not a database,"
+            " a truncated or corrupt one, or unreadable by this uid. Check"
+            " that FUND_DB names the fund's SQLite file.\n"
+            "  Preflight has NOT checked the live schema.")
 
 
 def main() -> int:
-    code, report = check(os.environ.get("FUND_DB"))
+    try:
+        code, report = check(os.environ.get("FUND_DB"))
+    except Exception:
+        # A crash must not exit 1 — that is MIGRATIONS_PENDING, and an
+        # operator reading "run the migration" off a traceback is exactly the
+        # mislabelling this script exists to end. Nothing is swallowed: the
+        # traceback is printed in full. Ambiguity is red (invariant 4).
+        code = CANNOT_DETERMINE
+        report = ("CANNOT DETERMINE: preflight itself failed before it could"
+                  " report on the live schema.\n"
+                  + "".join(f"  {line}\n" for line in
+                            traceback.format_exc().splitlines())
+                  + "  This is a bug in preflight or a broken"
+                    " state/schema.sql, NOT a finding about the live DB.")
     print(report, file=sys.stdout if code == OK else sys.stderr)
     return code
 

--- a/state/migrations.py
+++ b/state/migrations.py
@@ -40,8 +40,15 @@ _ATTRIBUTION = (
 # The one list of what each migration adds. Both the writer (apply) and the
 # reader (pending) consume it, so a migration cannot be applied by one and
 # invisible to the other — which is exactly how a preflight comes back green
-# against a database that is behind. Adding a migration means adding an entry
-# here and nothing else.
+# against a database that is behind.
+#
+# THE LIMIT OF THIS MAP. It holds column NAMES, so an entry can only describe
+# one shape of migration: ADD COLUMN ... TEXT NOT NULL DEFAULT 'unknown',
+# which is what apply() hardcodes below. A migration of any other shape — a
+# new table, another type, a backfill, anything destructive — needs code here
+# AND a matching change in scripts/preflight_schema.py, which reports a
+# missing column from this map as closable by that exact ALTER. Adding a
+# tuple is enough only while the new migration is that one shape.
 MIGRATIONS: dict[str, tuple[tuple[str, str], ...]] = {
     "0001_attribution": _ATTRIBUTION,
 }

--- a/state/migrations.py
+++ b/state/migrations.py
@@ -37,24 +37,44 @@ _ATTRIBUTION = (
     ("critiques", "model_id"),
 )
 
+# The one list of what each migration adds. Both the writer (apply) and the
+# reader (pending) consume it, so a migration cannot be applied by one and
+# invisible to the other — which is exactly how a preflight comes back green
+# against a database that is behind. Adding a migration means adding an entry
+# here and nothing else.
+MIGRATIONS: dict[str, tuple[tuple[str, str], ...]] = {
+    "0001_attribution": _ATTRIBUTION,
+}
+
 
 def _columns(conn: sqlite3.Connection, table: str) -> set[str]:
     return {r["name"] for r in conn.execute(f"PRAGMA table_info({table})")}
 
 
-def apply(conn: sqlite3.Connection) -> list[str]:
-    """Bring `conn` up to date. Returns the migrations applied, [] if current.
+def pending(conn: sqlite3.Connection) -> list[str]:
+    """Migrations `conn` has not had applied. Reads only — writes nothing.
+
+    The seam scripts/preflight_schema.py needs: it must report whether the
+    live database is behind WITHOUT bringing it up to date. connect() applies
+    migrations, so asking that question through connect() answers it by
+    changing it.
 
     Reported per migration, not per column: a partially-migrated database (one
-    table done, one not) completes and says "0001_attribution" once, because
-    what the caller wants to know is whether the schema moved.
+    table done, one not) says "0001_attribution" once, because what the caller
+    wants to know is whether the schema is current.
     """
-    applied: list[str] = []
-    missing = [(t, c) for t, c in _ATTRIBUTION if c not in _columns(conn, t)]
-    if missing:
-        for table, column in missing:
-            conn.execute(f"ALTER TABLE {table} ADD COLUMN {column}"
-                         " TEXT NOT NULL DEFAULT 'unknown'")
+    return [name for name, columns in MIGRATIONS.items()
+            if any(c not in _columns(conn, t) for t, c in columns)]
+
+
+def apply(conn: sqlite3.Connection) -> list[str]:
+    """Bring `conn` up to date. Returns the migrations applied, [] if current."""
+    applied = pending(conn)
+    for name in applied:
+        for table, column in MIGRATIONS[name]:
+            if column not in _columns(conn, table):
+                conn.execute(f"ALTER TABLE {table} ADD COLUMN {column}"
+                             " TEXT NOT NULL DEFAULT 'unknown'")
+    if applied:
         conn.commit()
-        applied.append("0001_attribution")
     return applied

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -20,7 +20,7 @@ from datetime import datetime, timezone
 from orchestrator.clock import SimClock
 from slackkit.fake import FakeSlack
 from state.db import connect
-from state.migrations import apply
+from state.migrations import apply, pending
 
 RUN = "2026-08-18"
 
@@ -84,6 +84,31 @@ def test_apply_reports_only_what_it_did(tmp_path):
     _drop_attribution(conn, "decisions")
     assert apply(conn) == ["0001_attribution"]
     assert apply(conn) == []
+
+
+# --- the read-only seam ------------------------------------------------------
+
+def test_pending_names_what_apply_would_do(tmp_path):
+    """One list of what a migration adds, read by both sides. If pending()
+    kept its own copy it could report current while apply() still had work —
+    which is a green preflight against a database that is behind (#17)."""
+    conn = connect(tmp_path / "fund.sqlite")
+    _drop_attribution(conn, "signals")
+
+    assert pending(conn) == ["0001_attribution"]
+    assert apply(conn) == ["0001_attribution"]
+    assert pending(conn) == []
+
+
+def test_pending_writes_nothing(tmp_path):
+    """The whole reason the seam exists: scripts/preflight_schema.py asks
+    whether the live DB is behind and must not answer by fixing it."""
+    conn = connect(tmp_path / "fund.sqlite")
+    _drop_attribution(conn, "decisions")
+
+    for _ in range(3):
+        assert pending(conn) == ["0001_attribution"]
+    assert not {"charter_version", "model_id"} & _columns(conn, "decisions")
 
 
 def test_no_attribution_column_is_ever_nullable(tmp_path):

--- a/tests/test_preflight_schema.py
+++ b/tests/test_preflight_schema.py
@@ -21,8 +21,16 @@ Two things are load-bearing here and both are tested rather than commented:
      migration explains is a real failure. They get distinct exit codes so the
      operator does not have to read the source to tell them apart.
 
-Ambiguity — FUND_DB unset, file missing, not a database, a WAL that needs
-recovery — is RED, never green (invariant 4).
+Ambiguity — FUND_DB unset, file missing, not a database, holding none of the
+expected tables, an unwritable directory, or preflight crashing — is RED, never
+green (invariant 4). A crash must be red as CANNOT_DETERMINE specifically: an
+unhandled exception exits 1, which is the MIGRATIONS_PENDING code, and telling
+an operator to run a migration off a traceback is the mislabelling this script
+exists to end.
+
+What is compared is NAMES ONLY — tables and columns, never types or
+constraints. test_only_column_names_are_compared pins that limit, and pins that
+the OK message admits it.
 
 Fully offline: every DB here is a temp file built from state/schema.sql.
 """
@@ -30,10 +38,12 @@ Fully offline: every DB here is a temp file built from state/schema.sql.
 from __future__ import annotations
 
 import importlib.util
+import io
 import os
 import sqlite3
 import subprocess
 import sys
+import textwrap
 from pathlib import Path
 
 import pytest
@@ -71,6 +81,35 @@ def _live_db(path: Path, drop_columns=(), drop_tables=()) -> Path:
     return path
 
 
+def _drop_sidecars(db: Path) -> None:
+    """Remove -wal/-shm so the next open has to recreate them."""
+    for suffix in ("-wal", "-shm"):
+        sidecar = db.with_name(db.name + suffix)
+        if sidecar.exists():
+            sidecar.unlink()
+
+
+def _wal_only_db(path: Path) -> Path:
+    """A DB whose schema lives entirely in an uncheckpointed `-wal`.
+
+    Built in a child that exits via os._exit, so SQLite never checkpoints on
+    close — the shape a live droplet DB has between commits, and the one that
+    separates mode=ro from immutable=1.
+    """
+    child = path.parent / "_build_wal.py"
+    child.write_text(textwrap.dedent(f"""
+        import os, sqlite3, pathlib
+        conn = sqlite3.connect({str(path)!r})
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.executescript(pathlib.Path({str(SCHEMA)!r}).read_text())
+        conn.commit()
+        os._exit(0)
+    """))
+    subprocess.run([sys.executable, str(child)], check=True)
+    child.unlink()
+    return path
+
+
 def _columns(path: Path, table: str) -> set[str]:
     conn = sqlite3.connect(path)
     try:
@@ -101,10 +140,53 @@ def test_a_current_db_is_green(tmp_path):
     assert "OK" in proc.stdout
 
 
-def test_green_requires_every_table_in_schema_sql(tmp_path):
-    """11 tables today. The count is read from schema.sql, not restated, so
-    adding a table to that file extends the check with no second edit."""
+def test_the_expected_table_count_is_pinned(tmp_path):
+    """11 tables today. expected_schema() reads state/schema.sql, so a table
+    added there is checked with no edit to the script — this assertion is the
+    tripwire that makes such an addition deliberate. It IS a second edit, on
+    purpose: bump it in the same commit that adds the table."""
     assert len(preflight.expected_schema()) == 11
+
+
+def test_only_column_names_are_compared(tmp_path):
+    """The limit, stated by a test so nobody has to trust the docstring.
+
+    A `tickets` rebuilt without `UNIQUE (decision_id)` — schema.sql:79, the
+    constraint behind invariant 5's order idempotency — is GREEN here.
+    Comparing constraints is a separate, deferred decision; what is not
+    optional is that the OK message admits the limit instead of claiming a
+    match it never tested.
+    """
+    db = _live_db(tmp_path / "fund.sqlite")
+    conn = sqlite3.connect(db)
+    conn.execute("DROP TABLE tickets")
+    conn.execute("CREATE TABLE tickets (id TEXT PRIMARY KEY,"
+                 " decision_id INTEGER NOT NULL, ticker TEXT NOT NULL,"
+                 " side TEXT NOT NULL, max_qty INTEGER NOT NULL,"
+                 " stop_price REAL, expires_at TEXT NOT NULL,"
+                 " status TEXT NOT NULL DEFAULT 'open', reason TEXT,"
+                 " created_at TEXT NOT NULL)")   # same names, no UNIQUE
+    conn.commit()
+    conn.close()
+
+    code, report = preflight.check(str(db))
+    assert code == preflight.OK
+    assert "Names only" in report
+    assert "UNIQUE" in report
+
+
+def test_a_db_ahead_of_the_repo_is_green(tmp_path):
+    """One-directional on purpose: `git checkout <previous-sha>` for a code
+    rollback (ops/README.md § Rollback) leaves a DB that already ran the newer
+    migration, and that must not read as a failure."""
+    db = _live_db(tmp_path / "fund.sqlite")
+    conn = sqlite3.connect(db)
+    conn.execute("ALTER TABLE signals ADD COLUMN from_the_future TEXT")
+    conn.execute("CREATE TABLE a_later_table (id INTEGER PRIMARY KEY)")
+    conn.commit()
+    conn.close()
+
+    assert _run(db).returncode == preflight.OK
 
 
 # --- RED: migrations pending -------------------------------------------------
@@ -202,20 +284,114 @@ def test_a_file_that_is_not_a_database_cannot_determine(tmp_path):
     assert _run(db).returncode == preflight.CANNOT_DETERMINE
 
 
-def test_a_wal_needing_recovery_cannot_determine(tmp_path, monkeypatch):
-    """The live DB runs in WAL. A read-only open of a DB whose -wal must be
-    replayed fails with SQLITE_READONLY_RECOVERY rather than reading a torn
-    snapshot, and that is 'cannot determine' — red, not green."""
+def test_an_uninitialized_or_wrong_db_cannot_determine(tmp_path):
+    """Zero of the 11 tables is a wrong FUND_DB or a database nothing has
+    initialized — not drift. Reporting UNEXPLAINED DIVERGENCE would send an
+    operator hunting a schema change that never happened."""
+    db = tmp_path / "fund.sqlite"
+    db.touch()                                    # zero bytes, valid to open
+    proc = _run(db)
+
+    assert proc.returncode == preflight.CANNOT_DETERMINE
+    assert "none of the 11 tables" in proc.stderr
+
+
+def test_a_database_that_is_not_the_fund_db_cannot_determine(tmp_path):
+    """e.g. FUND_DB pointing at fundbt's separate trial-registry DB."""
+    db = tmp_path / "registry.sqlite"
+    conn = sqlite3.connect(db)
+    conn.execute("CREATE TABLE trial_registry (id INTEGER PRIMARY KEY)")
+    conn.commit()
+    conn.close()
+
+    proc = _run(db)
+    assert proc.returncode == preflight.CANNOT_DETERMINE
+    assert "trial_registry" in proc.stderr        # names what it did find
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root ignores directory mode")
+def test_an_unwritable_directory_cannot_determine(tmp_path):
+    """The REAL failure mode of a read-only open, measured rather than
+    assumed. A WAL database needs its `-shm` sidecar beside the main file and
+    a read-only open still has to create it, so an unwritable DIRECTORY blocks
+    the read. This test replaces one that monkeypatched sqlite3.connect to
+    raise 'attempt to write a readonly database' and attributed it to WAL
+    recovery — the code never had that behaviour, so the test pinned a
+    fiction and could not have caught this."""
+    home = tmp_path / "locked"
+    home.mkdir()
+    db = _live_db(home / "fund.sqlite")
+    _drop_sidecars(db)
+    home.chmod(0o555)
+    try:
+        proc = _run(db)
+    finally:
+        home.chmod(0o755)                         # so tmp_path can be cleaned
+
+    assert proc.returncode == preflight.CANNOT_DETERMINE
+    assert "not writable" in proc.stderr
+
+
+def test_a_wal_holding_the_only_copy_of_the_schema_is_read(tmp_path):
+    """Why mode=ro and not immutable=1, pinned. With the DDL still in an
+    uncheckpointed `-wal`, mode=ro reads all 11 tables; immutable=1 skips the
+    WAL and sees the stale snapshot behind it, which would report a fully
+    migrated database as empty. It also documents that a `-wal` needing replay
+    does NOT fail the open — the old comment claimed it did."""
+    db = _wal_only_db(tmp_path / "fund.sqlite")
+    assert db.with_name(db.name + "-wal").exists()
+
+    assert _run(db).returncode == preflight.OK
+
+    stale = sqlite3.connect(
+        f"file:{db}?immutable=1", uri=True)
+    try:
+        found = {r[0] for r in stale.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'")}
+    finally:
+        stale.close()
+    assert "events" not in found, "immutable=1 would have seen the WAL"
+
+
+def test_a_crash_is_cannot_determine_not_migrations_pending(tmp_path,
+                                                            monkeypatch):
+    """An unhandled exception used to exit 1 — the MIGRATIONS_PENDING code —
+    so a broken state/schema.sql told the operator to run a migration. Still
+    red either way, but the wrong red, and distinguishable outcomes are the
+    whole point of this script."""
+    def boom(*a, **kw):
+        raise sqlite3.OperationalError("incomplete input")
+
+    monkeypatch.setattr(preflight, "expected_schema", boom)
+    monkeypatch.setenv("FUND_DB", str(_live_db(tmp_path / "fund.sqlite")))
+    out = io.StringIO()
+    monkeypatch.setattr(preflight.sys, "stderr", out)
+
+    assert preflight.main() == preflight.CANNOT_DETERMINE
+    assert "preflight itself failed" in out.getvalue()
+    assert "incomplete input" in out.getvalue()   # nothing swallowed
+    assert "Traceback" in out.getvalue()
+
+
+def test_a_broken_schema_sql_exits_cannot_determine(tmp_path):
+    """End to end, through the real process: the reviewer's reproduction."""
+    broken = tmp_path / "schema.sql"
+    broken.write_text("CREATE TABLE oops (")
     db = _live_db(tmp_path / "fund.sqlite")
 
-    def boom(*a, **kw):
-        raise sqlite3.OperationalError(
-            "attempt to write a readonly database")
+    env = {**os.environ, "FUND_DB": str(db)}
+    proc = subprocess.run(
+        [sys.executable, "-c",
+         "import runpy, sys, pathlib;"
+         f" sys.argv=['preflight_schema'];"
+         f" import importlib.util;"
+         f" spec=importlib.util.spec_from_file_location('pf', {str(SCRIPT)!r});"
+         " m=importlib.util.module_from_spec(spec); spec.loader.exec_module(m);"
+         f" m.SCHEMA=pathlib.Path({str(broken)!r}); sys.exit(m.main())"],
+        capture_output=True, text=True, env=env, cwd=str(ROOT))
 
-    monkeypatch.setattr(preflight.sqlite3, "connect", boom)
-    code, report = preflight.check(str(db))
-    assert code == preflight.CANNOT_DETERMINE
-    assert "readonly" in report
+    assert proc.returncode == preflight.CANNOT_DETERMINE, proc.stderr
+    assert proc.returncode != preflight.MIGRATIONS_PENDING
 
 
 # --- the four outcomes are distinguishable -----------------------------------

--- a/tests/test_preflight_schema.py
+++ b/tests/test_preflight_schema.py
@@ -1,0 +1,276 @@
+"""scripts/preflight_schema.py — preflight opens the LIVE database, read-only.
+
+`make preflight` used to run eval_suite.py alone, which builds a fresh per-trial
+DB. It therefore checked schema against a database it had created moments
+earlier and never touched `$FUND_DB`, so a green preflight said nothing about
+whether a pending migration had reached the droplet (#17). On 2026-08-19 the
+attribution columns were 0/6 on the live DB behind a green preflight; the next
+`connect()` would have ALTERed production unattended, mid trading day.
+
+Two things are load-bearing here and both are tested rather than commented:
+
+  1. **Reporting must not migrate.** state/db.py's connect() ends with
+     _apply_migrations(), so the obvious way to open the DB is the one that
+     silently applies the thing being reported on. Preflight opens
+     `file:...?mode=ro` instead, and test_reporting_pending_does_not_touch_the_db
+     is what stops that from regressing.
+
+  2. **"Run the migration" and "something is wrong" are different alerts.** A
+     live DB that has never run migrations.apply() genuinely differs from
+     schema.sql, and that difference is expected and actionable. A difference no
+     migration explains is a real failure. They get distinct exit codes so the
+     operator does not have to read the source to tell them apart.
+
+Ambiguity — FUND_DB unset, file missing, not a database, a WAL that needs
+recovery — is RED, never green (invariant 4).
+
+Fully offline: every DB here is a temp file built from state/schema.sql.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "preflight_schema.py"
+SCHEMA = ROOT / "state" / "schema.sql"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("preflight_schema", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+preflight = _load()
+
+
+def _live_db(path: Path, drop_columns=(), drop_tables=()) -> Path:
+    """A stand-in for the droplet's DB: schema.sql, in WAL, minus some pieces.
+
+    Dropping is how a live database that predates a schema.sql edit is
+    simulated — the columns/tables simply were never there.
+    """
+    conn = sqlite3.connect(path)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.executescript(SCHEMA.read_text())
+    for table, column in drop_columns:
+        conn.execute(f"ALTER TABLE {table} DROP COLUMN {column}")
+    for table in drop_tables:
+        conn.execute(f"DROP TABLE {table}")
+    conn.commit()
+    conn.close()
+    return path
+
+
+def _columns(path: Path, table: str) -> set[str]:
+    conn = sqlite3.connect(path)
+    try:
+        return {r[1] for r in conn.execute(f"PRAGMA table_info({table})")}
+    finally:
+        conn.close()
+
+
+def _run(db: Path | None):
+    """Run the script the way the Makefile does: FUND_DB out of the env."""
+    env = {k: v for k, v in os.environ.items() if k != "FUND_DB"}
+    if db is not None:
+        env["FUND_DB"] = str(db)
+    return subprocess.run([sys.executable, str(SCRIPT)], capture_output=True,
+                          text=True, env=env, cwd=str(ROOT))
+
+
+ATTRIBUTION = (("signals", "charter_version"), ("signals", "model_id"),
+               ("decisions", "charter_version"), ("decisions", "model_id"),
+               ("critiques", "charter_version"), ("critiques", "model_id"))
+
+
+# --- GREEN -------------------------------------------------------------------
+
+def test_a_current_db_is_green(tmp_path):
+    proc = _run(_live_db(tmp_path / "fund.sqlite"))
+    assert proc.returncode == preflight.OK, proc.stdout + proc.stderr
+    assert "OK" in proc.stdout
+
+
+def test_green_requires_every_table_in_schema_sql(tmp_path):
+    """11 tables today. The count is read from schema.sql, not restated, so
+    adding a table to that file extends the check with no second edit."""
+    assert len(preflight.expected_schema()) == 11
+
+
+# --- RED: migrations pending -------------------------------------------------
+
+def test_a_db_behind_a_migration_says_migrations_pending(tmp_path):
+    db = _live_db(tmp_path / "fund.sqlite", drop_columns=ATTRIBUTION)
+    proc = _run(db)
+
+    assert proc.returncode == preflight.MIGRATIONS_PENDING
+    out = proc.stdout + proc.stderr
+    assert "0001_attribution" in out, out
+    assert "backup" in out.lower(), out
+
+
+def test_one_missing_column_is_enough_to_be_pending(tmp_path):
+    """A partially-migrated DB — one table done, one not — is still behind."""
+    db = _live_db(tmp_path / "fund.sqlite",
+                  drop_columns=(("critiques", "model_id"),))
+    assert _run(db).returncode == preflight.MIGRATIONS_PENDING
+
+
+def test_reporting_pending_does_not_touch_the_db(tmp_path):
+    """THE trap. connect() applies migrations; preflight must only report.
+
+    A run that migrates turns the next run green without a human ever having
+    taken the backup #17 requires — the report would then be evidence of its
+    own side effect.
+    """
+    db = _live_db(tmp_path / "fund.sqlite", drop_columns=ATTRIBUTION)
+    before = db.stat().st_mtime_ns
+
+    assert _run(db).returncode == preflight.MIGRATIONS_PENDING
+
+    for table, column in ATTRIBUTION:
+        assert column not in _columns(db, table), f"{table}.{column} was added"
+    assert db.stat().st_mtime_ns == before
+    # Still pending on a second look: the first look changed nothing.
+    assert _run(db).returncode == preflight.MIGRATIONS_PENDING
+
+
+# --- RED: unexplained divergence ---------------------------------------------
+
+def test_a_missing_table_is_unexplained_divergence(tmp_path):
+    """No migration creates a table, so an absent one is a real failure —
+    not something the operator can fix by running a migration."""
+    db = _live_db(tmp_path / "fund.sqlite", drop_tables=("costs",))
+    proc = _run(db)
+
+    assert proc.returncode == preflight.UNEXPLAINED_DIVERGENCE
+    assert "costs" in proc.stdout + proc.stderr
+
+
+def test_a_column_no_migration_adds_is_unexplained_divergence(tmp_path):
+    db = _live_db(tmp_path / "fund.sqlite",
+                  drop_columns=(("critiques", "note"),))
+    proc = _run(db)
+
+    assert proc.returncode == preflight.UNEXPLAINED_DIVERGENCE
+    assert "critiques.note" in proc.stdout + proc.stderr
+
+
+def test_unexplained_wins_over_pending(tmp_path):
+    """A DB that is both behind AND broken reports the failure. "Run the
+    migration" would be wrong advice: it would not fix `critiques.note`."""
+    db = _live_db(tmp_path / "fund.sqlite",
+                  drop_columns=ATTRIBUTION + (("critiques", "note"),))
+    assert _run(db).returncode == preflight.UNEXPLAINED_DIVERGENCE
+
+
+# --- RED: cannot determine (invariant 4 — ambiguity is never green) ----------
+
+def test_fund_db_unset_cannot_determine():
+    proc = _run(None)
+    assert proc.returncode == preflight.CANNOT_DETERMINE
+    assert "FUND_DB" in proc.stdout + proc.stderr
+
+
+def test_a_blank_fund_db_cannot_determine(tmp_path):
+    env = {**os.environ, "FUND_DB": "   "}
+    proc = subprocess.run([sys.executable, str(SCRIPT)], capture_output=True,
+                          text=True, env=env, cwd=str(ROOT))
+    assert proc.returncode == preflight.CANNOT_DETERMINE
+
+
+def test_a_missing_file_cannot_determine(tmp_path):
+    """And must not create it — a read-only open never makes a database."""
+    db = tmp_path / "absent.sqlite"
+    assert _run(db).returncode == preflight.CANNOT_DETERMINE
+    assert not db.exists()
+
+
+def test_a_file_that_is_not_a_database_cannot_determine(tmp_path):
+    db = tmp_path / "fund.sqlite"
+    db.write_bytes(b"this is not a database")
+    assert _run(db).returncode == preflight.CANNOT_DETERMINE
+
+
+def test_a_wal_needing_recovery_cannot_determine(tmp_path, monkeypatch):
+    """The live DB runs in WAL. A read-only open of a DB whose -wal must be
+    replayed fails with SQLITE_READONLY_RECOVERY rather than reading a torn
+    snapshot, and that is 'cannot determine' — red, not green."""
+    db = _live_db(tmp_path / "fund.sqlite")
+
+    def boom(*a, **kw):
+        raise sqlite3.OperationalError(
+            "attempt to write a readonly database")
+
+    monkeypatch.setattr(preflight.sqlite3, "connect", boom)
+    code, report = preflight.check(str(db))
+    assert code == preflight.CANNOT_DETERMINE
+    assert "readonly" in report
+
+
+# --- the four outcomes are distinguishable -----------------------------------
+
+def test_the_four_outcomes_have_distinct_codes_and_messages(tmp_path):
+    """An operator must tell 'run the migration' from 'something is wrong'
+    without reading the source."""
+    green = _live_db(tmp_path / "green.sqlite")
+    behind = _live_db(tmp_path / "behind.sqlite", drop_columns=ATTRIBUTION)
+    broken = _live_db(tmp_path / "broken.sqlite", drop_tables=("costs",))
+    junk = tmp_path / "junk.sqlite"
+    junk.write_bytes(b"nope")
+
+    results = [preflight.check(str(green)), preflight.check(str(behind)),
+               preflight.check(str(broken)), preflight.check(None)]
+    codes = [c for c, _ in results]
+    assert codes == [preflight.OK, preflight.MIGRATIONS_PENDING,
+                     preflight.UNEXPLAINED_DIVERGENCE,
+                     preflight.CANNOT_DETERMINE]
+    assert len(set(codes)) == 4
+    headlines = {r.splitlines()[0] for _, r in results}
+    assert len(headlines) == 4, headlines
+
+
+def test_only_green_is_zero(tmp_path):
+    for code in (preflight.MIGRATIONS_PENDING,
+                 preflight.UNEXPLAINED_DIVERGENCE,
+                 preflight.CANNOT_DETERMINE):
+        assert code != 0
+
+
+# --- scope: $FUND_DB only ----------------------------------------------------
+
+def test_the_registry_tables_are_out_of_scope(tmp_path):
+    """fundbt/registry.py owns trial_registry/holdout_evaluations in a
+    SEPARATE database. Expecting them in $FUND_DB would fail every run."""
+    expected = preflight.expected_schema()
+    assert "trial_registry" not in expected
+    assert "holdout_evaluations" not in expected
+
+
+# --- the makefile wiring -----------------------------------------------------
+
+def test_preflight_target_runs_the_schema_check_before_eval_suite():
+    """Fail fast and cheap: a bad live schema must stop the deploy before
+    ~$0.31 of live LLM trials, not after."""
+    target = (ROOT / "Makefile").read_text().split("\npreflight:")[1]
+    target = target.split("\n\n")[0]
+    assert "preflight_schema.py" in target
+    assert target.index("preflight_schema.py") < target.index("eval_suite.py")
+
+
+@pytest.mark.parametrize("needle", ["EnvironmentFile=/etc/fund/env", "--uid=fund"])
+def test_the_schema_step_keeps_the_droplet_run_context(needle):
+    """FUND_DB comes from /etc/fund/env and the live DB is owned by `fund`."""
+    target = (ROOT / "Makefile").read_text().split("\npreflight:")[1]
+    step = target.split("preflight_schema.py")[0]
+    assert needle in step

--- a/tests/test_preflight_schema.py
+++ b/tests/test_preflight_schema.py
@@ -309,15 +309,23 @@ def test_a_database_that_is_not_the_fund_db_cannot_determine(tmp_path):
     assert "trial_registry" in proc.stderr        # names what it did find
 
 
-@pytest.mark.skipif(os.geteuid() == 0, reason="root ignores directory mode")
-def test_an_unwritable_directory_cannot_determine(tmp_path):
-    """The REAL failure mode of a read-only open, measured rather than
-    assumed. A WAL database needs its `-shm` sidecar beside the main file and
-    a read-only open still has to create it, so an unwritable DIRECTORY blocks
-    the read. This test replaces one that monkeypatched sqlite3.connect to
-    raise 'attempt to write a readonly database' and attributed it to WAL
-    recovery — the code never had that behaviour, so the test pinned a
-    fiction and could not have caught this."""
+needs_mode_bits = pytest.mark.skipif(
+    os.geteuid() == 0,
+    reason="root ignores directory mode. NOTE: master's ci.yml runs on"
+           " ubuntu-latest with no `container:` key, so CI is uid 1001 and"
+           " this DOES execute there. Adding a `container:` key would make it"
+           " root and turn this green-by-skipping.")
+
+
+@needs_mode_bits
+def test_a_sidecar_that_cannot_be_created_cannot_determine(tmp_path):
+    """The measured failure mode: SQLite must CREATE a `-wal`/`-shm` beside
+    the main file and the directory does not allow it. This is the droplet's
+    between-runs shape — WAL-mode header, sidecars cleanly checkpointed away.
+
+    Replaces a test that monkeypatched sqlite3.connect to raise and blamed WAL
+    recovery; the code never had that behaviour, so it pinned a fiction.
+    """
     home = tmp_path / "locked"
     home.mkdir()
     db = _live_db(home / "fund.sqlite")
@@ -330,6 +338,52 @@ def test_an_unwritable_directory_cannot_determine(tmp_path):
 
     assert proc.returncode == preflight.CANNOT_DETERMINE
     assert "not writable" in proc.stderr
+    assert "sidecar" in proc.stderr
+
+
+@needs_mode_bits
+def test_an_unwritable_directory_alone_is_not_a_failure(tmp_path):
+    """The non-trigger, pinned so the rule stops drifting. With both sidecars
+    already on disk there is nothing to create, and the open succeeds in an
+    unwritable directory. "Unwritable dir fails the read" was asserted twice
+    in review of this file and is false on its own."""
+    home = tmp_path / "locked"
+    home.mkdir()
+    db = _wal_only_db(home / "fund.sqlite")       # leaves -wal AND -shm
+    assert db.with_name(db.name + "-shm").exists()
+    home.chmod(0o555)
+    try:
+        proc = _run(db)
+    finally:
+        home.chmod(0o755)
+
+    assert proc.returncode == preflight.OK, proc.stderr
+
+
+@needs_mode_bits
+def test_a_corrupt_file_is_never_blamed_on_the_directory(tmp_path):
+    """Headline and explanation must not disagree about the cause.
+
+    Testing os.access before the SQLite error printed "file is not a database"
+    over an explanation about directory permissions — sending an operator to
+    chmod a directory when FUND_DB pointed at the wrong file. "file is not a
+    database" comes back identically in either directory mode, so it can never
+    mean a permission problem.
+    """
+    home = tmp_path / "locked"
+    home.mkdir()
+    db = home / "fund.sqlite"
+    db.write_bytes(b"this is not a database")
+    home.chmod(0o555)
+    try:
+        proc = _run(db)
+    finally:
+        home.chmod(0o755)
+
+    assert proc.returncode == preflight.CANNOT_DETERMINE
+    assert "not a database" in proc.stderr
+    assert "not writable" not in proc.stderr
+    assert "sidecar" not in proc.stderr
 
 
 def test_a_wal_holding_the_only_copy_of_the_schema_is_read(tmp_path):


### PR DESCRIPTION
Closes #17.

`make preflight` never opened the production database. `eval_suite.py` builds a fresh per-trial DB, so preflight exercised schema against a database it had created moments earlier — a green preflight said nothing about whether a pending migration had reached the live DB.

## What this adds

`scripts/preflight_schema.py` opens `$FUND_DB` **read-only** and reports, as step 1 of the `preflight` target, ahead of `eval_suite.py`.

| Outcome | Code | Meaning |
|---|---|---|
| OK | 0 | every table and column `state/schema.sql` declares is present, no migrations pending |
| MIGRATIONS PENDING | 1 | live DB is behind, every difference explained by a known migration; names them and says to take a backup |
| UNEXPLAINED DIVERGENCE | 2 | differs in a way no migration explains — "running a migration will NOT fix this" |
| CANNOT DETERMINE | 3 | `FUND_DB` unset, missing, unreadable, not a database, or preflight itself crashed |

Fail-closed per invariant 4: ambiguity is red, never green. `make` collapses any recipe failure to its own exit 2, so these codes surface in the step's stderr rather than to a caller of `make preflight` — stated in the Makefile comment.

Also adds a read-only `pending()` seam to `state/migrations.py`, with `apply()` refactored to consume it so what a migration adds is stated exactly once.

## The safety property

**Preflight must never call `state.db.connect()`.** `connect()` ends with `_apply_migrations(conn)`, so calling it would make the check itself perform the production migration that #17 explicitly puts out of scope ("Preflight reports; a human decides when to migrate, with a backup"). This uses `sqlite3.connect("file:…?mode=ro", uri=True)`.

Trap-tested, and the trap test was verified to bite by an independent reviewer: swapping the read-only open for `connect()` makes 5 tests fail, with the check silently migrating all three test DBs and reporting green (`assert [0, 0, 0, 3] == [0, 1, 2, 3]`).

`immutable=1` was measured and rejected rather than argued: with DDL still in an uncheckpointed WAL it sees **zero tables**, i.e. it would report a fully-migrated production DB as empty. Pinned by test.

## Deliberate limits

- **Names only.** Table and column *names* are compared, not types, `NOT NULL`, `DEFAULT`, `CHECK` or `UNIQUE`. A `tickets` table rebuilt without `UNIQUE (decision_id)` returns exit 0. The green message says so explicitly, which is what #17 asks for ("or say explicitly that it has not checked it"). Constraint drift is deferred to a follow-up, not overlooked.
- **One-directional.** A live DB *ahead* of the repo returns OK, so the code-rollback path in `ops/README.md` stays green. Documented rather than implicit.
- **Scope.** Expected schema is `state/schema.sql` alone; `migrations.py` is the catch-up path to it, not a second source of truth. `trial_registry`/`holdout_evaluations` (`fundbt/registry.py`, a separate database — see #50) are excluded; including them would produce false failures.

## Does not fix

`connect()` auto-applies migrations and is called per tool call, so an unapplied migration still `ALTER`s the live droplet DB unattended at the first tool call of a trading day. **This PR makes that visible before a deploy; it does not remove the path.** Tracked separately.

## Verification

`make test`: **1210 passed, 1 skipped, 7 deselected** (baseline 1181 on `master`). The single skip is pre-existing and unrelated. Purity and alert-code lints clean. Tests are additive — the only deleted line across the tests diff is an import widened from `apply` to `apply, pending`; no fixture, golden number, or expected value touched.

Reviewed across four rounds by an independent context, including mutation-testing every new test by reverting its fix and confirming the test fails.
