### PR TITLE
fix(#40): recover orders that filled at the broker but never got a row

### DIFF
--- a/gate/tickets.py
+++ b/gate/tickets.py
@@ -51,16 +51,25 @@ def open_tickets_without_orders(conn: sqlite3.Connection) -> list[dict]:
 
     Deliberately CLOCK-FREE, unlike open_tickets. That function answers "what
     may the trader still act on?", where filtering out a time-expired ticket is
-    exactly right, and tests/test_tickets.py:46 pins it. Borrowing it to answer
-    "what did the turn fail to place?" is issue #40's TTL hole: a turn that
-    overruns the 45-minute TTL leaves a ticket that is still status='open' —
-    expire_open_tickets runs at the START of the execution body, before the
-    overrun — and the filter deletes precisely that row from the answer, so no
-    alert fires and nothing repairs it. The question "did this ticket produce
-    an order?" has no clock in it, and this signature makes that structural.
+    exactly right, and test_open_tickets_excludes_expired_even_before_sweep
+    pins it. Borrowing it to answer "what did the turn fail to place?" is issue
+    #40's TTL hole: a turn that overruns the 45-minute TTL leaves a ticket that
+    is still status='open' — expire_open_tickets runs at the START of the
+    execution body, before the overrun — and the filter deletes precisely that
+    row from the answer, so no alert fires and nothing repairs it. The question
+    "did this ticket produce an order?" has no clock in it, and this signature
+    makes that structural.
+
+    The join is on the ID, never on the symbol: yesterday's NVDA order row is
+    keyed by yesterday's ticket and says nothing about today's NVDA ticket.
+    Pinned by test_a_ticket_is_not_suppressed_by_another_tickets_same_symbol_order.
+
+    Four columns, because those are what a repair pass can act on — the ticket
+    it re-places and what that ticket authorizes. decision_id, stop_price, and
+    expires_at have no reader; speculative surface is forbidden.
     """
     rows = conn.execute(
-        "SELECT id, decision_id, ticker, side, max_qty, stop_price, expires_at"
+        "SELECT id, ticker, side, max_qty"
         " FROM tickets t WHERE t.status = 'open'"
         " AND NOT EXISTS (SELECT 1 FROM orders o"
         " WHERE o.client_order_id = t.id)"

--- a/gate/tickets.py
+++ b/gate/tickets.py
@@ -44,6 +44,30 @@ def open_tickets(conn: sqlite3.Connection, now_iso: str) -> list[dict]:
     return [dict(r) for r in rows if not _expired(r["expires_at"], now_iso)]
 
 
+def open_tickets_without_orders(conn: sqlite3.Connection) -> list[dict]:
+    """Tickets the gate approved that are STILL status='open' and have no
+    order row keyed by them (invariant 5: orders.client_order_id IS the ticket
+    id).
+
+    Deliberately CLOCK-FREE, unlike open_tickets. That function answers "what
+    may the trader still act on?", where filtering out a time-expired ticket is
+    exactly right, and tests/test_tickets.py:46 pins it. Borrowing it to answer
+    "what did the turn fail to place?" is issue #40's TTL hole: a turn that
+    overruns the 45-minute TTL leaves a ticket that is still status='open' —
+    expire_open_tickets runs at the START of the execution body, before the
+    overrun — and the filter deletes precisely that row from the answer, so no
+    alert fires and nothing repairs it. The question "did this ticket produce
+    an order?" has no clock in it, and this signature makes that structural.
+    """
+    rows = conn.execute(
+        "SELECT id, decision_id, ticker, side, max_qty, stop_price, expires_at"
+        " FROM tickets t WHERE t.status = 'open'"
+        " AND NOT EXISTS (SELECT 1 FROM orders o"
+        " WHERE o.client_order_id = t.id)"
+        " ORDER BY t.created_at").fetchall()
+    return [dict(r) for r in rows]
+
+
 def expire_open_tickets(conn: sqlite3.Connection, now_iso: str) -> list[str]:
     """Gate expiry, clock-injected (acceptance §0). Ticket open->expired and
     its decision approved->expired (contracts §1)."""

--- a/orchestrator/daily.py
+++ b/orchestrator/daily.py
@@ -346,10 +346,14 @@ def _alert_unexecuted_tickets(ctx: StageCtx) -> None:
 def run_execution(ctx: StageCtx, run_trader_turn: Callable[[], None] | None) -> str:
     """Trader stage. Zero open tickets -> no turn at all (no LLM spend on a
     hold day); the stage still drains and still checkpoints done."""
-    now = iso(ctx.clock.now())
-    expire_open_tickets(ctx.conn, now)   # clock-injected expiry (acceptance §0)
-
     def body() -> None:
+        # INSIDE the body (issue #40). run_stage skips the body entirely on a
+        # resumed day whose execution checkpoint is already 'done'; with expiry
+        # outside it, that resume still ran — finalizing the ticket AND its
+        # decision to 'expired' while every repair path was skipped. There is
+        # no legal edge out of 'expired', so a real fill sitting at the broker
+        # was locked out of the books permanently.
+        expire_open_tickets(ctx.conn, iso(ctx.clock.now()))   # clock-injected (acceptance §0)
         if run_trader_turn is not None and open_tickets(ctx.conn, iso(ctx.clock.now())):
             run_trader_turn()
         _alert_unexecuted_tickets(ctx)

--- a/orchestrator/daily.py
+++ b/orchestrator/daily.py
@@ -18,7 +18,8 @@ from pathlib import Path
 from typing import Callable
 
 from gate.risk import Approved, Rejected, size
-from gate.tickets import create_ticket, expire_open_tickets, open_tickets
+from gate.tickets import (create_ticket, expire_open_tickets, open_tickets,
+                          open_tickets_without_orders)
 from orchestrator.clock import Clock, et_hhmm, iso
 from orchestrator.protection import (assert_positions_accounted,
                                      assert_positions_protected)
@@ -321,23 +322,25 @@ def run_gate(ctx: StageCtx) -> None:
 
 
 def _alert_unexecuted_tickets(ctx: StageCtx) -> None:
-    """D2: a ticket the gate approved that is STILL open and unexpired after
-    the trader turn, with no order row keyed by it (invariant 5:
-    orders.client_order_id IS the ticket id), means the turn produced nothing.
-    That is exactly the 2026-08-17 failure — turn billed, no order placed,
-    stage 'done', day reported a success. Alerting (not raising) is
-    deliberate: default HOLD stands, the day still finishes, and the alert
-    plus the reddened audit are the signal. Zero open tickets stays silent —
-    a hold day is normal."""
+    """D2: a ticket the gate approved that is STILL open after the trader
+    turn, with no order row keyed by it (invariant 5: orders.client_order_id
+    IS the ticket id), means the turn produced nothing. That is exactly the
+    2026-08-17 failure — turn billed, no order placed, stage 'done', day
+    reported a success. Alerting (not raising) is deliberate: default HOLD
+    stands, the day still finishes, and the alert plus the reddened audit are
+    the signal. Zero open tickets stays silent — a hold day is normal.
+
+    Keyed on STATUS, never on the clock (issue #40). Expiry sweeps at the
+    start of the body, before the turn, so the only way a past-TTL ticket is
+    still 'open' here is that its TTL passed DURING the turn — a turn that
+    overran its whole 45-minute budget and placed nothing. That is the loudest
+    case there is, and the clock filter in open_tickets silently deleted
+    exactly it from the answer."""
     now = iso(ctx.clock.now())
-    for ticket in open_tickets(ctx.conn, now):
-        placed = ctx.conn.execute(
-            "SELECT 1 FROM orders WHERE client_order_id = ?",
-            (ticket["id"],)).fetchone()
-        if placed is None:
-            append_alert(ctx.conn, "ticket_open_after_exec",
-                         f"ticket {ticket['id'][:8]} open after exec"
-                         " turn — no order", now_iso=now)
+    for ticket in open_tickets_without_orders(ctx.conn):
+        append_alert(ctx.conn, "ticket_open_after_exec",
+                     f"ticket {ticket['id'][:8]} open after exec"
+                     " turn — no order", now_iso=now)
 
 
 def run_execution(ctx: StageCtx, run_trader_turn: Callable[[], None] | None) -> str:

--- a/orchestrator/daily.py
+++ b/orchestrator/daily.py
@@ -23,7 +23,7 @@ from gate.tickets import (create_ticket, expire_open_tickets, open_tickets,
 from orchestrator.clock import Clock, et_hhmm, iso
 from orchestrator.protection import (assert_positions_accounted,
                                      assert_positions_protected)
-from orchestrator.reconcile import reconcile_orders
+from orchestrator.reconcile import reconcile_stage
 from slackkit.outbox import append_alert, append_event, drain
 from state.critiques import insert_default_critiques
 from state.journal import append_entry
@@ -481,8 +481,8 @@ def run_day(ctx: StageCtx, *, execution_turn: Callable[[], None] | None = None,
     run_execution(ctx, execution_turn if execution_turn is not None
                   else ctx.run_turn.get("execution"))
     run_stage(ctx, "reconciliation",
-              lambda: reconcile_orders(ctx.conn, clock=ctx.clock, broker=broker,
-                                       sleep=sleep or (lambda _s: None)))
+              lambda: reconcile_stage(ctx.conn, clock=ctx.clock, broker=broker,
+                                      sleep=sleep or (lambda _s: None)))
     # NOT a stage: an assertion must re-check on a resumed day, never be
     # skipped as 'done'. Drained explicitly because a resumed day can find
     # close already 'done', and run_stage returns before draining — which

--- a/orchestrator/reconcile.py
+++ b/orchestrator/reconcile.py
@@ -10,6 +10,7 @@ the broker has not confirmed (invariants 4 and 6)."""
 from __future__ import annotations
 import sqlite3
 from typing import Callable
+from gate.tickets import open_tickets_without_orders
 from orchestrator.clock import Clock, iso
 from slackkit.outbox import append_alert, append_event
 from state.transition import EDGES, try_transition
@@ -273,3 +274,120 @@ def reconcile_orders(conn: sqlite3.Connection, *, clock: Clock, broker,
             f"unparseable ({reason}) at cap, left {cur_status} for retry",
             now_iso=now)
     return filled
+
+
+def _recoverable_qty(o: dict, ticket: dict) -> int | None:
+    """The whole-share qty on a broker order that MATCHES the ticket which
+    authorized it; None if anything does not line up.
+
+    Fail closed (invariant 4): an order that is not what the gate approved is
+    not this ticket's order, and recording it would put an unauthorized trade
+    in the books. So a mismatched symbol or side, a qty that is fractional,
+    below 1, or above the ticket's max_qty all deny. Numbers arrive as STRINGS
+    on the real wire (alpaca-py 0.44 Order fields are Optional[str]), so
+    coerce and reject rather than floor — this fund is whole-share only and
+    orders.qty is INTEGER."""
+    if o.get("symbol") != ticket["ticker"] or o.get("side") != ticket["side"]:
+        return None
+    try:
+        raw = float(o["qty"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    if raw != int(raw):
+        return None
+    qty = int(raw)
+    if qty < 1 or qty > ticket["max_qty"]:
+        return None
+    return qty
+
+
+def recover_lost_orders(conn: sqlite3.Connection, *, clock: Clock,
+                        broker) -> int:
+    """Repair pass for issue #40: an order that LANDED at the broker but whose
+    `orders` row was never written. Returns the number of tickets whose
+    open->consumed CAS THIS call won, so a re-run cannot over-count.
+
+    The row is written submit-then-write, by a PostToolUse hook on the place_*
+    response. A response lost to a gateway 504, or returned as the
+    duplicate-client_order_id 422, makes agents.runtime._extract_order return
+    None and nothing at all is written. reconcile_orders selects `FROM orders`
+    and so is structurally blind to it: the broker filled and SQLite
+    permanently records that nothing traded.
+
+    **The recovered order is recorded at status 'submitted' and nothing else.**
+    No fill parsing, no order transition, no fill event, no decision touched —
+    reconcile_orders runs immediately after, in the same stage body, and drives
+    all of that through its already-tested _apply. This holds even when the
+    broker's order is already 'rejected' or 'canceled': it is still recorded at
+    'submitted', and reconcile_orders then polls, sees the terminal status at
+    the broker, and CASes it through the state machine. A recovered order must
+    behave IDENTICALLY to a normally-recorded one — same broker state, same
+    outcome, regardless of whether the recorder happened to work that day —
+    because two classes of order row would force anyone defining retry
+    semantics later to handle both. state/schema.sql declares
+    `status TEXT NOT NULL DEFAULT 'submitted'`: rows are born submitted and
+    move by CAS, and that is the canonical DDL's stated intent.
+
+    Fail closed everywhere (invariant 4). No broker or a port without the
+    lookup: return 0, no writes, no alert. Broker never heard of the ticket:
+    SILENT skip — that is the ordinary "the turn placed nothing" day, which
+    the execution stage's ticket_open_after_exec alert already reports. Broker
+    raises: alert, write nothing, leave the ticket open for the next run.
+    Order does not match the ticket: alert, write nothing. The try/except is
+    INSIDE the loop, so one bad ticket does not stop the rest.
+
+    A successful recovery alerts deliberately: the PostToolUse recorder
+    failing is a fault a human should see, and #40 exists because such days
+    read as clean. Idempotent (invariant 5): INSERT OR IGNORE, the ticket
+    moves by CAS, and the alert fires only when that CAS wins."""
+    lookup = getattr(broker, "get_order_by_client_order_id", None)
+    if lookup is None:
+        return 0
+    now = iso(clock.now())
+    recovered = 0
+    for ticket in open_tickets_without_orders(conn):
+        tid = ticket["id"]
+        try:
+            o = lookup(tid)
+            if not o:
+                continue                  # the turn placed nothing: normal
+            qty = _recoverable_qty(o, ticket)
+            if qty is None:
+                append_alert(conn, "order_recovery_mismatch",
+                    f"ticket {tid[:8]} has no order row and the broker's order"
+                    f" does not match it ({o.get('symbol')!r}"
+                    f" {o.get('side')!r} {o.get('qty')!r} vs ticket"
+                    f" {ticket['ticker']!r} {ticket['side']!r} max"
+                    f" {ticket['max_qty']}) — nothing recorded", now_iso=now)
+                continue
+            conn.execute(
+                "INSERT OR IGNORE INTO orders (client_order_id,"
+                " alpaca_order_id, symbol, side, qty, status, submitted_at)"
+                " VALUES (?, ?, ?, ?, ?, 'submitted', ?)",
+                (tid, o.get("id"), ticket["ticker"], ticket["side"], qty, now))
+            conn.commit()
+            if try_transition(conn, "tickets", {"id": tid},
+                              "open", "consumed", now):
+                recovered += 1
+                append_alert(conn, "order_recovered",
+                    f"ticket {tid[:8]} had no order row but the broker holds"
+                    f" {qty} — recorded submitted; the place_* recorder did"
+                    " not run", now_iso=now)
+        except Exception as e:            # per-ticket isolation, fail closed
+            append_alert(conn, "order_recovery_failed",
+                f"ticket {tid[:8]} could not be checked against the broker"
+                f" ({type(e).__name__}) — nothing recorded, left open for the"
+                " next run", now_iso=now)
+    return recovered
+
+
+def reconcile_stage(conn: sqlite3.Connection, *, clock: Clock, broker,
+                    sleep: Callable[[float], None],
+                    poll_s: float = 3.0, max_wait_s: float = 90.0) -> int:
+    """The reconciliation stage body: recover the orders that never got a row,
+    then poll every submitted order to a terminal state. Returns
+    reconcile_orders' fill count, so the stage's return value keeps its
+    existing meaning."""
+    recover_lost_orders(conn, clock=clock, broker=broker)
+    return reconcile_orders(conn, clock=clock, broker=broker, sleep=sleep,
+                            poll_s=poll_s, max_wait_s=max_wait_s)

--- a/orchestrator/reconcile.py
+++ b/orchestrator/reconcile.py
@@ -282,20 +282,41 @@ def _recoverable_qty(o: dict, ticket: dict) -> int | None:
 
     Fail closed (invariant 4): an order that is not what the gate approved is
     not this ticket's order, and recording it would put an unauthorized trade
-    in the books. So a mismatched symbol or side, a qty that is fractional,
-    below 1, or above the ticket's max_qty all deny. Numbers arrive as STRINGS
-    on the real wire (alpaca-py 0.44 Order fields are Optional[str]), so
-    coerce and reject rather than floor — this fund is whole-share only and
-    orders.qty is INTEGER."""
+    in the books. So a mismatched client_order_id, symbol or side, and a qty
+    that is not a whole number, is below 1, or is above the ticket's max_qty
+    all deny.
+
+    client_order_id IS the ticket id (invariant 5) and is the key this whole
+    lookup was made on, so it is CHECKED, never assumed: an adapter that
+    answers a lookup with some other order — a stop leg, a fuzzy match — must
+    not get that order recorded under this ticket, under a foreign
+    alpaca_order_id. An order that does not echo the key at all denies too:
+    open_tickets_without_orders always supplies the ticket's id, so an absent
+    key compares unequal, and an answer that cannot prove which order it is is
+    exactly the ambiguity invariant 4 resolves to no action.
+
+    Numbers arrive as STRINGS on the real wire (alpaca-py 0.44 Order fields
+    are Optional[str]), so coerce and reject rather than floor — this fund is
+    whole-share only and orders.qty is INTEGER. The coercion accepts an int or
+    an ASCII digit-string and nothing else, which is at least as strict as
+    both sibling coercers (gate/tickets.py:_as_share_count, which this
+    mirrors, and orchestrator/protection.py:_qty). They stay separate
+    functions on purpose — see _qty's docstring. Matching on SHAPE rather than
+    running float() is also what keeps this function total: 'nan' and 'inf'
+    parse as floats and then raise inside int(), which would make this
+    function raise where it promises None, and the caller would file
+    "could not be checked against the broker" for a payload it checked fine."""
     if o.get("symbol") != ticket["ticker"] or o.get("side") != ticket["side"]:
         return None
-    try:
-        raw = float(o["qty"])
-    except (KeyError, TypeError, ValueError):
+    if o.get("client_order_id") != ticket.get("id"):
         return None
-    if raw != int(raw):
+    qty = o.get("qty")
+    if isinstance(qty, bool):              # bool is an int; 1 share nobody placed
         return None
-    qty = int(raw)
+    if isinstance(qty, str) and qty.isascii() and qty.isdigit():
+        qty = int(qty)
+    if not isinstance(qty, int):
+        return None
     if qty < 1 or qty > ticket["max_qty"]:
         return None
     return qty
@@ -333,13 +354,21 @@ def recover_lost_orders(conn: sqlite3.Connection, *, clock: Clock,
     SILENT skip — that is the ordinary "the turn placed nothing" day, which
     the execution stage's ticket_open_after_exec alert already reports. Broker
     raises: alert, write nothing, leave the ticket open for the next run.
-    Order does not match the ticket: alert, write nothing. The try/except is
-    INSIDE the loop, so one bad ticket does not stop the rest.
+    Order does not match the ticket: alert, write nothing. Row could not be
+    written: alert, leave the ticket open — see the INSERT below. The
+    try/except is INSIDE the loop, so one bad ticket does not stop the rest.
+
+    Every alert here passes the ticket's `ticker`. scripts/file_alert_issues.py
+    groups on ("alert:{code}", "ticker:{ticker}") and skips a group that
+    already has an open issue, so a bare code would file the first bad ticket
+    and silently drop every later one — one issue for the whole class, on the
+    path that exists to catch an order the fund cannot account for.
 
     A successful recovery alerts deliberately: the PostToolUse recorder
     failing is a fault a human should see, and #40 exists because such days
-    read as clean. Idempotent (invariant 5): INSERT OR IGNORE, the ticket
-    moves by CAS, and the alert fires only when that CAS wins."""
+    read as clean. Idempotent (invariant 5): INSERT OR IGNORE whose rowcount
+    is CHECKED, then the ticket moves by CAS, and the count and the alert fire
+    only when that CAS wins."""
     lookup = getattr(broker, "get_order_by_client_order_id", None)
     if lookup is None:
         return 0
@@ -358,26 +387,45 @@ def recover_lost_orders(conn: sqlite3.Connection, *, clock: Clock,
                     f" does not match it ({o.get('symbol')!r}"
                     f" {o.get('side')!r} {o.get('qty')!r} vs ticket"
                     f" {ticket['ticker']!r} {ticket['side']!r} max"
-                    f" {ticket['max_qty']}) — nothing recorded", now_iso=now)
+                    f" {ticket['max_qty']}) — nothing recorded", now_iso=now,
+                    ticker=ticket["ticker"])
                 continue
-            conn.execute(
+            cur = conn.execute(
                 "INSERT OR IGNORE INTO orders (client_order_id,"
                 " alpaca_order_id, symbol, side, qty, status, submitted_at)"
                 " VALUES (?, ?, ?, ?, ?, 'submitted', ?)",
                 (tid, o.get("id"), ticket["ticker"], ticket["side"], qty, now))
             conn.commit()
+            if cur.rowcount != 1:
+                # The INSERT was DROPPED and OR IGNORE swallowed it — most
+                # likely orders.alpaca_order_id (TEXT UNIQUE) already holds
+                # this broker id. Consuming the ticket now would take it out
+                # of open_tickets_without_orders forever and leave a live
+                # broker order with no row anywhere, while the alert claimed
+                # success: precisely the hole this pass exists to close. So
+                # do not CAS, do not claim recovery — alert and leave it open
+                # for the next run (invariant 4).
+                append_alert(conn, "order_recovery_unwritable",
+                    f"ticket {tid[:8]} has no order row and the broker's order"
+                    f" {o.get('id')!r} could NOT be written — the INSERT was"
+                    " dropped (alpaca_order_id is UNIQUE and this id is"
+                    " already in the books). Nothing recorded, ticket left"
+                    " open; the broker order is unaccounted for until a human"
+                    " resolves the id collision", now_iso=now,
+                    ticker=ticket["ticker"])
+                continue
             if try_transition(conn, "tickets", {"id": tid},
                               "open", "consumed", now):
                 recovered += 1
                 append_alert(conn, "order_recovered",
                     f"ticket {tid[:8]} had no order row but the broker holds"
                     f" {qty} — recorded submitted; the place_* recorder did"
-                    " not run", now_iso=now)
+                    " not run", now_iso=now, ticker=ticket["ticker"])
         except Exception as e:            # per-ticket isolation, fail closed
             append_alert(conn, "order_recovery_failed",
                 f"ticket {tid[:8]} could not be checked against the broker"
                 f" ({type(e).__name__}) — nothing recorded, left open for the"
-                " next run", now_iso=now)
+                " next run", now_iso=now, ticker=ticket["ticker"])
     return recovered
 
 

--- a/orchestrator/reconcile.py
+++ b/orchestrator/reconcile.py
@@ -8,6 +8,7 @@ closed — the order stays 'submitted' and the next run retries; all of it is
 surfaced as loud alerts, never silent. The DB never claims a terminal state
 the broker has not confirmed (invariants 4 and 6)."""
 from __future__ import annotations
+import re
 import sqlite3
 from typing import Callable
 from gate.tickets import open_tickets_without_orders
@@ -276,6 +277,14 @@ def reconcile_orders(conn: sqlite3.Connection, *, clock: Clock, broker,
     return filled
 
 
+# A whole-number share count as the wire may spell it: ASCII digits, with an
+# optional decimal point and fractional part. Written [0-9] rather than \d so
+# non-ASCII digits (which int() would happily take) can never match, and
+# anchored by fullmatch so padding, underscores, signs, 'nan' and 'inf' never
+# reach a conversion.
+_DECIMAL_QTY = re.compile(r"[0-9]+(?:\.[0-9]+)?")
+
+
 def _recoverable_qty(o: dict, ticket: dict) -> int | None:
     """The whole-share qty on a broker order that MATCHES the ticket which
     authorized it; None if anything does not line up.
@@ -297,15 +306,27 @@ def _recoverable_qty(o: dict, ticket: dict) -> int | None:
 
     Numbers arrive as STRINGS on the real wire (alpaca-py 0.44 Order fields
     are Optional[str]), so coerce and reject rather than floor — this fund is
-    whole-share only and orders.qty is INTEGER. The coercion accepts an int or
-    an ASCII digit-string and nothing else, which is at least as strict as
-    both sibling coercers (gate/tickets.py:_as_share_count, which this
-    mirrors, and orchestrator/protection.py:_qty). They stay separate
-    functions on purpose — see _qty's docstring. Matching on SHAPE rather than
-    running float() is also what keeps this function total: 'nan' and 'inf'
-    parse as floats and then raise inside int(), which would make this
-    function raise where it promises None, and the caller would file
-    "could not be checked against the broker" for a payload it checked fine."""
+    whole-share only and orders.qty is INTEGER. The accepted forms are an int
+    and a whole-number decimal string: "67", "67.0" and 67 all recover.
+
+    That decimal form is why this coercer is deliberately NOT a copy of
+    gate/tickets.py:_as_share_count. _as_share_count coerces TOOL INPUT — a
+    string the fund itself constructed — where .isdigit() is exactly right.
+    This one coerces a BROKER ECHO, a different contract:
+    market/source_alpaca.py builds its dict with str(v) over qty, so if
+    alpaca-py hands back a Decimal or a float, "67.0" is what arrives here.
+    _parse_fill, the sibling that parses the same payload in the same module,
+    has always accepted that form (float() then an integrality check); being
+    stricter than it would file order_recovery_mismatch on a real fill, on the
+    path whose whole job is repairing real fills. The third coercer,
+    orchestrator/protection.py:_qty, stays separate too — see its docstring.
+
+    Matching on SHAPE before converting is what keeps this function total, and
+    is why there is no bare float(): 'nan' and 'inf' parse as floats and then
+    raise inside int(), which would make this function raise where it promises
+    None, and the caller would file "could not be checked against the broker"
+    for a payload it checked fine. Padded ("  67  ") and underscored ("6_7")
+    forms never come off the wire, and a bare float() would take them."""
     if o.get("symbol") != ticket["ticker"] or o.get("side") != ticket["side"]:
         return None
     if o.get("client_order_id") != ticket.get("id"):
@@ -313,8 +334,13 @@ def _recoverable_qty(o: dict, ticket: dict) -> int | None:
     qty = o.get("qty")
     if isinstance(qty, bool):              # bool is an int; 1 share nobody placed
         return None
-    if isinstance(qty, str) and qty.isascii() and qty.isdigit():
-        qty = int(qty)
+    if isinstance(qty, str):
+        if not _DECIMAL_QTY.fullmatch(qty):
+            return None
+        whole, _, frac = qty.partition(".")
+        if frac.strip("0"):                # fractional: reject, never floor
+            return None
+        qty = int(whole)
     if not isinstance(qty, int):
         return None
     if qty < 1 or qty > ticket["max_qty"]:
@@ -326,7 +352,11 @@ def recover_lost_orders(conn: sqlite3.Connection, *, clock: Clock,
                         broker) -> int:
     """Repair pass for issue #40: an order that LANDED at the broker but whose
     `orders` row was never written. Returns the number of tickets whose
-    open->consumed CAS THIS call won, so a re-run cannot over-count.
+    open->consumed CAS THIS call won; a re-run cannot over-count it. Nothing
+    in production reads that count — it is kept because returning it is the
+    idiomatic way to report work done, and because reconcile_orders, its
+    sibling on the next line of reconcile_stage, returns an equally-unread
+    fill count.
 
     The row is written submit-then-write, by a PostToolUse hook on the place_*
     response. A response lost to a gateway 504, or returned as the

--- a/orchestrator/reconcile.py
+++ b/orchestrator/reconcile.py
@@ -383,10 +383,31 @@ def recover_lost_orders(conn: sqlite3.Connection, *, clock: Clock,
     lookup: return 0, no writes, no alert. Broker never heard of the ticket:
     SILENT skip — that is the ordinary "the turn placed nothing" day, which
     the execution stage's ticket_open_after_exec alert already reports. Broker
-    raises: alert, write nothing, leave the ticket open for the next run.
-    Order does not match the ticket: alert, write nothing. Row could not be
-    written: alert, leave the ticket open — see the INSERT below. The
-    try/except is INSIDE the loop, so one bad ticket does not stop the rest.
+    raises: alert, write nothing, leave the ticket open. Order does not match
+    the ticket: alert, write nothing. Row could not be written: alert, leave
+    the ticket open — see the INSERT below. The try/except is INSIDE the loop,
+    so one bad ticket does not stop the rest.
+
+    ONE ATTEMPT, at the reconciliation stage of the day the ticket opened.
+    "Left open" does NOT mean "retried tomorrow" — there is no next run.
+    run_execution's body calls expire_open_tickets FIRST, and it is unscoped
+    by date, so the next day's execution stage sweeps the still-open ticket
+    open->expired (and its decision approved->expired) before that day's
+    reconciliation stage ever reaches this function, whose predicate is
+    status='open'. The ticket is then permanently out of scope. Traced over
+    three days: day 1 alerts, days 2 and 3 emit nothing, final state
+    ticket=expired decision=expired orders=0 while the broker holds a real
+    filled position — a discrepancy that is now permanently invisible.
+
+    A swallow amplifies it. market/source_alpaca.py's
+    get_order_by_client_order_id catches every exception and returns None
+    ("# fail closed; poll retries" — a precondition true for reconcile_orders
+    and false for this caller), so against the real adapter a broker outage
+    takes the SILENT-SKIP path above rather than the alert path, and is
+    indistinguishable from "the turn placed nothing". Issue #55 is the
+    completing fix (recovery reaching an 'expired' ticket, held for a human
+    ruling); issue #74 is the adapter's two-callers-incompatible-contracts
+    problem.
 
     Every alert here passes the ticket's `ticker`. scripts/file_alert_issues.py
     groups on ("alert:{code}", "ticker:{ticker}") and skips a group that
@@ -454,8 +475,10 @@ def recover_lost_orders(conn: sqlite3.Connection, *, clock: Clock,
         except Exception as e:            # per-ticket isolation, fail closed
             append_alert(conn, "order_recovery_failed",
                 f"ticket {tid[:8]} could not be checked against the broker"
-                f" ({type(e).__name__}) — nothing recorded, left open for the"
-                " next run", now_iso=now, ticker=ticket["ticker"])
+                f" ({type(e).__name__}) — nothing recorded and this ticket will"
+                " NOT be retried: tomorrow's execution stage expires it before"
+                " recovery runs again. Reconcile it against the broker by hand",
+                now_iso=now, ticker=ticket["ticker"])
     return recovered
 
 

--- a/tests/test_daily_stages.py
+++ b/tests/test_daily_stages.py
@@ -789,3 +789,22 @@ def test_execution_alert_is_not_reposted_on_a_resume(fund_db, sim_clock):
     run_execution(ctx, lambda: None)
     run_execution(ctx, lambda: None)
     assert len(_alert_texts(fund_db)) == 1
+
+
+def test_execution_alerts_when_the_turn_overran_the_tickets_ttl(fund_db, sim_clock):
+    """Issue #40's TTL hole. The turn burns past the 45-minute TTL and places
+    nothing, so the ticket is still 'open' when the alert pass runs — expiry
+    already swept at the start of the body, before the overrun. The old pass
+    asked open_tickets, whose clock filter dropped precisely this ticket, so
+    the loudest no-order day was the one that alerted least. Same code, same
+    text: the alert is about status, not about the clock."""
+    _open_ticket(fund_db, sim_clock)
+    ctx = _ctx(fund_db, sim_clock, {"NVDA": _nvda_inputs()})
+
+    def overrunning_turn() -> None:
+        sim_clock.advance(minutes=46)          # past expires_at, nothing placed
+
+    assert run_execution(ctx, overrunning_turn) == "done"
+    assert _alert_texts(fund_db) == [
+        f"ticket {TID[:8]} open after exec turn — no order"]
+    assert _codes(fund_db) == ["ticket_open_after_exec"]

--- a/tests/test_daily_stages.py
+++ b/tests/test_daily_stages.py
@@ -830,3 +830,22 @@ def test_a_resumed_execution_stage_does_not_expire_the_ticket(fund_db, sim_clock
         "SELECT status FROM decisions WHERE ticker='NVDA'"
     ).fetchone()["status"] == "approved"
     assert len(_alert_texts(fund_db)) == 1
+
+
+def test_execution_is_silent_when_the_ticket_was_past_ttl_on_entry(fund_db, sim_clock):
+    """Pins the ORDER of the two statements in the body. _alert_unexecuted_tickets
+    is clock-free, which is only safe because expire_open_tickets runs FIRST and
+    has already swept every ticket whose TTL passed before the stage started —
+    yesterday's included. Run the alert pass first and each of those stale open
+    tickets fires a spurious ticket_open_after_exec, reddening the audit and
+    paging a human for a ticket that was never this stage's to place. A false
+    positive is how people learn to ignore the alert."""
+    tid = _open_ticket(fund_db, sim_clock)
+    fund_db.execute("UPDATE decisions SET status='approved' WHERE ticker='NVDA'")
+    fund_db.commit()
+    sim_clock.advance(minutes=46)          # TTL passed BEFORE the stage runs
+    ctx = _ctx(fund_db, sim_clock, {"NVDA": _nvda_inputs()})
+    assert run_execution(ctx, lambda: None) == "done"
+    assert _alert_texts(fund_db) == []
+    assert fund_db.execute("SELECT status FROM tickets WHERE id=?",
+                           (tid,)).fetchone()["status"] == "expired"

--- a/tests/test_daily_stages.py
+++ b/tests/test_daily_stages.py
@@ -808,3 +808,25 @@ def test_execution_alerts_when_the_turn_overran_the_tickets_ttl(fund_db, sim_clo
     assert _alert_texts(fund_db) == [
         f"ticket {TID[:8]} open after exec turn — no order"]
     assert _codes(fund_db) == ["ticket_open_after_exec"]
+
+
+def test_a_resumed_execution_stage_does_not_expire_the_ticket(fund_db, sim_clock):
+    """Issue #40. A day re-fired after the execution checkpoint reached 'done'
+    skips the body — so every repair path in it is skipped too. With expiry
+    sitting OUTSIDE the body it ran anyway, finalizing ticket AND decision to
+    'expired' on a resume that did no work. There is no legal edge out of
+    'expired', so a real fill sitting at the broker was locked out of the books
+    permanently. Expiry belongs to the stage, not to the resume."""
+    tid = _open_ticket(fund_db, sim_clock)
+    fund_db.execute("UPDATE decisions SET status='approved' WHERE ticker='NVDA'")
+    fund_db.commit()
+    ctx = _ctx(fund_db, sim_clock, {"NVDA": _nvda_inputs()})
+    assert run_execution(ctx, lambda: None) == "done"   # checkpoint -> done
+    sim_clock.advance(minutes=46)                       # past the ticket's TTL
+    assert run_execution(ctx, lambda: None) == "done"   # body skipped on resume
+    assert fund_db.execute("SELECT status FROM tickets WHERE id=?",
+                           (tid,)).fetchone()["status"] == "open"
+    assert fund_db.execute(
+        "SELECT status FROM decisions WHERE ticker='NVDA'"
+    ).fetchone()["status"] == "approved"
+    assert len(_alert_texts(fund_db)) == 1

--- a/tests/test_order_recovery.py
+++ b/tests/test_order_recovery.py
@@ -230,10 +230,38 @@ def test_unparseable_qty_is_a_mismatch_and_never_raises(fund_db, sim_clock):
     assert _codes(fund_db) == ["order_recovery_mismatch"]
 
 
-def test_qty_coercion_is_no_laxer_than_its_sibling_coercers(fund_db, sim_clock):
-    """gate/tickets.py:_as_share_count rejects bool and requires .isdigit();
-    orchestrator/protection.py:_qty rejects bool. A bool reaching here would
-    record a 1-share trade nobody placed."""
+def test_whole_number_decimal_qty_recovers(fund_db, sim_clock):
+    """A BROKER ECHO, not tool input: market/source_alpaca.py builds its dict
+    with str(v) over qty, so a Decimal or float at the adapter arrives here as
+    "67.0". _parse_fill — the sibling parsing the same payload in the same
+    module — has always accepted that form, and refusing it here would file
+    order_recovery_mismatch on a real fill, on the path whose whole job is
+    repairing real fills. Every rejection that matters still denies."""
+    assert _recoverable_qty(_o(qty="67"), _TICKET) == 67
+    assert _recoverable_qty(_o(qty="67.0"), _TICKET) == 67
+    assert _recoverable_qty(_o(qty=67), _TICKET) == 67
+
+    for bad in (True, "67.5", 67.5, "nan", "inf", "-inf", "  67  ", "6_7",
+                None):
+        assert _recoverable_qty(_o(qty=bad), _TICKET) is None, bad
+    missing = _o()
+    del missing["qty"]
+    assert _recoverable_qty(missing, _TICKET) is None
+
+    _seed(fund_db)
+    assert recover_lost_orders(fund_db, clock=sim_clock,
+                               broker=_Holding(qty="67.0")) == 1
+    assert fund_db.execute("SELECT qty FROM orders").fetchone()["qty"] == 67
+    assert _codes(fund_db) == ["order_recovered"]
+
+
+def test_qty_coercion_still_rejects_bool_padding_and_underscores(
+        fund_db, sim_clock):
+    """The decimal form is the ONLY loosening. gate/tickets.py:_as_share_count
+    and orchestrator/protection.py:_qty both reject bool, and a bool reaching
+    here would record a 1-share trade nobody placed; padded and underscored
+    strings never come off the wire and a bare float() would silently take
+    them."""
     assert _recoverable_qty(_o(qty=67), _TICKET) == 67       # the plain case
     assert _recoverable_qty(_o(qty=True), _TICKET) is None
     assert _recoverable_qty(_o(qty="  67  "), _TICKET) is None

--- a/tests/test_order_recovery.py
+++ b/tests/test_order_recovery.py
@@ -1,0 +1,327 @@
+"""Issue #40: the order that landed at the broker and never reached SQLite.
+
+The `orders` row is written submit-then-write, by a PostToolUse hook on the
+place_* response. When that response never arrives (gateway 504) or comes back
+as the duplicate-client_order_id 422, `_extract_order` returns None and NOTHING
+is written — no order row, no ticket CAS. `reconcile_orders` selects `FROM
+orders`, so it cannot see what has no row, and the books permanently record
+that nothing traded while the broker holds a fill.
+
+These tests pin the repair pass: `recover_lost_orders` asks the broker about
+every still-open ticket with no order row, records what matches at
+'submitted', and lets the already-tested `reconcile_orders` drive everything
+else."""
+
+import asyncio
+import json
+
+from agents.runtime import make_order_recorder
+from gate.tickets import expire_open_tickets
+from orchestrator.clock import iso
+from orchestrator.daily import StageCtx, run_day
+from orchestrator.reconcile import (_recoverable_qty, recover_lost_orders,
+                                    reconcile_stage)
+from slackkit.fake import FakeSlack
+from tests.conftest import make_executor
+from tests.fake_alpaca import FakeAlpaca
+from tests.test_tickets import LATER, TID, TID2, _seed, order
+
+
+def _codes(conn):
+    return [json.loads(r["payload"]).get("code") for r in conn.execute(
+        "SELECT payload FROM events WHERE kind='alert' ORDER BY id")]
+
+
+def _counts(conn):
+    n = conn.execute("SELECT COUNT(*) c FROM orders").fetchone()["c"]
+    fills = conn.execute(
+        "SELECT COUNT(*) c FROM events WHERE kind='fill'").fetchone()["c"]
+    return n, fills
+
+
+class _Holding:
+    """Broker holding exactly one order under `coid`, shape as the real wire
+    has it: every numeric a STRING."""
+
+    def __init__(self, coid=TID, **over):
+        self.o = {"id": "alp-0001", "client_order_id": coid, "symbol": "NVDA",
+                  "side": "buy", "qty": "67", "status": "accepted",
+                  "filled_qty": "0", "filled_avg_price": None}
+        self.o.update(over)
+        self.coid = coid
+
+    def get_order_by_client_order_id(self, coid):
+        return dict(self.o) if coid == self.coid else None
+
+
+class _Unreachable:
+    def get_order_by_client_order_id(self, coid):
+        raise ConnectionError("broker unreachable")
+
+
+class _NoLookup:
+    """A port with no get_order_by_client_order_id at all — the shape several
+    existing test doubles (_FlatBroker, _NakedBroker, _QuietSource) have."""
+
+    def open_positions(self):
+        return []
+
+
+# --- the headline case ------------------------------------------------------
+
+def test_lost_place_response_is_recovered_and_settles(fund_db, sim_clock):
+    """The 504, reproduced through the real hook path: the order is placed
+    DIRECTLY at the broker (the request landed, no response came back, so the
+    PostToolUse recorder never ran), then the seat retries and Alpaca 422s the
+    duplicate client_order_id. The recorder writes nothing. reconcile_stage
+    must recover the order and settle it exactly like a normal one."""
+    _seed(fund_db)
+    broker = FakeAlpaca({"NVDA": 180.0}, {"NVDA": 180.14})
+    broker.place_order(order())                       # the placement that landed
+
+    execute = make_executor(lambda: fund_db, sim_clock, broker)
+    resp = execute("mcp__alpaca__place_stock_order", order())   # the 422 retry
+    rec = make_order_recorder(lambda: fund_db, sim_clock)
+    asyncio.run(rec({"tool_name": "mcp__alpaca__place_stock_order",
+                     "tool_input": order(), "tool_response": resp}, "t1", None))
+
+    # The bug: the broker holds the order and SQLite records nothing.
+    assert _counts(fund_db) == (0, 0)
+    assert fund_db.execute("SELECT status FROM tickets").fetchone()["status"] == "open"
+    assert broker.orders[TID]["status"] == "accepted"
+
+    n = reconcile_stage(fund_db, clock=sim_clock, broker=broker,
+                        sleep=lambda s: broker.tick(), poll_s=3.0,
+                        max_wait_s=90.0)
+    assert n == 1
+    o = fund_db.execute("SELECT * FROM orders").fetchone()
+    assert (o["client_order_id"], o["symbol"], o["side"], o["qty"]) == (
+        TID, "NVDA", "buy", 67)
+    assert o["status"] == "filled"
+    assert o["filled_qty"] == 67 and o["filled_avg_price"] == 180.14
+    assert fund_db.execute("SELECT status FROM tickets").fetchone()["status"] == "consumed"
+    assert fund_db.execute("SELECT status FROM decisions").fetchone()["status"] == "executed"
+    assert fund_db.execute(
+        "SELECT COUNT(*) c FROM events WHERE kind='fill'").fetchone()["c"] == 1
+    assert "order_recovered" in _codes(fund_db)
+
+
+# --- fail-closed paths ------------------------------------------------------
+
+def test_no_broker_recovers_nothing_silently(fund_db, sim_clock):
+    _seed(fund_db)
+    assert recover_lost_orders(fund_db, clock=sim_clock, broker=None) == 0
+    assert _counts(fund_db) == (0, 0)
+    assert _codes(fund_db) == []
+    assert fund_db.execute("SELECT status FROM tickets").fetchone()["status"] == "open"
+
+
+def test_port_without_the_lookup_method_recovers_nothing_silently(fund_db, sim_clock):
+    """Feature-detected, not assumed: several existing doubles are position-
+    only ports and would AttributeError."""
+    _seed(fund_db)
+    assert recover_lost_orders(fund_db, clock=sim_clock, broker=_NoLookup()) == 0
+    assert _counts(fund_db) == (0, 0)
+    assert _codes(fund_db) == []
+
+
+def test_raising_broker_alerts_and_leaves_the_ticket_open(fund_db, sim_clock):
+    _seed(fund_db)
+    assert recover_lost_orders(fund_db, clock=sim_clock,
+                               broker=_Unreachable()) == 0
+    assert _counts(fund_db) == (0, 0)
+    assert _codes(fund_db) == ["order_recovery_failed"]
+    alert = fund_db.execute(
+        "SELECT payload FROM events WHERE kind='alert'").fetchone()
+    assert "ConnectionError" in alert["payload"]
+    assert fund_db.execute("SELECT status FROM tickets").fetchone()["status"] == "open"
+
+
+def test_broker_never_got_the_order_is_a_silent_skip(fund_db, sim_clock):
+    """The ordinary hold day: the turn placed nothing. The execution stage's
+    ticket_open_after_exec alert already reports it; a second alert here would
+    double-post on every such day."""
+    _seed(fund_db)
+
+    class _Empty:
+        def get_order_by_client_order_id(self, coid):
+            return None
+
+    assert recover_lost_orders(fund_db, clock=sim_clock, broker=_Empty()) == 0
+    assert _counts(fund_db) == (0, 0)
+    assert _codes(fund_db) == []
+    assert fund_db.execute("SELECT status FROM tickets").fetchone()["status"] == "open"
+
+
+def test_order_over_the_tickets_max_qty_is_a_mismatch(fund_db, sim_clock):
+    """Recording it would put an unauthorized trade in the books."""
+    _seed(fund_db)
+    broker = _Holding(qty="99")
+    assert recover_lost_orders(fund_db, clock=sim_clock, broker=broker) == 0
+    assert _counts(fund_db) == (0, 0)
+    assert _codes(fund_db) == ["order_recovery_mismatch"]
+    assert fund_db.execute("SELECT status FROM tickets").fetchone()["status"] == "open"
+
+
+def test_wrong_symbol_order_is_a_mismatch(fund_db, sim_clock):
+    _seed(fund_db)
+    broker = _Holding(symbol="AMD")
+    assert recover_lost_orders(fund_db, clock=sim_clock, broker=broker) == 0
+    assert _counts(fund_db) == (0, 0)
+    assert _codes(fund_db) == ["order_recovery_mismatch"]
+
+
+def test_fractional_qty_is_a_mismatch_not_floored(fund_db, sim_clock):
+    """This fund is whole-share only and orders.qty is INTEGER."""
+    _seed(fund_db)
+    assert _recoverable_qty({"symbol": "NVDA", "side": "buy", "qty": "1.5"},
+                            {"ticker": "NVDA", "side": "buy", "max_qty": 67}) is None
+    broker = _Holding(qty="1.5")
+    assert recover_lost_orders(fund_db, clock=sim_clock, broker=broker) == 0
+    assert _counts(fund_db) == (0, 0)
+    assert _codes(fund_db) == ["order_recovery_mismatch"]
+
+
+# --- scope ------------------------------------------------------------------
+
+def test_consumed_ticket_is_never_revisited(fund_db, sim_clock):
+    _seed(fund_db)
+    fund_db.execute("UPDATE tickets SET status='consumed'")
+    fund_db.commit()
+    assert recover_lost_orders(fund_db, clock=sim_clock, broker=_Holding()) == 0
+    assert _counts(fund_db) == (0, 0)
+    assert _codes(fund_db) == []
+
+
+def test_expired_ticket_is_left_alone(fund_db, sim_clock):
+    """There is no legal edge out of 'expired', so an expired ticket is out of
+    scope by construction — recording an order against it could never CAS."""
+    _seed(fund_db)
+    assert expire_open_tickets(fund_db, LATER) == [TID]
+    assert recover_lost_orders(fund_db, clock=sim_clock, broker=_Holding()) == 0
+    assert _counts(fund_db) == (0, 0)
+    assert _codes(fund_db) == []
+    assert fund_db.execute("SELECT status FROM tickets").fetchone()["status"] == "expired"
+
+
+# --- idempotency and isolation ---------------------------------------------
+
+def test_second_run_recovers_nothing_and_posts_no_second_alert(fund_db, sim_clock):
+    """Invariant 5: INSERT OR IGNORE + a CAS-gated alert. On the second run the
+    predicate's own result set is empty anyway."""
+    _seed(fund_db)
+    broker = FakeAlpaca({"NVDA": 180.0}, {"NVDA": 180.14})
+    broker.place_order(order())
+    reconcile_stage(fund_db, clock=sim_clock, broker=broker,
+                    sleep=lambda s: broker.tick(), poll_s=3.0, max_wait_s=90.0)
+    before_events = fund_db.execute("SELECT COUNT(*) c FROM events").fetchone()["c"]
+    before_codes = _codes(fund_db)
+
+    assert reconcile_stage(fund_db, clock=sim_clock, broker=broker,
+                           sleep=lambda s: broker.tick(), poll_s=3.0,
+                           max_wait_s=90.0) == 0
+    assert fund_db.execute("SELECT COUNT(*) c FROM orders").fetchone()["c"] == 1
+    assert fund_db.execute(
+        "SELECT COUNT(*) c FROM events WHERE kind='fill'").fetchone()["c"] == 1
+    assert fund_db.execute("SELECT COUNT(*) c FROM events").fetchone()["c"] == before_events
+    assert _codes(fund_db) == before_codes
+    assert before_codes.count("order_recovered") == 1
+
+
+def test_one_raising_ticket_does_not_stop_the_next(fund_db, sim_clock):
+    """Per-ticket isolation: the try/except is inside the loop."""
+    _seed(fund_db)
+    _seed(fund_db, tid=TID2, run_date="2026-07-07")
+
+    class _RaisesOnFirst:
+        def get_order_by_client_order_id(self, coid):
+            if coid == TID:
+                raise TimeoutError("gateway timeout")
+            return {"id": "alp-0002", "client_order_id": TID2, "symbol": "NVDA",
+                    "side": "buy", "qty": "67", "status": "accepted",
+                    "filled_qty": "0", "filled_avg_price": None}
+
+    assert recover_lost_orders(fund_db, clock=sim_clock,
+                               broker=_RaisesOnFirst()) == 1
+    assert fund_db.execute("SELECT status FROM tickets WHERE id=?",
+                           (TID,)).fetchone()["status"] == "open"
+    assert fund_db.execute("SELECT status FROM tickets WHERE id=?",
+                           (TID2,)).fetchone()["status"] == "consumed"
+    rows = fund_db.execute("SELECT client_order_id FROM orders").fetchall()
+    assert [r["client_order_id"] for r in rows] == [TID2]
+    assert _codes(fund_db) == ["order_recovery_failed", "order_recovered"]
+
+
+# --- the semantic: a recovered order is not a second class of order ---------
+
+class _Rejected:
+    """The broker rejected both orders. cancel_order is a no-op (a rejected
+    order is already dead), so the timeout path's re-query is what settles."""
+
+    def __init__(self):
+        self.cancel_attempts = []
+
+    def get_order_by_client_order_id(self, coid):
+        return {"id": f"alp-{coid[-1]}", "client_order_id": coid,
+                "symbol": "NVDA", "side": "buy", "qty": "67",
+                "status": "rejected", "filled_qty": "0",
+                "filled_avg_price": None}
+
+    def cancel_order(self, coid):
+        self.cancel_attempts.append(coid)
+
+
+def test_recovered_rejection_settles_exactly_like_a_recorded_one(fund_db, sim_clock):
+    """The recovery pass records at 'submitted' even when the broker's order is
+    already rejected, and lets reconcile_orders drive it through the state
+    machine. Two tickets, same broker answer, one recovered and one recorded
+    normally: the rows must end IDENTICAL. Two classes of order row would force
+    anyone defining retry semantics later to handle both."""
+    _seed(fund_db)                                       # TID: recovered
+    _seed(fund_db, tid=TID2, run_date="2026-07-07")      # TID2: recorded normally
+    fund_db.execute("UPDATE tickets SET status='consumed' WHERE id=?", (TID2,))
+    fund_db.execute(
+        "INSERT INTO orders (client_order_id, symbol, side, qty, status,"
+        " submitted_at) VALUES (?,'NVDA','buy',67,'submitted',?)",
+        (TID2, iso(sim_clock.now())))
+    fund_db.commit()
+
+    reconcile_stage(fund_db, clock=sim_clock, broker=_Rejected(),
+                    sleep=lambda s: None, poll_s=3.0, max_wait_s=3.0)
+
+    rows = {r["client_order_id"]: r for r in
+            fund_db.execute("SELECT * FROM orders")}
+    assert set(rows) == {TID, TID2}
+    fields = ("status", "symbol", "side", "qty", "filled_qty",
+              "filled_avg_price")
+    assert ([rows[TID][f] for f in fields] == [rows[TID2][f] for f in fields])
+    assert rows[TID]["status"] == "rejected"
+    decisions = [r["status"] for r in fund_db.execute(
+        "SELECT status FROM decisions ORDER BY id")]
+    assert decisions == ["failed", "failed"]
+    assert fund_db.execute(
+        "SELECT COUNT(*) c FROM events WHERE kind='fill'").fetchone()["c"] == 0
+    assert fund_db.execute("SELECT status FROM tickets WHERE id=?",
+                           (TID,)).fetchone()["status"] == "consumed"
+
+
+# --- the wiring: still exactly one stage ------------------------------------
+
+def test_run_days_reconciliation_stage_recovers_the_lost_order(fund_db, sim_clock):
+    """The repair only helps if the day actually runs it: run_day's single
+    reconciliation stage must be reconcile_stage, not reconcile_orders."""
+    _seed(fund_db)
+    broker = FakeAlpaca({"NVDA": 180.0}, {"NVDA": 180.14}, mode="instant")
+    broker.place_order(order())
+    ctx = StageCtx(conn=fund_db, run_date="2026-07-06", clock=sim_clock,
+                   slack=FakeSlack(), market_inputs={},
+                   research_seats=("analyst",))
+    run_day(ctx, execution_turn=None, broker=broker, sleep=lambda s: None)
+    o = fund_db.execute("SELECT * FROM orders").fetchone()
+    assert o is not None and o["client_order_id"] == TID
+    assert o["status"] == "filled" and o["qty"] == 67
+    assert fund_db.execute("SELECT status FROM tickets").fetchone()["status"] == "consumed"
+    assert fund_db.execute("SELECT status FROM decisions").fetchone()["status"] == "executed"
+    stages = [r["stage"] for r in fund_db.execute(
+        "SELECT stage FROM checkpoints WHERE stage LIKE 'reconcil%'")]
+    assert stages == ["reconciliation"]

--- a/tests/test_order_recovery.py
+++ b/tests/test_order_recovery.py
@@ -182,6 +182,187 @@ def test_fractional_qty_is_a_mismatch_not_floored(fund_db, sim_clock):
     assert _codes(fund_db) == ["order_recovery_mismatch"]
 
 
+# --- what _recoverable_qty accepts, field by field --------------------------
+
+_TICKET = {"id": TID, "ticker": "NVDA", "side": "buy", "max_qty": 67}
+
+
+def _o(**over):
+    """A broker order that matches _TICKET, before the override under test."""
+    base = {"id": "alp-0001", "client_order_id": TID, "symbol": "NVDA",
+            "side": "buy", "qty": "67"}
+    base.update(over)
+    return base
+
+
+def test_only_this_tickets_own_order_is_recoverable(fund_db, sim_clock):
+    """client_order_id IS the ticket id (invariant 5) and is the key the
+    lookup was made on — so it is checked, not assumed. An adapter that
+    answers with some OTHER order (a stop leg, a fuzzy match) would otherwise
+    get that order recorded under this ticket, with the wrong
+    alpaca_order_id."""
+    assert _recoverable_qty(_o(), _TICKET) == 67
+    assert _recoverable_qty(_o(client_order_id="SOMEONE-ELSE"), _TICKET) is None
+    unkeyed = _o()
+    del unkeyed["client_order_id"]
+    assert _recoverable_qty(unkeyed, _TICKET) is None   # cannot prove which order
+
+    _seed(fund_db)
+    broker = _Holding(client_order_id="a3f90000-0000-4000-8000-0000000000ff")
+    assert recover_lost_orders(fund_db, clock=sim_clock, broker=broker) == 0
+    assert _counts(fund_db) == (0, 0)
+    assert _codes(fund_db) == ["order_recovery_mismatch"]
+    assert fund_db.execute("SELECT status FROM tickets").fetchone()["status"] == "open"
+
+
+def test_unparseable_qty_is_a_mismatch_and_never_raises(fund_db, sim_clock):
+    """The docstring promises None, so 'nan' and 'inf' must deny, not raise:
+    a raise reaches the caller's blanket except and files
+    order_recovery_failed — 'could not be checked against the broker' — for a
+    payload that was checked fine and simply did not match."""
+    for bad in ("nan", "NaN", "inf", "-inf", "-1", ""):
+        assert _recoverable_qty(_o(qty=bad), _TICKET) is None
+
+    _seed(fund_db)
+    assert recover_lost_orders(fund_db, clock=sim_clock,
+                               broker=_Holding(qty="nan")) == 0
+    assert _counts(fund_db) == (0, 0)
+    assert _codes(fund_db) == ["order_recovery_mismatch"]
+
+
+def test_qty_coercion_is_no_laxer_than_its_sibling_coercers(fund_db, sim_clock):
+    """gate/tickets.py:_as_share_count rejects bool and requires .isdigit();
+    orchestrator/protection.py:_qty rejects bool. A bool reaching here would
+    record a 1-share trade nobody placed."""
+    assert _recoverable_qty(_o(qty=67), _TICKET) == 67       # the plain case
+    assert _recoverable_qty(_o(qty=True), _TICKET) is None
+    assert _recoverable_qty(_o(qty="  67  "), _TICKET) is None
+    assert _recoverable_qty(_o(qty="6_7"), _TICKET) is None
+
+    _seed(fund_db)
+    assert recover_lost_orders(fund_db, clock=sim_clock,
+                               broker=_Holding(qty=True)) == 0
+    assert _counts(fund_db) == (0, 0)
+    assert _codes(fund_db) == ["order_recovery_mismatch"]
+    assert fund_db.execute("SELECT status FROM tickets").fetchone()["status"] == "open"
+
+
+# --- the write must actually land -------------------------------------------
+
+def test_dropped_insert_neither_consumes_the_ticket_nor_claims_success(
+        fund_db, sim_clock):
+    """orders.alpaca_order_id is TEXT UNIQUE. When the broker's id is already
+    in the books the INSERT OR IGNORE is dropped silently — and consuming the
+    ticket on that would remove it from open_tickets_without_orders FOREVER,
+    leaving a live broker order with no row anywhere, while the alert claims
+    it was recorded. Fail closed: alert, leave the ticket open."""
+    _seed(fund_db)                                   # TID / NVDA, still open
+    _seed(fund_db, tid=TID2, ticker="AMD")           # TID2 already recorded
+    fund_db.execute("UPDATE tickets SET status='consumed' WHERE id=?", (TID2,))
+    fund_db.execute(
+        "INSERT INTO orders (client_order_id, alpaca_order_id, symbol, side,"
+        " qty, status, submitted_at) VALUES (?,?,'AMD','buy',67,'submitted',?)",
+        (TID2, "alp-0001", iso(sim_clock.now())))     # same id _Holding returns
+    fund_db.commit()
+
+    assert recover_lost_orders(fund_db, clock=sim_clock, broker=_Holding()) == 0
+    assert [r["client_order_id"] for r in fund_db.execute(
+        "SELECT client_order_id FROM orders")] == [TID2]
+    assert fund_db.execute("SELECT status FROM tickets WHERE id=?",
+                           (TID,)).fetchone()["status"] == "open"
+    codes = _codes(fund_db)
+    assert codes == ["order_recovery_unwritable"]
+    assert "order_recovered" not in codes
+
+
+# --- one issue per ticket, not one per code ---------------------------------
+
+def _alerts(conn):
+    return [json.loads(r["payload"]) for r in conn.execute(
+        "SELECT payload FROM events WHERE kind='alert' ORDER BY id")]
+
+
+def test_two_mismatching_tickets_alert_with_their_own_ticker(fund_db, sim_clock):
+    """scripts/file_alert_issues.py groups on ("alert:{code}",
+    "ticker:{ticker}") and SKIPS a group whose labels already have an open
+    issue. With no ticker= the second ticket's mismatch is filed as a
+    duplicate of the first and silently dropped — on the one path meant to
+    catch an order the fund cannot account for."""
+    _seed(fund_db)                                   # NVDA
+    _seed(fund_db, tid=TID2, ticker="AMD")           # AMD
+
+    class _OverCap:
+        def get_order_by_client_order_id(self, coid):
+            return {"id": f"alp-{coid[-2:]}", "client_order_id": coid,
+                    "symbol": "NVDA" if coid == TID else "AMD", "side": "buy",
+                    "qty": "99", "status": "accepted", "filled_qty": "0",
+                    "filled_avg_price": None}
+
+    assert recover_lost_orders(fund_db, clock=sim_clock, broker=_OverCap()) == 0
+    alerts = _alerts(fund_db)
+    assert [a["code"] for a in alerts] == ["order_recovery_mismatch"] * 2
+    assert sorted(a["ticker"] for a in alerts) == ["AMD", "NVDA"]
+
+
+def test_recovered_and_failed_alerts_both_carry_their_ticker(fund_db, sim_clock):
+    _seed(fund_db)                                   # NVDA — the broker raises
+    _seed(fund_db, tid=TID2, ticker="AMD")           # AMD  — recovers
+
+    class _RaisesOnTheFirst:
+        def get_order_by_client_order_id(self, coid):
+            if coid == TID:
+                raise TimeoutError("gateway timeout")
+            return {"id": "alp-0002", "client_order_id": TID2, "symbol": "AMD",
+                    "side": "buy", "qty": "67", "status": "accepted",
+                    "filled_qty": "0", "filled_avg_price": None}
+
+    assert recover_lost_orders(fund_db, clock=sim_clock,
+                               broker=_RaisesOnTheFirst()) == 1
+    by_code = {a["code"]: a for a in _alerts(fund_db)}
+    assert by_code["order_recovery_failed"]["ticker"] == "NVDA"
+    assert by_code["order_recovered"]["ticker"] == "AMD"
+
+
+# --- the CAS gate ------------------------------------------------------------
+
+class _ConsumesTheTicketMidWrite:
+    """A connection that consumes the ticket between the order INSERT and the
+    ticket CAS. Nothing inside one process can move a ticket under this loop —
+    the predicate selected it as 'open' and only this loop touches it — so a
+    concurrent writer is the only way to reach the losing branch of the CAS,
+    and this stands in for one. Delegates everything else to the real
+    connection; recover_lost_orders and everything it calls reach SQLite only
+    through .execute/.commit."""
+
+    def __init__(self, conn, tid):
+        self._conn, self._tid, self._armed = conn, tid, True
+
+    def execute(self, sql, params=()):
+        cur = self._conn.execute(sql, params)
+        if self._armed and sql.startswith("INSERT OR IGNORE INTO orders"):
+            self._armed = False
+            self._conn.execute("UPDATE tickets SET status='consumed'"
+                               " WHERE id=?", (self._tid,))
+            self._conn.commit()
+        return cur
+
+    def __getattr__(self, name):
+        return getattr(self._conn, name)
+
+
+def test_alert_and_count_fire_only_when_the_ticket_cas_wins(fund_db, sim_clock):
+    """The recovery alert says a human should look at a recorder that failed,
+    and the return value promises it cannot over-count. Both hang off the CAS
+    winning — so a run that loses the CAS must announce nothing and count
+    nothing, even though its INSERT landed."""
+    _seed(fund_db)
+    conn = _ConsumesTheTicketMidWrite(fund_db, TID)
+    assert recover_lost_orders(conn, clock=sim_clock, broker=_Holding()) == 0
+    assert fund_db.execute(
+        "SELECT COUNT(*) c FROM orders").fetchone()["c"] == 1   # the row landed
+    assert "order_recovered" not in _codes(fund_db)
+
+
 # --- scope ------------------------------------------------------------------
 
 def test_consumed_ticket_is_never_revisited(fund_db, sim_clock):

--- a/tests/test_order_recovery.py
+++ b/tests/test_order_recovery.py
@@ -126,6 +126,11 @@ def test_port_without_the_lookup_method_recovers_nothing_silently(fund_db, sim_c
 
 
 def test_raising_broker_alerts_and_leaves_the_ticket_open(fund_db, sim_clock):
+    """The ticket is left open, but the alert must NOT promise a retry: there
+    is none. run_execution calls expire_open_tickets first and unscoped by
+    date, so tomorrow's execution stage sweeps this ticket open->expired
+    before tomorrow's reconciliation stage can look at it again. An operator
+    told to wait for the next run waits forever."""
     _seed(fund_db)
     assert recover_lost_orders(fund_db, clock=sim_clock,
                                broker=_Unreachable()) == 0
@@ -134,6 +139,9 @@ def test_raising_broker_alerts_and_leaves_the_ticket_open(fund_db, sim_clock):
     alert = fund_db.execute(
         "SELECT payload FROM events WHERE kind='alert'").fetchone()
     assert "ConnectionError" in alert["payload"]
+    text = json.loads(alert["payload"])["text"]
+    assert "will NOT be retried" in text and "by hand" in text
+    assert "next run" not in text
     assert fund_db.execute("SELECT status FROM tickets").fetchone()["status"] == "open"
 
 

--- a/tests/test_tickets.py
+++ b/tests/test_tickets.py
@@ -8,16 +8,20 @@ NOW = "2026-07-06T15:30:00+00:00"        # 11:30 ET on the golden day
 EXPIRY = "2026-07-06T16:00:00+00:00"     # ticket expiry
 LATER = "2026-07-06T16:00:01+00:00"      # 1s past expiry
 TID = "a3f90000-0000-4000-8000-000000000001"
+TID2 = "a3f90000-0000-4000-8000-000000000002"
 
 
-def _seed(conn, *, stop_price=None, expires=EXPIRY, max_qty=67, tid=TID):
+def _seed(conn, *, stop_price=None, expires=EXPIRY, max_qty=67, tid=TID,
+          ticker="NVDA", run_date="2026-07-06"):
+    # decisions is UNIQUE(run_date, ticker), so a second ticket on the same
+    # ticker is by definition a different day's decision.
     cur = conn.execute(
         "INSERT INTO decisions (run_date, ticker, action, qty, thesis,"
         " invalidation, stop_price, status, created_at) VALUES"
-        " ('2026-07-06', 'NVDA', 'buy', 80, 't', 'i', ?, 'approved', ?)",
-        (stop_price, NOW))
+        " (?, ?, 'buy', 80, 't', 'i', ?, 'approved', ?)",
+        (run_date, ticker, stop_price, NOW))
     conn.commit()
-    create_ticket(conn, id=tid, decision_id=cur.lastrowid, ticker="NVDA",
+    create_ticket(conn, id=tid, decision_id=cur.lastrowid, ticker=ticker,
                   side="buy", max_qty=max_qty, stop_price=stop_price,
                   expires_at_iso=expires, now_iso=NOW)
     return cur.lastrowid
@@ -331,11 +335,11 @@ def test_order_class_is_denied_before_time_in_force(fund_db):
 
 # ---- open_tickets_without_orders: "did this ticket produce an order?" ----
 
-def _place(conn, tid=TID):
+def _place(conn, tid=TID, symbol="NVDA"):
     conn.execute(
         "INSERT INTO orders (client_order_id, symbol, side, qty, status,"
-        " submitted_at) VALUES (?, 'NVDA', 'buy', 67, 'submitted', ?)",
-        (tid, NOW))
+        " submitted_at) VALUES (?, ?, 'buy', 67, 'submitted', ?)",
+        (tid, symbol, NOW))
     conn.commit()
 
 
@@ -372,3 +376,35 @@ def test_a_past_ttl_ticket_is_still_returned_where_open_tickets_is_empty(fund_db
     _seed(fund_db)
     assert open_tickets(fund_db, LATER) == []
     assert [t["id"] for t in open_tickets_without_orders(fund_db)] == [TID]
+
+
+def test_only_the_ticket_with_no_order_of_its_own_is_returned(fund_db):
+    """Two live tickets, one order. Every other test here holds a single
+    ticker, which cannot tell a per-ticket answer from a per-symbol one."""
+    _seed(fund_db)                              # NVDA, order placed
+    _place(fund_db)
+    _seed(fund_db, ticker="AMD", tid=TID2)      # AMD, nothing placed
+    assert [t["id"] for t in open_tickets_without_orders(fund_db)] == [TID2]
+
+
+def test_a_ticket_is_not_suppressed_by_another_tickets_same_symbol_order(fund_db):
+    """The join key is the ticket ID, not the symbol (invariant 5:
+    orders.client_order_id IS the ticket id). Yesterday's NVDA order is keyed
+    by yesterday's ticket and says nothing about whether today's NVDA ticket
+    was placed. Correlating on o.symbol = t.ticker instead still passes every
+    single-ticker test in this file while silently deleting today's ticket
+    from the answer — the exact suppression issue #40 exists to surface."""
+    _seed(fund_db, run_date="2026-07-03")       # yesterday's ticket...
+    _place(fund_db)                             # ...and its NVDA order row
+    fund_db.execute("UPDATE tickets SET status='consumed' WHERE id=?", (TID,))
+    fund_db.commit()
+    _seed(fund_db, tid=TID2)                    # today's NVDA ticket, no order
+    assert [t["id"] for t in open_tickets_without_orders(fund_db)] == [TID2]
+
+
+def test_the_predicate_returns_only_the_repair_fields(fund_db):
+    """Narrow on purpose: the ticket a repair pass would re-place, and what
+    that ticket authorizes. No field here is without a reader."""
+    _seed(fund_db)
+    assert sorted(open_tickets_without_orders(fund_db)[0]) == [
+        "id", "max_qty", "side", "ticker"]

--- a/tests/test_tickets.py
+++ b/tests/test_tickets.py
@@ -1,7 +1,8 @@
 import pytest
 
 from gate.tickets import (create_ticket, expire_open_tickets, get_ticket,
-                          open_tickets, validate_order)
+                          open_tickets, open_tickets_without_orders,
+                          validate_order)
 
 NOW = "2026-07-06T15:30:00+00:00"        # 11:30 ET on the golden day
 EXPIRY = "2026-07-06T16:00:00+00:00"     # ticket expiry
@@ -326,3 +327,48 @@ def test_order_class_is_denied_before_time_in_force(fund_db):
         time_in_force="day"), NOW)
     assert not ok
     assert "oto" in reason
+
+
+# ---- open_tickets_without_orders: "did this ticket produce an order?" ----
+
+def _place(conn, tid=TID):
+    conn.execute(
+        "INSERT INTO orders (client_order_id, symbol, side, qty, status,"
+        " submitted_at) VALUES (?, 'NVDA', 'buy', 67, 'submitted', ?)",
+        (tid, NOW))
+    conn.commit()
+
+
+def test_an_open_ticket_with_no_order_is_returned(fund_db):
+    _seed(fund_db)
+    assert [t["id"] for t in open_tickets_without_orders(fund_db)] == [TID]
+
+
+def test_a_ticket_with_an_order_row_is_excluded(fund_db):
+    """invariant 5: orders.client_order_id IS the ticket id, so the existence
+    of that row is the whole answer to "did the turn place it?"."""
+    _seed(fund_db)
+    _place(fund_db)
+    assert open_tickets_without_orders(fund_db) == []
+
+
+@pytest.mark.parametrize("status", ["consumed", "expired"])
+def test_a_ticket_that_is_no_longer_open_is_excluded(fund_db, status):
+    """Only status='open' is a ticket the turn still owed an order for; a
+    consumed or already-swept one is settled business."""
+    _seed(fund_db)
+    fund_db.execute("UPDATE tickets SET status=? WHERE id=?", (status, TID))
+    fund_db.commit()
+    assert open_tickets_without_orders(fund_db) == []
+
+
+def test_a_past_ttl_ticket_is_still_returned_where_open_tickets_is_empty(fund_db):
+    """The point of the function (issue #40). open_tickets filters on the
+    clock — correct for "what may the trader still act on?", pinned above at
+    test_open_tickets_excludes_expired_even_before_sweep. But a turn that
+    overruns the TTL leaves a ticket still status='open' with no order, and
+    that filter deletes exactly that row from the answer. This question has no
+    clock in it, so the signature has no clock in it either."""
+    _seed(fund_db)
+    assert open_tickets(fund_db, LATER) == []
+    assert [t["id"] for t in open_tickets_without_orders(fund_db)] == [TID]


### PR DESCRIPTION
Closes the same-day half of #40: an order that fills at the broker while its `place_*` response is lost no longer leaves SQLite recording that nothing traded.

## The bug

The `orders` row is written by a **PostToolUse hook** — submit-then-write. `_extract_order` returns `None` for any payload carrying `error` or `code`, so a placement that **landed at the broker** but whose response was lost (gateway 504), or came back as the duplicate-`client_order_id` 422 that `specs/contracts.md` §5.1 says to *treat as success*, writes no row and never consumes the ticket. `reconcile_orders` selects only `FROM orders`, so it cannot see what has no row.

## What this does

A ticket-driven repair pass in the **existing** reconciliation stage. For every ticket still `status='open'` with no `orders` row, it asks the broker `get_order_by_client_order_id` and records what it finds.

It **records only** — at `'submitted'`, then hands off. `reconcile_orders` runs next in the same stage body and drives the fill, the events and the decision through its already-tested `_apply`. That is deliberate: a recovered order must behave *identically* to a normally-recorded one, or retry semantics later have to be defined over two behaviours instead of one.

**Verified rather than asserted.** Both situations were built in a real DB — one order recorded by the hook, one recovered by this pass, same broker answer — and compared column by column across `filled`, `rejected`, `canceled` and `canceled-after-partial`. `status`, `symbol`, `side`, `qty`, `filled_qty`, `filled_avg_price`, `closed_at`, ticket status, decision status and every emitted event match. Only the two ids differ.

Two adjacent holes closed on the way:

- **TTL filter.** `_alert_unexecuted_tickets` used `open_tickets`, whose time filter is right for *"what may the trader still act on?"* and wrong for *"what did the turn fail to place?"* — it deleted exactly the ticket whose TTL passed *during* the turn. It now keys on status via a clock-free predicate.
- **Crash resume.** `expire_open_tickets` sat *outside* the execution stage body, so a resumed day whose checkpoint was already `done` skipped the turn, the alert and every repair path while still finalizing ticket **and** decision to `expired` — and there is no legal edge out of `expired`.

## What this does NOT fix — stated in the code, not just here

**The pass gets one attempt, at the reconciliation stage of the day the ticket opened.** If it fails, the next day's `expire_open_tickets` — unscoped by date, running at the top of the execution body — sweeps the ticket before recovery sees it again. Traced across three days: day 1 alerts, days 2 and 3 emit nothing, final state `ticket=expired decision=expired orders=0` against a real filled position.

The docstring and the `order_recovery_failed` alert now say so. They previously promised *"left open for the next run"*, which was false in the way that matters — an operator reads it and waits.

- **#55** is the completing fix (recovery reaching an `expired` ticket — needs a state-machine widening, held for a human ruling).
- **#74** is the amplifier: `get_order_by_client_order_id` swallows every exception with the comment `# fail closed; poll retries` — a precondition true for `reconcile_orders` and false for this caller — so against the real adapter a broker outage is indistinguishable from "the turn placed nothing".

A strict improvement on those terms: it repairs the common case and makes the remaining hole honest rather than advertised as covered.

## Ops note

A recovered day now **exits non-zero** (the recorder failing is a fault a human should see). The permanently-red-masks-the-next-failure concern does not apply — a recovery is *episodic* and clears, not *permanent until reconciled*.

Also: a second same-day `run_execution` no longer expires a stuck ticket, so a duplicate manual `audit_day` run shows a red that master would have cleared. No effect on the normal single-pass day driven by `run_day.py`.

## Invariants

`state/schema.sql`, `state/transition.py`, `orchestrator/protection.py`, `market/source_alpaca.py`, `tests/fake_alpaca.py` and `scripts/audit_day.py` are **untouched** (empty diff vs master). No `EDGES` change, no schema change, no FK relaxation, no new `BrokerPort` method, no new stage — the stage-name set is diffed against master and identical. `run_stage` and `run_execution` are untouched; `orchestrator/daily.py`'s entire delta since the expiry fix is one import line and one call-site line.

No existing test was weakened, deleted or re-recorded. One alert-text expectation changed, because the behaviour it pinned was corrected.

`1213 passed, 1 skipped, 7 deselected`. Purity lint and alert-code lint both clean.

## Review history

Two adversarial review rounds, both using mutation testing. Round one found two properties whose tests passed under mutation (the expiry-before-alert ordering, and the predicate's join key — every test used NVDA for both ticket and order, so a same-symbol match was indistinguishable from a same-id match). Round two found that the pass got one attempt ever, and an unchecked `INSERT OR IGNORE` that consumed the ticket and reported success while the row was silently dropped. All fixed and mutation-verified.
