### PR TITLE
fix: validate the positions payload before the gate sizes the day (#39)

### DIFF
--- a/market/source_alpaca.py
+++ b/market/source_alpaca.py
@@ -176,7 +176,7 @@ class AlpacaSource:
             # within one response, which could never disagree with itself.
             #
             # Excludes short_market_value, which is correct only while the
-            # fund is long-only (specs/design.md:21, protection.py:42-45) and
+            # fund is long-only (specs/design.md:21, protection.py:41-44) and
             # becomes wrong the day shorting lands: a short book would report
             # a non-zero market value with a legitimately empty LONG list.
             #

--- a/market/source_alpaca.py
+++ b/market/source_alpaca.py
@@ -167,6 +167,29 @@ class AlpacaSource:
             # the percentage to recover the denominator would report a figure
             # derived from a different pair of numbers than the gate's.
             "last_equity": _safe_float(a.last_equity),
+            # The discriminator orchestrator/ingest_guard.py reads: an EMPTY
+            # positions list is ambiguous (a flat account and a dropped
+            # payload look identical), and this is the broker's own answer to
+            # which one it is. It works as a discriminator only because
+            # get_account() and get_all_positions() above are TWO INDEPENDENT
+            # API calls — this is a cross-call check, not a consistency check
+            # within one response, which could never disagree with itself.
+            #
+            # Excludes short_market_value, which is correct only while the
+            # fund is long-only (specs/design.md:21, protection.py:42-45) and
+            # becomes wrong the day shorting lands: a short book would report
+            # a non-zero market value with a legitimately empty LONG list.
+            #
+            # Plain attribute, not getattr(a, ..., None) — see the type pin in
+            # tests. Two different failures, and only one of them is loud: an
+            # alpaca-py RENAME raises AttributeError here, which guarded()
+            # turns into an alert and exit 1 (HOLD), and the offline pin test
+            # catches it before deploy. Alpaca dropping the field FROM THE
+            # WIRE is silent: alpaca-py 0.44.0 declares it `str | None`
+            # defaulting to None, so it arrives as None -> NaN -> the records
+            # tie-breaker in ingest_guard. Safe, but quiet; getattr with a
+            # default would make the loud case quiet too, for no gain.
+            "long_market_value": _safe_float(a.long_market_value),
             "daily_pnl_pct": _pnl_pct(a.equity, a.last_equity),
             "positions": {p.symbol: int(float(p.qty)) for p in pos},
             "prices": {p.symbol: float(p.current_price) for p in pos},

--- a/market/source_alpaca.py
+++ b/market/source_alpaca.py
@@ -176,7 +176,8 @@ class AlpacaSource:
             # within one response, which could never disagree with itself.
             #
             # Excludes short_market_value, which is correct only while the
-            # fund is long-only (specs/design.md:21, protection.py:41-44) and
+            # fund is long-only (specs/design.md:21, _CLOSING_SIDE at
+            # protection.py:41-44) and
             # becomes wrong the day shorting lands: a short book would report
             # a non-zero market value with a legitimately empty LONG list.
             #

--- a/orchestrator/ingest_guard.py
+++ b/orchestrator/ingest_guard.py
@@ -5,7 +5,7 @@ scripts/run_day.py reads the account ONCE, at the top of the day, and every
 gate input for every ticker is computed from that one payload. A positions
 list that comes back EMPTY therefore does not fail — it sizes. held_qty 0, so
 no sell is possible; position_count 0; an empty correlation book, which
-market/features.py:83 correctly scores at the most permissive 1.10x tier;
+market/features.py:81-83 correctly scores at the most permissive 1.10x tier;
 sector book value 0. The day trades UP, on a book it cannot see, and the
 holdings it does have cannot be exited.
 
@@ -38,16 +38,50 @@ SETTINGS, not identity, so a fresh paper account passes it today.
 
 The fund's own records WOULD catch that class, and they are still only the
 tie-breaker below. That is deliberate, and the reason is one line of SQL:
-recorded_holdings (protection.py:284-289) selects every order ever placed with
+recorded_holdings (protection.py:290-291) selects every order ever placed with
 NO DATE FILTER. A stop that fires on day 5 leaves those rows forever, so a
 records-first guard refuses day 6 and every day after until a human edits the
 table. Buying the #64 class costs a fund that can never trade again.
+
+THE COST OF THE TIE-BREAKER, WHICH THE PARAGRAPH ABOVE DOES NOT ADMIT
+---------------------------------------------------------------------
+That argument is aimed at a records-FIRST guard, but the unreadable branch
+below is records-deciding, and the same SQL indicts it. A position closed by
+a fired OTO stop leg is never netted out: the exit has no `orders` row by
+construction (make_order_recorder, agents/runtime.py:211-227, writes one row
+per place_* TOOL RESPONSE, and a broker-fired stop leg is not one), and an
+untickered row cannot be inserted anyway — orders.client_order_id REFERENCES
+tickets(id) (state/schema.sql:85) under PRAGMA foreign_keys = ON
+(state/db.py:22). So the records stay net-long forever on a position the fund
+no longer holds.
+
+The arming condition is therefore permanently true and structurally
+unclearable. The fund is one optional-field outage away from a total halt at
+all times, and stays halted for the duration of that outage. (Issue #39
+reports exactly this state on the production book: one NVDA buy row, all
+time, against a broker showing 40 after the stop fired.)
+
+The halt ITSELF is clearable — restore long_market_value and the next run
+proceeds — and that is the real difference from the records-first design
+rejected above, which offers no escape at any price. What is not clearable is
+the standing exposure to it. Both halves are load-bearing; either alone
+misleads.
+
+Foreseeable rather than hypothetical: alpaca-py 0.44.0 declares
+long_market_value as `str | None` defaulting to None, so the vendor's own
+contract says the field may be absent. tests/test_source_alpaca_helpers.py
+pins that, and fails if a later version makes it required.
+
+None of this argues for trading on an unreadable discriminator. Invariant 4
+puts ambiguity at HOLD, and sizing a day on a book nothing can confirm is the
+direction this pipeline must never fail. It argues only that the exposure
+should be known before an outage introduces it.
 
 Not caught here either: a PARTIAL payload (some positions listed, some
 dropped) — issue #63. Detecting one needs a tolerance, a tolerance is a
 threshold, and invariant 3 makes thresholds human-commit decisions.
 
-Deliberately NOT here: any per-symbol comparison. protection.py:352-357
+Deliberately NOT here: any per-symbol comparison. protection.py:356-361
 settled that direction — the broker is the authority on what is held, the
 fund's records on what the fund DID — and reversing it would halt the fund on
 every hand-placed intervention its alerts ask for.
@@ -62,7 +96,7 @@ positions concept, so the day is AUDIT CLEAN"), so a fix whose own end state
 is "absent from the audit" looks like it repeats the mistake.
 
 It does not. append_alert (slackkit/outbox.py:33) writes through _insert to
-INSERT INTO events (kind, payload, created_at) (outbox.py:21-22), so the alert
+INSERT INTO events (kind, payload, created_at) (outbox.py:21-23), so the alert
 is durably in SQLite, not only in Slack — the day is recorded in the source of
 truth, satisfying invariant 6 rather than skirting it. And append_alert's own
 docstring makes `code` "what scripts/file_alert_issues.py keys a GitHub issue
@@ -118,10 +152,10 @@ def payload_fault(account: dict, recorded: dict[str, int]) -> str | None:
     The broker's own long_market_value settles it for the class this module
     catches — see the module docstring for the class it does not. The fund's
     records cannot lead here: an OTO stop leg has no `orders` row by
-    construction (protection.py:347), so a fund stopped out overnight has
+    construction (protection.py:351), so a fund stopped out overnight has
     non-empty records and an honestly empty book — the state
     tests/test_protection.py:530 pins as alert-once-and-keep-trading. And
-    recorded_holdings has no date filter (protection.py:284-289), so halting
+    recorded_holdings has no date filter (protection.py:290-291), so halting
     on records alone would halt that day and every day after it, until a human
     edits the orders table. A fund that never trades again is not the safe
     direction, it is a different outage.
@@ -182,7 +216,7 @@ def account_snapshot(conn: sqlite3.Connection, *, source, now_iso: str,
     the case where the broker answers, plausibly, and is wrong needs this
     module.
 
-    One nap and one re-read before refusing, for the reason protection.py:405
+    One nap and one re-read before refusing, for the reason protection.py:413
     naps: a buy that just filled is recorded before the broker lists the
     position. A FIRST run of the day has placed no orders and cannot hit that
     race; a RESUMED run reads the account again after the execution stage

--- a/orchestrator/ingest_guard.py
+++ b/orchestrator/ingest_guard.py
@@ -130,8 +130,6 @@ def _as_dollars(value) -> float | None:
     parse. Cousin of protection.py:_qty, which coerces SHARE counts and so
     rejects fractions and zero; a market value is legitimately fractional and
     legitimately zero, and zero is the answer that matters most here."""
-    if isinstance(value, bool):
-        return None
     try:
         n = float(value)
     except (TypeError, ValueError):

--- a/orchestrator/ingest_guard.py
+++ b/orchestrator/ingest_guard.py
@@ -1,0 +1,165 @@
+"""Guard on the positions payload the whole trading day is sized from
+(issue #39, 2026-08-25).
+
+scripts/run_day.py reads the account ONCE, at the top of the day, and every
+gate input for every ticker is computed from that one payload. A positions
+list that comes back EMPTY therefore does not fail — it sizes. held_qty 0, so
+no sell is possible; position_count 0; an empty correlation book, which
+market/features.py:83 correctly scores at the most permissive 1.10x tier;
+sector book value 0. The day trades UP, on a book it cannot see, and the
+holdings it does have cannot be exited.
+
+The 1.85x mis-sizing issue #39 reports is from a WHAT-IF run against a
+recorded account, not an observed production incident. The defect is real and
+reachable; the number is a simulation. Do not cite it as a measured event.
+
+orchestrator/protection.py already compares the broker against the fund's own
+records — but at the CLOSE stage, hours after the gate sized the day. This is
+the same seam read at INGESTION, and with the opposite consequence:
+protection alerts and lets the day finish, this refuses the day (invariant 4).
+
+WHAT THIS CATCHES, AND WHAT IT DOES NOT
+---------------------------------------
+market/source_alpaca.py:161-162 makes TWO independent API calls against ONE
+broker backend, and the account's long_market_value is derived from the same
+position store the positions list is read from. So this catches a fault
+BETWEEN the two reads — transport, serialization, a dropped or truncated
+response — because that is the class where they disagree.
+
+It does NOT catch a fault at or below the position store, where both reads
+agree and are both wrong: a wrong ALPACA_API_KEY pointing at a different or
+fresh paper account, an account reset, a backend that lost the positions.
+Those return a self-consistent positions=[] + long_market_value=0, this reads
+"genuinely flat", and the day trades. That class is issue #64 ("The fund never
+verifies it is talking to the account it thinks it is") and belongs in the
+daily preconditions pass, not here — identity needs one field against one
+pinned value and no tolerance. orchestrator/preconditions.py:46 pins account
+SETTINGS, not identity, so a fresh paper account passes it today.
+
+The fund's own records WOULD catch that class, and they are still only the
+tie-breaker below. That is deliberate, and the reason is one line of SQL:
+recorded_holdings (protection.py:284-289) selects every order ever placed with
+NO DATE FILTER. A stop that fires on day 5 leaves those rows forever, so a
+records-first guard refuses day 6 and every day after until a human edits the
+table. Buying the #64 class costs a fund that can never trade again.
+
+Not caught here either: a PARTIAL payload (some positions listed, some
+dropped) — issue #63. Detecting one needs a tolerance, a tolerance is a
+threshold, and invariant 3 makes thresholds human-commit decisions.
+
+Deliberately NOT here: any per-symbol comparison. protection.py:352-357
+settled that direction — the broker is the authority on what is held, the
+fund's records on what the fund DID — and reversing it would halt the fund on
+every hand-placed intervention its alerts ask for.
+
+WHY A REFUSED DAY IS ABSENT FROM THE AUDIT, AND WHY THAT IS NOT #39 AGAIN
+-------------------------------------------------------------------------
+scripts/run_day.py returns before StageCtx is built, so report_audit never
+runs — the same shape as every other guarded() exit. The irony is worth
+naming, because the next reader will notice it: this lane exists because of a
+defect that produced an AUDIT CLEAN day (#39's body — "audit_day.py has no
+positions concept, so the day is AUDIT CLEAN"), so a fix whose own end state
+is "absent from the audit" looks like it repeats the mistake.
+
+It does not. append_alert (slackkit/outbox.py:33) writes through _insert to
+INSERT INTO events (kind, payload, created_at) (outbox.py:21-22), so the alert
+is durably in SQLite, not only in Slack — the day is recorded in the source of
+truth, satisfying invariant 6 rather than skirting it. And append_alert's own
+docstring makes `code` "what scripts/file_alert_issues.py keys a GitHub issue
+on", identical across runs, so the day carries a stable machine identity that
+can become a tracked issue on its own — a stronger trail than an audit row,
+not a weaker one.
+
+So a payload-lost day is absent from the audit, present in the source of
+truth, and carrying a machine-readable code. That is a different thing from
+#39's original defect, where the day was present in the audit and marked
+CLEAN: the audit affirmatively said nothing was wrong. Not-asserted and
+wrongly-asserted are not the same failure.
+"""
+from __future__ import annotations
+
+import math
+import sqlite3
+from typing import Callable
+
+from orchestrator.protection import recorded_holdings
+from slackkit.outbox import append_alert
+
+# One short wait before refusing a day, matching orchestrator/protection.py:35
+# and for the same reason — see account_snapshot. Deliberately a local
+# constant: this sits at a different point in the day and may diverge.
+_RETRY_S = 3.0
+
+
+def _as_dollars(value) -> float | None:
+    """The broker's dollar figure, or None if it is missing, NaN, or will not
+    parse. Cousin of protection.py:_qty, which coerces SHARE counts and so
+    rejects fractions and zero; a market value is legitimately fractional and
+    legitimately zero, and zero is the answer that matters most here."""
+    if isinstance(value, bool):
+        return None
+    try:
+        n = float(value)
+    except (TypeError, ValueError):
+        return None
+    return None if math.isnan(n) else n
+
+
+def payload_fault(account: dict, recorded: dict[str, int]) -> str | None:
+    """Why today's positions payload cannot be trusted, or None if it can.
+
+    Fires ONLY on an empty positions payload. Empty is ambiguous, and telling
+    the two cases apart is the whole of this function:
+
+      - genuinely empty — the fund has never traded, or it sold out. The
+        permissive empty-book tier is the correct answer and must be reached.
+      - lost — the account holds something and the list did not say so.
+
+    The broker's own long_market_value settles it for the class this module
+    catches — see the module docstring for the class it does not. The fund's
+    records cannot lead here: an OTO stop leg has no `orders` row by
+    construction (protection.py:347), so a fund stopped out overnight has
+    non-empty records and an honestly empty book — the state
+    tests/test_protection.py:530 pins as alert-once-and-keep-trading. And
+    recorded_holdings has no date filter (protection.py:284-289), so halting
+    on records alone would halt that day and every day after it, until a human
+    edits the orders table. A fund that never trades again is not the safe
+    direction, it is a different outage.
+
+    So a readable long_market_value of exactly 0 means flat, whatever the
+    records say. A readable non-zero means the list dropped positions the
+    account still carries. An UNREADABLE one is ambiguity, and there the
+    records are the tie-breaker: no records means nothing suggests a book
+    exists and the fund's first day must not be blocked by a broker that will
+    not report a market value; records mean HOLD.
+
+    `recorded` is recorded_holdings()' raw output, signed and unfiltered.
+    Netting to zero or below is not a holding — a fully sold symbol nets to 0
+    — so it is filtered here rather than being trusted to arrive filtered.
+    """
+    # Bare truthiness, deliberately: a missing key, None, and {} all mean
+    # "the list said nothing", which is the case this guards. (No `or {}` —
+    # it would be dead code, since {} is already falsy.)
+    if account.get("positions"):
+        return None
+
+    held_value = _as_dollars(account.get("long_market_value"))
+    if held_value == 0:
+        return None
+    if held_value is not None:
+        return (f"the broker returned NO positions while reporting"
+                f" {held_value} of long market value — the positions payload"
+                " was lost, not empty. Sizing the day on it would compute"
+                " every gate input against a book that is not there and make"
+                " every sell impossible, so no stage ran and nothing traded."
+                " Re-run once the broker lists positions again")
+
+    book = {s: q for s, q in recorded.items() if q > 0}
+    if not book:
+        return None
+    holdings = ", ".join(f"{s} {q}" for s, q in sorted(book.items()))
+    return ("the broker returned NO positions and no readable long market"
+            f" value, while the fund's own filled orders account for"
+            f" {holdings} — whether the book is empty or the payload was lost"
+            " cannot be established, so no stage ran and nothing traded"
+            " (invariant 4)")

--- a/orchestrator/ingest_guard.py
+++ b/orchestrator/ingest_guard.py
@@ -5,9 +5,9 @@ scripts/run_day.py reads the account ONCE, at the top of the day, and every
 gate input for every ticker is computed from that one payload. A positions
 list that comes back EMPTY therefore does not fail — it sizes. held_qty 0, so
 no sell is possible; position_count 0; an empty correlation book, which
-market/features.py:81-83 correctly scores at the most permissive 1.10x tier;
-sector book value 0. The day trades UP, on a book it cannot see, and the
-holdings it does have cannot be exited.
+avg_corr_vs_book (market/features.py:81-83) correctly scores at the most
+permissive 1.10x tier; sector book value 0. The day trades UP, on a book it
+cannot see, and the holdings it does have cannot be exited.
 
 The 1.85x mis-sizing issue #39 reports is from a WHAT-IF run against a
 recorded account, not an observed production incident. The defect is real and
@@ -20,9 +20,10 @@ protection alerts and lets the day finish, this refuses the day (invariant 4).
 
 WHAT THIS CATCHES, AND WHAT IT DOES NOT
 ---------------------------------------
-market/source_alpaca.py:161-162 makes TWO independent API calls against ONE
-broker backend, and the account's long_market_value is derived from the same
-position store the positions list is read from. So this catches a fault
+AlpacaSource.account_state (market/source_alpaca.py:161-162) makes TWO
+independent API calls against ONE broker backend, and the account's
+long_market_value is derived from the same position store the positions list
+is read from. So this catches a fault
 BETWEEN the two reads — transport, serialization, a dropped or truncated
 response — because that is the class where they disagree.
 
@@ -33,8 +34,9 @@ Those return a self-consistent positions=[] + long_market_value=0, this reads
 "genuinely flat", and the day trades. That class is issue #64 ("The fund never
 verifies it is talking to the account it thinks it is") and belongs in the
 daily preconditions pass, not here — identity needs one field against one
-pinned value and no tolerance. orchestrator/preconditions.py:46 pins account
-SETTINGS, not identity, so a fresh paper account passes it today.
+pinned value and no tolerance. assert_account_config_unchanged
+(orchestrator/preconditions.py:46) pins account SETTINGS, not identity, so a
+fresh paper account passes it today.
 
 The fund's own records WOULD catch that class, and they are still only the
 tie-breaker below. That is deliberate, and the reason is one line of SQL:
@@ -57,9 +59,13 @@ no longer holds.
 
 The arming condition is therefore permanently true and structurally
 unclearable. The fund is one optional-field outage away from a total halt at
-all times, and stays halted for the duration of that outage. (Issue #39
-reports exactly this state on the production book: one NVDA buy row, all
-time, against a broker showing 40 after the stop fired.)
+all times, and stays halted for the duration of that outage.
+
+Measured, not inferred: on backups-from-vm/fund-2026-08-24.sqlite the `orders`
+table holds ONE row for all time — NVDA buy 80, filled, filled_qty 80 — so
+recorded_holdings returns {NVDA: 80}, while a direct broker read the same week
+showed 40 after the stop fired. The branch is armed on the production book as
+of that date, and nothing in the schema can disarm it.
 
 The halt ITSELF is clearable — restore long_market_value and the next run
 proceeds — and that is the real difference from the records-first design
@@ -81,10 +87,10 @@ Not caught here either: a PARTIAL payload (some positions listed, some
 dropped) — issue #63. Detecting one needs a tolerance, a tolerance is a
 threshold, and invariant 3 makes thresholds human-commit decisions.
 
-Deliberately NOT here: any per-symbol comparison. protection.py:356-361
-settled that direction — the broker is the authority on what is held, the
-fund's records on what the fund DID — and reversing it would halt the fund on
-every hand-placed intervention its alerts ask for.
+Deliberately NOT here: any per-symbol comparison. assert_positions_accounted
+(protection.py:356-361) settled that direction — the broker is the authority
+on what is held, the fund's records on what the fund DID — and reversing it
+would halt the fund on every hand-placed intervention its alerts ask for.
 
 WHY A REFUSED DAY IS ABSENT FROM THE AUDIT, AND WHY THAT IS NOT #39 AGAIN
 -------------------------------------------------------------------------
@@ -119,9 +125,10 @@ from typing import Callable
 from orchestrator.protection import recorded_holdings
 from slackkit.outbox import append_alert
 
-# One short wait before refusing a day, matching orchestrator/protection.py:35
-# and for the same reason — see account_snapshot. Deliberately a local
-# constant: this sits at a different point in the day and may diverge.
+# One short wait before refusing a day, matching _RETRY_S
+# (orchestrator/protection.py:35) and for the same reason — see
+# account_snapshot. Deliberately a local constant: this sits at a different
+# point in the day and may diverge.
 _RETRY_S = 3.0
 
 
@@ -150,9 +157,11 @@ def payload_fault(account: dict, recorded: dict[str, int]) -> str | None:
     The broker's own long_market_value settles it for the class this module
     catches — see the module docstring for the class it does not. The fund's
     records cannot lead here: an OTO stop leg has no `orders` row by
-    construction (protection.py:351), so a fund stopped out overnight has
-    non-empty records and an honestly empty book — the state
-    tests/test_protection.py:530 pins as alert-once-and-keep-trading. And
+    construction (assert_positions_accounted's docstring, protection.py:351),
+    so a fund stopped out overnight has non-empty records and an honestly
+    empty book — the state pinned as alert-once-and-keep-trading by
+    test_a_recorded_buy_the_broker_no_longer_holds_alerts
+    (tests/test_protection.py:530). And
     recorded_holdings has no date filter (protection.py:290-291), so halting
     on records alone would halt that day and every day after it, until a human
     edits the orders table. A fund that never trades again is not the safe
@@ -214,10 +223,11 @@ def account_snapshot(conn: sqlite3.Connection, *, source, now_iso: str,
     the case where the broker answers, plausibly, and is wrong needs this
     module.
 
-    One nap and one re-read before refusing, for the reason protection.py:413
-    naps: a buy that just filled is recorded before the broker lists the
-    position. A FIRST run of the day has placed no orders and cannot hit that
-    race; a RESUMED run reads the account again after the execution stage
+    One nap and one re-read before refusing, for the reason
+    assert_positions_accounted (protection.py:413) naps: a buy that just
+    filled is recorded before the broker lists the position. A FIRST run of
+    the day has placed no orders and cannot hit that race; a RESUMED run
+    reads the account again after the execution stage
     already filled something, and it can. Three seconds is a cheap price for
     not killing a trading day over a settle lag, and it is only ever paid on
     the path that is about to refuse.

--- a/orchestrator/ingest_guard.py
+++ b/orchestrator/ingest_guard.py
@@ -163,3 +163,50 @@ def payload_fault(account: dict, recorded: dict[str, int]) -> str | None:
             f" {holdings} — whether the book is empty or the payload was lost"
             " cannot be established, so no stage ran and nothing traded"
             " (invariant 4)")
+
+
+def account_snapshot(conn: sqlite3.Connection, *, source, now_iso: str,
+                     sleep: Callable[[float], None] | None = None
+                     ) -> dict | None:
+    """The account the day may trade on, or None — the positions payload could
+    not be trusted, an alert is appended, and no stage may run.
+
+    None rather than a raise. The caller has to drain the outbox before it
+    exits, and a raise would land in scripts/run_day.py's guarded(), which
+    records every failure under the single code `run_day_failed` — the code
+    scripts/file_alert_issues.py keys its GitHub issue on. A lost positions
+    payload has its own operator response and deserves its own code.
+
+    A broker read that RAISES is deliberately not caught: guarded() already
+    turns it into an alert, a drain and exit 1, which is the same HOLD. Only
+    the case where the broker answers, plausibly, and is wrong needs this
+    module.
+
+    One nap and one re-read before refusing, for the reason protection.py:405
+    naps: a buy that just filled is recorded before the broker lists the
+    position. A FIRST run of the day has placed no orders and cannot hit that
+    race; a RESUMED run reads the account again after the execution stage
+    already filled something, and it can. Three seconds is a cheap price for
+    not killing a trading day over a settle lag, and it is only ever paid on
+    the path that is about to refuse.
+
+    The re-read replaces the whole account, and the FRESH one is what the day
+    is sized from. Validating a fresh payload and sizing on the stale one
+    would be this same bug wearing a guard.
+    """
+    nap = sleep or (lambda _s: None)
+    recorded = recorded_holdings(conn)
+
+    account = source.account_state()
+    fault = payload_fault(account, recorded)
+    if fault is None:
+        return account
+
+    nap(_RETRY_S)
+    account = source.account_state()
+    fault = payload_fault(account, recorded)
+    if fault is None:
+        return account
+
+    append_alert(conn, "positions_payload_lost", fault, now_iso=now_iso)
+    return None

--- a/orchestrator/protection.py
+++ b/orchestrator/protection.py
@@ -270,13 +270,18 @@ def assert_positions_protected(conn: sqlite3.Connection, *, broker,
 # --- the mirror: shares the records account for that the broker does not hold -
 
 
-def _recorded_holdings(conn: sqlite3.Connection) -> dict[str, int]:
+def recorded_holdings(conn: sqlite3.Connection) -> dict[str, int]:
     """Net shares per symbol the fund's OWN order records account for.
 
     THE SEAM. The fund stores no position — `state/schema.sql` has no positions
     table — so what it holds is *implied* by its filled orders. If a later
     design stores that fact directly, swap this one read; nothing above it
     changes.
+
+    Public because orchestrator/ingest_guard.py reads it too: the same seam
+    answers "is the fund's book empty?" at ingestion and "does the broker
+    still hold what we opened?" at the close. Two readers of one seam is the
+    point of naming it a seam.
 
     `filled_qty > 0` rather than `status = 'filled'`, for the same reason
     _promised_stop does it: reconcile.py records a timed-out partial as
@@ -377,7 +382,7 @@ def assert_positions_accounted(conn: sqlite3.Connection, *, broker,
         append_alert(conn, "accounting_unverified", text, now_iso=now_iso)
         return 1
 
-    recorded = {s: q for s, q in _recorded_holdings(conn).items() if q > 0}
+    recorded = {s: q for s, q in recorded_holdings(conn).items() if q > 0}
     if not recorded:
         return 0
 

--- a/scripts/run_day.py
+++ b/scripts/run_day.py
@@ -72,6 +72,7 @@ from market.features import (build_market_inputs, unmapped_holdings,  # noqa: E4
 from orchestrator.clock import et_run_date, iso                    # noqa: E402
 from orchestrator.daily import (StageCtx, allowed_actions,        # noqa: E402
                                 run_day)
+from orchestrator.ingest_guard import account_snapshot             # noqa: E402
 from orchestrator.preconditions import assert_account_config_unchanged  # noqa: E402
 from slackkit.outbox import append_alert, drain                    # noqa: E402
 from state.db import connect                                       # noqa: E402
@@ -520,7 +521,21 @@ def _trading_day(conn, slack, clock, source, run_date: str, db_path: str,
 
     watchlist = load_watchlist(WATCHLIST_YAML)
     sectors = yaml.safe_load(SECTORS_YAML.read_text()) or {}
-    account = source.account_state()
+    # The gate sizes the ENTIRE day from this one payload, so it is validated
+    # before anything reads it: an empty positions list does not fail
+    # downstream, it sizes (held_qty 0 blocks every sell, the empty book takes
+    # the permissive correlation tier). None means the payload could not be
+    # trusted; the alert is already appended and no stage may run.
+    account = account_snapshot(conn, source=source, now_iso=iso(clock.now()),
+                               sleep=time.sleep)
+    if account is None:
+        # Drained here because run_day drains per stage and no stage will run,
+        # so the alert would otherwise sit in the outbox until the next day —
+        # the same reason the account-config precondition drains explicitly.
+        log("ALERT positions_payload_lost — the broker's positions payload"
+            " could not be trusted; no stages run, nothing traded (exit 1)")
+        drain(conn, slack, iso(clock.now()))
+        return 1
     universe = sorted(set(watchlist) | set(account.get("positions") or {}))
     close_df = source.close_frame(universe, end=pd.Timestamp(clock.now()))
     alert_missing_price_history(conn, clock, close_df,

--- a/tests/test_ingest_guard.py
+++ b/tests/test_ingest_guard.py
@@ -28,7 +28,8 @@ def test_a_populated_payload_is_trusted():
 
 
 def test_a_per_symbol_disagreement_is_not_a_fault_here():
-    """The direction orchestrator/protection.py:356-361 already settled: the
+    """The direction assert_positions_accounted
+    (orchestrator/protection.py:356-361) already settled: the
     broker is the authority on what is held, and this lane does not reverse
     it. Records say 80, the broker shows 40 — assert_positions_accounted
     alerts once at the close and the day trades. Halting here would stop the
@@ -41,15 +42,18 @@ def test_a_per_symbol_disagreement_is_not_a_fault_here():
 def test_the_genuinely_empty_first_day_is_trusted():
     """The fund has never traded. No records, and the broker says it carries
     no long value. market/features.py's empty-book 1.10x tier is the CORRECT
-    answer here (tests/test_features.py:335) and must keep being reached."""
+    answer here (test_an_empty_book_sizes_at_the_permissive_tier,
+    tests/test_features.py:335) and must keep being reached."""
     assert payload_fault(_account({}, 0.0), {}) is None
 
 
 def test_a_flat_broker_is_trusted_even_when_the_records_disagree():
     """The false positive that a records-only detector would ship. An OTO stop
-    leg has no `orders` row by construction (protection.py:351), so a fund
+    leg has no `orders` row by construction (assert_positions_accounted's
+    docstring, protection.py:351), so a fund
     stopped out overnight has non-empty records and an honestly empty book —
-    the state tests/test_protection.py:530 pins as alert-once-and-keep-
+    the state test_a_recorded_buy_the_broker_no_longer_holds_alerts
+    (tests/test_protection.py:530) pins as alert-once-and-keep-
     trading. Halting on it would halt every day after it too, because the
     condition is permanent until a human reconciles."""
     assert payload_fault(_account({}, 0.0), {"NVDA": 80}) is None

--- a/tests/test_ingest_guard.py
+++ b/tests/test_ingest_guard.py
@@ -28,7 +28,7 @@ def test_a_populated_payload_is_trusted():
 
 
 def test_a_per_symbol_disagreement_is_not_a_fault_here():
-    """The direction orchestrator/protection.py:352-357 already settled: the
+    """The direction orchestrator/protection.py:356-361 already settled: the
     broker is the authority on what is held, and this lane does not reverse
     it. Records say 80, the broker shows 40 — assert_positions_accounted
     alerts once at the close and the day trades. Halting here would stop the
@@ -47,7 +47,7 @@ def test_the_genuinely_empty_first_day_is_trusted():
 
 def test_a_flat_broker_is_trusted_even_when_the_records_disagree():
     """The false positive that a records-only detector would ship. An OTO stop
-    leg has no `orders` row by construction (protection.py:347), so a fund
+    leg has no `orders` row by construction (protection.py:351), so a fund
     stopped out overnight has non-empty records and an honestly empty book —
     the state tests/test_protection.py:530 pins as alert-once-and-keep-
     trading. Halting on it would halt every day after it too, because the

--- a/tests/test_ingest_guard.py
+++ b/tests/test_ingest_guard.py
@@ -1,0 +1,112 @@
+"""Offline tests for the ingestion guard on the broker's positions payload
+(issue #39).
+
+The defect: scripts/run_day.py reads the account once, at the top of the day,
+and every gate input for every ticker is computed from that one payload. An
+EMPTY positions list does not fail — it sizes: held_qty 0 so no sell is
+possible, position_count 0, an empty correlation book (the 1.10x tier), sector
+book value 0. The day trades up, on a book it cannot see.
+"""
+
+from __future__ import annotations
+
+from orchestrator.ingest_guard import payload_fault
+
+
+def _account(positions=None, long_market_value=0.0, **extra) -> dict:
+    """account_state()'s shape, minus the keys this guard never reads."""
+    return {"equity": 100_000.0, "cash": 30_000.0, "last_equity": 100_000.0,
+            "daily_pnl_pct": 0.0, "prices": {},
+            "positions": positions if positions is not None else {},
+            "long_market_value": long_market_value, **extra}
+
+
+# ---- a payload that lists positions is never this module's business --------
+
+def test_a_populated_payload_is_trusted():
+    assert payload_fault(_account({"NVDA": 40}, 8_594.0), {"NVDA": 40}) is None
+
+
+def test_a_per_symbol_disagreement_is_not_a_fault_here():
+    """The direction orchestrator/protection.py:352-357 already settled: the
+    broker is the authority on what is held, and this lane does not reverse
+    it. Records say 80, the broker shows 40 — assert_positions_accounted
+    alerts once at the close and the day trades. Halting here would stop the
+    fund on every hand-placed intervention those alerts exist to ask for."""
+    assert payload_fault(_account({"NVDA": 40}, 8_594.0), {"NVDA": 80}) is None
+
+
+# ---- an empty payload: the whole design is telling the two cases apart -----
+
+def test_the_genuinely_empty_first_day_is_trusted():
+    """The fund has never traded. No records, and the broker says it carries
+    no long value. market/features.py's empty-book 1.10x tier is the CORRECT
+    answer here (tests/test_features.py:335) and must keep being reached."""
+    assert payload_fault(_account({}, 0.0), {}) is None
+
+
+def test_a_flat_broker_is_trusted_even_when_the_records_disagree():
+    """The false positive that a records-only detector would ship. An OTO stop
+    leg has no `orders` row by construction (protection.py:347), so a fund
+    stopped out overnight has non-empty records and an honestly empty book —
+    the state tests/test_protection.py:530 pins as alert-once-and-keep-
+    trading. Halting on it would halt every day after it too, because the
+    condition is permanent until a human reconciles."""
+    assert payload_fault(_account({}, 0.0), {"NVDA": 80}) is None
+
+
+def test_an_empty_payload_on_a_funded_book_is_a_fault():
+    """The issue-39 case. The broker reports long market value and lists no
+    positions: the payload was lost, not empty."""
+    fault = payload_fault(_account({}, 8_594.0), {"NVDA": 80})
+    assert fault is not None
+    assert "8594" in fault              # the operator needs the actual number
+    assert "no positions" in fault.lower()
+
+
+def test_a_lost_payload_is_a_fault_even_with_no_records_to_corroborate():
+    """A position opened by hand has no `orders` row, so records cannot
+    corroborate. The broker's own market value is enough on its own."""
+    assert payload_fault(_account({}, 8_594.0), {}) is not None
+
+
+# ---- the unreadable case: records are the tie-breaker ----------------------
+
+def test_an_unreadable_market_value_with_records_is_a_fault():
+    """Ambiguity resolves to no action (invariant 4): we cannot tell an empty
+    book from a lost payload, and the fund's own orders say it holds
+    something."""
+    fault = payload_fault(_account({}, float("nan")), {"NVDA": 80})
+    assert fault is not None
+    assert "NVDA" in fault and "80" in fault
+
+
+def test_a_missing_market_value_key_reads_as_unreadable():
+    account = _account({}, 0.0)
+    del account["long_market_value"]
+    assert payload_fault(account, {"NVDA": 80}) is not None
+    assert payload_fault(account, {}) is None
+
+
+def test_an_unreadable_market_value_with_no_records_is_trusted():
+    """The fund's first day must not be blocked by a broker that will not
+    report a market value. Nothing anywhere suggests a book exists."""
+    assert payload_fault(_account({}, float("nan")), {}) is None
+
+
+def test_records_that_net_to_zero_or_below_are_not_a_book():
+    """recorded_holdings signs by side and does not filter; a fully sold
+    symbol nets to 0 and a mis-recorded one can net negative. Neither is a
+    holding, and neither may block a day."""
+    account = _account({}, float("nan"))
+    assert payload_fault(account, {"NVDA": 0}) is None
+    assert payload_fault(account, {"NVDA": -5}) is None
+    assert payload_fault(account, {"NVDA": 0, "AAPL": 10}) is not None
+
+
+def test_a_none_positions_value_reads_as_empty():
+    """account.get('positions') can be absent or None on a degraded payload;
+    both mean 'the list said nothing', which is the case this guards."""
+    account = _account({}, 8_594.0)
+    account["positions"] = None
+    assert payload_fault(account, {}) is not None

--- a/tests/test_ingest_guard.py
+++ b/tests/test_ingest_guard.py
@@ -10,7 +10,7 @@ book value 0. The day trades up, on a book it cannot see.
 
 from __future__ import annotations
 
-from orchestrator.ingest_guard import payload_fault
+from orchestrator.ingest_guard import account_snapshot, payload_fault
 
 
 def _account(positions=None, long_market_value=0.0, **extra) -> dict:
@@ -110,3 +110,145 @@ def test_a_none_positions_value_reads_as_empty():
     account = _account({}, 8_594.0)
     account["positions"] = None
     assert payload_fault(account, {}) is not None
+
+
+# ---- account_snapshot: read, nap once, re-read, refuse ---------------------
+
+import json
+
+import pytest
+
+NOW = "2026-08-25T13:30:00+00:00"
+
+
+class _Source:
+    """A broker that answers account_state() from a scripted queue. The queue
+    is popped per call, so a test can hand a stale payload first and a settled
+    one second — the resumed-day settle lag account_snapshot naps for."""
+
+    def __init__(self, *states):
+        self.states = list(states)
+        self.calls = 0
+
+    def account_state(self) -> dict:
+        self.calls += 1
+        return self.states[min(self.calls - 1, len(self.states) - 1)]
+
+
+@pytest.fixture
+def naps():
+    recorded: list[float] = []
+    return recorded, recorded.append
+
+
+def _alerts(conn) -> list[dict]:
+    return [json.loads(r["payload"]) for r in conn.execute(
+        "SELECT payload FROM events WHERE kind = 'alert' ORDER BY id")]
+
+
+def _filled_buy(conn, symbol="NVDA", qty=80,
+                tid="a3f90000-0000-4000-8000-000000000001",
+                submitted_at="2026-08-17T19:59:00+00:00"):
+    """A filled buy and the ticket behind it. `orders.client_order_id`
+    REFERENCES tickets(id) with foreign keys ON (state/db.py:22), so an order
+    row cannot exist without one — this mirrors tests/test_protection.py's
+    _promised for the same reason."""
+    cur = conn.execute(
+        "INSERT INTO decisions (run_date, ticker, action, qty, thesis,"
+        " invalidation, stop_price, status, created_at) VALUES"
+        " (?, ?, 'buy', ?, 't', 'i', NULL, 'executed', ?)",
+        (submitted_at[:10], symbol, qty, submitted_at))
+    conn.execute(
+        "INSERT INTO tickets (id, decision_id, ticker, side, max_qty,"
+        " stop_price, expires_at, status, created_at)"
+        " VALUES (?, ?, ?, 'buy', ?, NULL, ?, 'consumed', ?)",
+        (tid, cur.lastrowid, symbol, qty, submitted_at, submitted_at))
+    conn.execute(
+        "INSERT INTO orders (client_order_id, symbol, side, qty, status,"
+        " filled_qty, submitted_at) VALUES (?, ?, 'buy', ?, 'filled', ?, ?)",
+        (tid, symbol, qty, qty, submitted_at))
+    conn.commit()
+
+
+def test_a_trusted_payload_is_returned_without_napping(fund_db, naps):
+    """The happy path pays nothing for the retry: one broker read, no wait."""
+    recorded, sleep = naps
+    source = _Source(_account({"NVDA": 40}, 8_594.0))
+    assert account_snapshot(fund_db, source=source, now_iso=NOW,
+                            sleep=sleep) is source.states[0]
+    assert source.calls == 1
+    assert recorded == []
+    assert _alerts(fund_db) == []
+
+
+def test_the_genuinely_empty_first_day_is_returned(fund_db, naps):
+    """No orders, no long market value, no positions — the fund's first day.
+    It must reach the stages, or the 1.10x empty-book tier can never be used."""
+    recorded, sleep = naps
+    source = _Source(_account({}, 0.0))
+    assert account_snapshot(fund_db, source=source, now_iso=NOW,
+                            sleep=sleep) is source.states[0]
+    assert _alerts(fund_db) == []
+
+
+def test_a_payload_that_settles_on_the_re_read_returns_the_FRESH_account(
+        fund_db, naps):
+    """A buy that just filled is recorded before the broker lists the
+    position. The point of the re-read is not merely to avoid the alert — it
+    is that the day must then be sized on the payload that HAS the position,
+    never on the stale empty one that passed the second look by luck."""
+    recorded, sleep = naps
+    _filled_buy(fund_db)
+    stale, fresh = _account({}, 8_594.0), _account({"NVDA": 80}, 17_188.0)
+    source = _Source(stale, fresh)
+    assert account_snapshot(fund_db, source=source, now_iso=NOW,
+                            sleep=sleep) is fresh
+    assert source.calls == 2
+    assert recorded == [3.0]
+    assert _alerts(fund_db) == []
+
+
+def test_a_payload_still_lost_after_the_re_read_refuses_the_day(fund_db, naps):
+    """Issue #39's case (a): the DB has filled positions, the broker returns
+    no positions, and the account is not flat. HOLD, with an alert that names
+    itself so scripts/file_alert_issues.py can key an issue on it."""
+    recorded, sleep = naps
+    _filled_buy(fund_db)
+    source = _Source(_account({}, 8_594.0))
+    assert account_snapshot(fund_db, source=source, now_iso=NOW,
+                            sleep=sleep) is None
+    assert source.calls == 2
+    assert recorded == [3.0]
+    payloads = _alerts(fund_db)
+    assert len(payloads) == 1
+    assert payloads[0]["code"] == "positions_payload_lost"
+    assert "nothing traded" in payloads[0]["text"]
+
+
+def test_a_broker_read_that_raises_is_not_swallowed(fund_db, naps):
+    """Unlike protection.py, this one must NOT turn a broker failure into an
+    alert-and-continue: the day has not started, and scripts/run_day.py's
+    guarded() already turns a raise here into an alert, a drain and exit 1 —
+    which is the same HOLD, recorded under the code that fits it."""
+    _, sleep = naps
+
+    class Dead:
+        def account_state(self):
+            raise ConnectionError("alpaca trading api unreachable")
+
+    with pytest.raises(ConnectionError):
+        account_snapshot(fund_db, source=Dead(), now_iso=NOW, sleep=sleep)
+
+
+def test_the_sleep_argument_is_optional(fund_db):
+    """An offline caller passes nothing and still gets the retry path — the
+    same two reads and the same verdict — with a no-op nap.
+
+    Named for what it checks. It does NOT prove no wall-clock wait occurred,
+    and no unit test here can: that property is enforced statically instead,
+    by scripts/check_purity.py, which forbids time.sleep() anywhere in
+    orchestrator/. The default literally cannot be a real sleep."""
+    _filled_buy(fund_db)
+    source = _Source(_account({}, 8_594.0))
+    assert account_snapshot(fund_db, source=source, now_iso=NOW) is None
+    assert source.calls == 2        # the retry ran, with the default nap

--- a/tests/test_run_day.py
+++ b/tests/test_run_day.py
@@ -277,7 +277,15 @@ class _DeadDataSource:
 
     def account_state(self) -> dict:
         return {"equity": 100000.0, "cash": 30000.0, "positions": {},
-                "position_count": 0, "daily_pnl_pct": 0.0}
+                "position_count": 0, "daily_pnl_pct": 0.0,
+                # Explicitly flat, not merely silent. Without this key
+                # orchestrator/ingest_guard.py reads the field as UNREADABLE
+                # and falls through to the fund's own order records, which
+                # this fixture's DB happens to have none of — so the day
+                # would run by accident, and would start halting the moment
+                # anyone gave the `wired` fixture an `orders` row. This
+                # fixture must fail at close_frame, not before it.
+                "long_market_value": 0.0}
 
     def close_frame(self, universe, end=None):
         raise ConnectionError("alpaca data api unreachable")
@@ -630,7 +638,16 @@ class _QuietSource:
 
     def account_state(self) -> dict:
         return {"equity": 100000.0, "cash": 0.0, "positions": {},
-                "prices": {}, "daily_pnl_pct": 0.0}
+                "prices": {}, "daily_pnl_pct": 0.0,
+                # Explicitly flat, not merely silent. Without this key
+                # orchestrator/ingest_guard.py reads the field as UNREADABLE
+                # and falls through to the fund's own order records, which
+                # this fixture's DB happens to have none of — so the day
+                # would run by accident, and would start halting the moment
+                # anyone gave the `wired` fixture an `orders` row. Zero cash
+                # and zero long market value is the state this docstring
+                # already claims.
+                "long_market_value": 0.0}
 
     def close_frame(self, universe, end=None):
         import pandas as pd
@@ -729,6 +746,117 @@ def test_a_zero_ticker_day_writes_no_decisions_and_costs_nothing(
     for table in ("signals", "decisions", "tickets", "costs", "orders"):
         assert conn.execute(f"SELECT COUNT(*) c FROM {table}"
                             ).fetchone()["c"] == 0, table
+
+
+# --- the positions payload the whole day is sized from (issue #39) ----------
+
+class _LostPayloadSource(_QuietSource):
+    """The broker answers, plausibly, and is wrong: it reports long market
+    value and lists no positions. Everything else about the day is fine, which
+    is the point — nothing downstream would notice.
+
+    Keeps _QuietSource's zero cash on purpose. It is not what this test is
+    about, and a funded account would make every ticker active, open three
+    seat turns, and bury the assertion under seat_turn_failed noise."""
+
+    def account_state(self) -> dict:
+        return {"equity": 100000.0, "cash": 0.0, "last_equity": 100000.0,
+                "long_market_value": 8594.0, "positions": {}, "prices": {},
+                "daily_pnl_pct": 0.0}
+
+
+class _FlatSource(_QuietSource):
+    """The fund's genuinely-empty first day, said explicitly: no positions AND
+    the broker's own long market value is zero. Identical to _QuietSource
+    post-change; kept as its own name so the test that reads it says what it
+    is testing."""
+
+    def account_state(self) -> dict:
+        return {"equity": 100000.0, "cash": 0.0, "last_equity": 100000.0,
+                "long_market_value": 0.0, "positions": {}, "prices": {},
+                "daily_pnl_pct": 0.0}
+
+
+def _filled_buy_row(conn, symbol="NVDA", qty=80,
+                    tid="a3f90000-0000-4000-8000-000000000001",
+                    submitted_at="2026-07-02T19:59:00+00:00"):
+    """A filled buy and the ticket behind it — the fund's own record that it
+    holds something. Returns the ticket id, so a caller can tell the row it
+    seeded apart from one the day minted."""
+    cur = conn.execute(
+        "INSERT INTO decisions (run_date, ticker, action, qty, thesis,"
+        " invalidation, stop_price, status, created_at) VALUES"
+        " (?, ?, 'buy', ?, 't', 'i', NULL, 'executed', ?)",
+        (submitted_at[:10], symbol, qty, submitted_at))
+    conn.execute(
+        "INSERT INTO tickets (id, decision_id, ticker, side, max_qty,"
+        " stop_price, expires_at, status, created_at)"
+        " VALUES (?, ?, ?, 'buy', ?, NULL, ?, 'consumed', ?)",
+        (tid, cur.lastrowid, symbol, qty, submitted_at, submitted_at))
+    conn.execute(
+        "INSERT INTO orders (client_order_id, symbol, side, qty, status,"
+        " filled_qty, submitted_at) VALUES (?, ?, 'buy', ?, 'filled', ?, ?)",
+        (tid, symbol, qty, qty, submitted_at))
+    conn.commit()
+    return tid
+
+
+def test_a_lost_positions_payload_holds_the_whole_day(wired, tmp_path,
+                                                      monkeypatch):
+    """Issue #39 case (a). The fund's records hold filled positions, the broker
+    returns none, and the account is not flat. Nothing may be sized from that
+    payload: no checkpoint, no seat turn, no ticket — and #risk must be told
+    under a code the alert filer can key an issue on."""
+    conn, slack, clock = wired
+    seeded = _filled_buy_row(conn)
+
+    async def _no_llm(*a, **k):
+        raise AssertionError("a held day must open no seat session")
+
+    monkeypatch.setattr(run_day_script, "_seat_session", _no_llm)
+
+    code = run_day_script._trading_day(
+        conn, slack, clock, _LostPayloadSource(), "2026-07-06",
+        str(tmp_path / "fund.sqlite"),
+        {"FUND_JOURNALS": str(tmp_path / "journals")})
+
+    assert code == 1
+    assert conn.execute(
+        "SELECT COUNT(*) c FROM checkpoints").fetchone()["c"] == 0
+    # Not a count of zero: orders.client_order_id REFERENCES tickets(id), so
+    # the seeded fill above CANNOT exist without a ticket row. Naming the
+    # seeded id is the stronger claim anyway — the day minted nothing of its
+    # own, and a ticket from any other source would fail this too.
+    assert [r["id"] for r in conn.execute("SELECT id FROM tickets")] == [seeded]
+    payloads = _alert_payloads(conn)
+    assert [p["code"] for p in payloads] == ["positions_payload_lost"]
+    assert any("long market value" in t for t in _risk_texts(slack))
+
+
+def test_a_genuinely_empty_first_day_still_trades(wired, tmp_path, monkeypatch):
+    """Issue #39 case (b), and the constraint the whole design bends around.
+    A flat broker and an empty book are the fund's normal first day: every
+    stage must still run, and market/features.py's 1.10x empty-book tier
+    (tests/test_features.py:335) must still be reachable."""
+    conn, slack, clock = wired
+
+    async def _no_llm(*a, **k):
+        raise AssertionError("a zero-ticker day must open no seat session")
+
+    monkeypatch.setattr(run_day_script, "_seat_session", _no_llm)
+
+    code = run_day_script._trading_day(
+        conn, slack, clock, _FlatSource(), "2026-07-06",
+        str(tmp_path / "fund.sqlite"),
+        {"FUND_JOURNALS": str(tmp_path / "journals")})
+
+    assert code == 0
+    assert [p["code"] for p in _alert_payloads(conn)
+            if p["code"] == "positions_payload_lost"] == []
+    assert {r["stage"]: r["status"] for r in conn.execute(
+        "SELECT stage, status FROM checkpoints WHERE run_date = '2026-07-06'")
+    } == {s: "done" for s in ("pre_gate", "research", "decision", "gate",
+                              "execution", "reconciliation", "close")}
 
 
 def test_the_open_ticket_count_reaches_check_tool_calls(wired, monkeypatch):

--- a/tests/test_source_alpaca_helpers.py
+++ b/tests/test_source_alpaca_helpers.py
@@ -139,7 +139,8 @@ def test_account_state_carries_last_equity():
     numbers the circuit breaker does."""
     class Trading:
         def get_account(self):
-            return _Clock(equity="101500", last_equity="101000", cash="30000")
+            return _Clock(equity="101500", last_equity="101000", cash="30000",
+                          long_market_value="71500")
         def get_all_positions(self):
             return []
 
@@ -157,7 +158,8 @@ def test_account_state_last_equity_is_nan_when_unparseable():
     a P&L computed from it fails closed instead of reporting a wrong day."""
     class Trading:
         def get_account(self):
-            return _Clock(equity="101500", last_equity=None, cash="30000")
+            return _Clock(equity="101500", last_equity=None, cash="30000",
+                          long_market_value="71500")
         def get_all_positions(self):
             return []
 
@@ -166,18 +168,83 @@ def test_account_state_last_equity_is_nan_when_unparseable():
     assert math.isnan(src.account_state()["last_equity"])
 
 
+def test_account_state_carries_long_market_value():
+    """The one number that tells an EMPTY positions payload apart from a LOST
+    one. orchestrator/ingest_guard.py refuses the day when the list is empty
+    and this is not zero: the account is carrying value the list did not
+    report, so every gate input computed from that list is a fiction."""
+    class Trading:
+        def get_account(self):
+            return _Clock(equity="101500", last_equity="101000", cash="30000",
+                          long_market_value="71500")
+        def get_all_positions(self):
+            return []
+
+    src = _bare_source()
+    src._trading = Trading()
+    assert src.account_state()["long_market_value"] == 71_500.0
+
+
+def test_account_state_long_market_value_is_nan_when_unparseable():
+    """Same posture as last_equity: NaN, not 0.0. A zero here would read as
+    'the account is flat' and license exactly the empty-book sizing this
+    field exists to block, so an unreadable value must fall through to
+    ingest_guard's records tie-breaker instead."""
+    class Trading:
+        def get_account(self):
+            return _Clock(equity="101500", last_equity="101000", cash="30000",
+                          long_market_value=None)
+        def get_all_positions(self):
+            return []
+
+    src = _bare_source()
+    src._trading = Trading()
+    assert math.isnan(src.account_state()["long_market_value"])
+
+
 # ---- open_positions / open_orders: the protection assertion's broker reads ----
 
 def test_installed_alpaca_py_exposes_the_read_apis_we_call():
     """Same posture as the cancel-wiring pin: a wrong alpaca-py method name
     can otherwise only fail LIVE, and this read is what stands between a naked
-    position and nobody noticing."""
+    position and nobody noticing. long_market_value is pinned for the same
+    reason one layer over: if the field is renamed away, account_state raises
+    at 09:00 instead of silently reporting a flat account."""
     from alpaca.trading.client import TradingClient
+    from alpaca.trading.models import TradeAccount
     from alpaca.trading.requests import GetOrdersRequest
     assert callable(TradingClient.get_all_positions)
     assert callable(TradingClient.get_orders)
     for field in ("status", "nested", "limit"):
         assert field in GetOrdersRequest.model_fields
+    assert "long_market_value" in TradeAccount.model_fields
+
+
+def test_long_market_value_is_the_type_ingest_guard_reasons_about():
+    """3374ec8's posture, applied one field over. ingest_guard's whole
+    unreadable-value branch rests on two properties of this field, and
+    neither is written down anywhere else: it arrives as a STRING (so
+    _safe_float, not float, is the right coercion), and it is OPTIONAL with
+    a None default (so Alpaca dropping it from the wire is a silent NaN, not
+    a raise — the reason account_state's comment calls that case quiet).
+
+    If a future alpaca-py makes it a float, _safe_float still works and this
+    test still passes. If it makes it REQUIRED, the silent-NaN branch becomes
+    unreachable and ingest_guard's docstring is stale — that is the change
+    worth being told about, so it is asserted rather than assumed."""
+    from alpaca.trading.models import TradeAccount
+
+    field = TradeAccount.model_fields["long_market_value"]
+    py_types = {a for a in getattr(field.annotation, "__args__",
+                                   (field.annotation,))
+                if a is not type(None)}
+    assert py_types == {str}, (
+        f"long_market_value is now {py_types}, not str — re-read"
+        " market/source_alpaca.py's coercion and ingest_guard._as_dollars")
+    assert not field.is_required() and field.default is None, (
+        "long_market_value is no longer optional-with-None — a dropped field"
+        " now raises instead of arriving as NaN, and"
+        " orchestrator/ingest_guard.py's unreadable branch is stale")
 
 
 def test_open_positions_unwraps_alpaca_enums():


### PR DESCRIPTION
Closes #39.

A lost positions payload made the risk gate maximally permissive — measured at **1.85x** sizing — while collapsing every sell to `Rejected("nothing_held")`. Both data-gap alarms iterate the same dict and go silent, so the day read AUDIT CLEAN.

## What this actually is

Most of the prescribed fix already existed. `assert_positions_accounted` (`orchestrator/protection.py:336`, wired at `orchestrator/daily.py:493`) already compares the fund's filled orders against broker positions, and **already fires on this direction**. The defect is *timing*, not coverage: `scripts/run_day.py` sizes the whole day at `:523-529`, while that check runs at the **close** stage, hours later.

So this adds an ingestion-time guard and reuses the existing seam rather than building a second reader.

## The discriminator

`long_market_value` from `get_account()` cross-checked against `positions` from `get_all_positions()` — **two independent API calls**.

| Broker positions | `long_market_value` | Verdict |
|---|---|---|
| empty | readable, `== 0` | genuinely flat -> **trade** |
| empty | readable, `!= 0` | payload lost -> **HOLD + alert** |
| empty | unreadable | fall back to the fund's own records |
| non-empty | — | out of scope (see #63) |

**The obvious detector was rejected because it ships a permanent halt.** "Records non-empty while broker empty" is pinned by `tests/test_protection.py:530` as a *legitimate* state — the stop fired, and an OTO stop leg has no `orders` row by construction. `recorded_holdings` has no date filter, so that condition never clears: a records-first guard would halt that day and every day after.

## Known residuals, all filed before this merges

- **#73** — when `long_market_value` is unreadable the records decide, and the arming condition is permanently true on the production book (one `orders` row, NVDA 80, against a broker showing 40). Shipped because invariant 4 puts ambiguity at HOLD and the failure is loud from day one.
- **#63** — partial payloads. A check is possible but needs a tolerance, and a tolerance is a threshold; invariant 3 makes those human-commit decisions.
- **#64** — the fund never verifies it is talking to the account it thinks it is.

## Scope

`orchestrator/protection.py` is **7 insertions / 2 deletions** — the `_recorded_holdings` -> `recorded_holdings` rename, its one call site, and a docstring. Consented to by #40's owner before dispatch. `tests/test_features.py`, `orchestrator/reconcile.py`, `gate/tickets.py` and `agents/runtime.py` are **untouched**. `int(float(p.qty))` is untouched, so **#32 is not foreclosed**.

## Verification

```
PURITY LINT: clean (38 files across ['gate','stratgate','fundbt','calibration','orchestrator','state'])
ALERT CODE LINT: clean (92 files across 12 packages)
1202 passed, 1 skipped, 7 deselected
```

Plan-reviewed, then branch-reviewed independently: mutation testing killed 11 of 12 mutations of the new module; the twelfth was an unreachable guard, since removed.