### PR TITLE
fix: tally failure tags per case instead of deduplicating them

### DIFF
--- a/evals/report.py
+++ b/evals/report.py
@@ -12,6 +12,7 @@ support.
 
 from __future__ import annotations
 
+from collections import Counter
 from dataclasses import dataclass
 from math import comb
 
@@ -31,7 +32,7 @@ class CaseReport:
     trials: int
     passes: int
     inconclusive: int
-    failures: list[str]
+    failures: Counter[str]   # tag -> how many trials produced it, never a set
 
     @property
     def fraction(self) -> str:
@@ -57,8 +58,14 @@ def build_report(results) -> list[CaseReport]:
             case=case, trials=len(rs),
             passes=sum(1 for r in rs if r.passed),
             inconclusive=sum(1 for r in rs if r.inconclusive),
-            failures=sorted(set(failures))))
+            failures=Counter(failures)))
     return out
+
+
+def format_failures(failures) -> str:
+    """`TAG xN`, one per sub-kind, sorted. Same idiom as `INCONCLUSIVE xN`:
+    three identical FAILs are three findings, not one."""
+    return ", ".join(f"{tag} x{n}" for tag, n in sorted(failures.items()))
 
 
 def render(reports) -> str:
@@ -66,7 +73,7 @@ def render(reports) -> str:
              "-----   ------   ------"]
     for r in reports:
         if r.failures:
-            status = ", ".join(r.failures)
+            status = format_failures(r.failures)
         elif r.inconclusive:
             status = f"INCONCLUSIVE x{r.inconclusive}"
         else:

--- a/tests/test_evals_live.py
+++ b/tests/test_evals_live.py
@@ -16,7 +16,7 @@ import pytest
 
 from evals.cases import load_cases
 from evals.grade import full_registry, grade_trace
-from evals.report import build_report, render
+from evals.report import build_report, format_failures, render
 from evals.runner import run_trial
 
 CASES = Path(__file__).resolve().parents[1] / "evals/cases/pm"
@@ -53,4 +53,5 @@ def test_pm_suite():
     failed = [r for r in reports if r.failures]
     assert not failed, (
         "Tier S failures (blocking at 3/3): "
-        + "; ".join(f"{r.case} {r.fraction} {r.failures}" for r in failed))
+        + "; ".join(f"{r.case} {r.fraction} {format_failures(r.failures)}"
+                    for r in failed))

--- a/tests/test_evals_report.py
+++ b/tests/test_evals_report.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections import Counter
+
 import pytest
 
 from evals.grade import TrialResult
@@ -35,7 +37,51 @@ def test_report_counts_passes_per_case():
     ]
     (rep,) = build_report(results)
     assert (rep.case, rep.passes, rep.trials) == ("a01", 2, 3)
-    assert rep.failures == ["I1:oversize"]
+    assert rep.failures == Counter({"I1:oversize": 1})
+
+
+def test_report_tallies_repeated_failure_tags_instead_of_deduplicating():
+    """The tag carries the sub-kind so triage can start from the report. A set
+    throws the frequency away: one wrong action and three read identically."""
+    results = [TrialResult("a03", i, "pm",
+                           [Verdict("EXPECT", "FAIL", "wrong action",
+                                    tag="wrong-action")])
+               for i in (1, 2, 3)]
+    (rep,) = build_report(results)
+    assert rep.failures == Counter({"EXPECT:wrong-action": 3})
+
+
+def test_three_identical_failures_render_differently_from_one():
+    def trials(n_failing):
+        return [TrialResult("a03", i, "pm",
+                            [Verdict("EXPECT", "FAIL", "wrong action",
+                                     tag="wrong-action")
+                             if i <= n_failing else Verdict("EXPECT", "PASS")])
+                for i in (1, 2, 3)]
+    once = render(build_report(trials(1)))
+    thrice = render(build_report(trials(3)))
+    assert "EXPECT:wrong-action x3" in thrice
+    assert "EXPECT:wrong-action x3" not in once
+
+
+def test_render_sorts_tags_and_counts_every_one_including_a_singleton():
+    """One case, two distinct sub-kinds at different counts — the only shape
+    that exercises the sort, the separator, and the `x1` on a singleton.
+    Registry order puts I1 first, alphabetical order puts EXPECT first, so an
+    unsorted render is a different string, not the same one."""
+    oversize = Verdict("I1", "FAIL", "oversize", tag="oversize")
+    wrong = Verdict("EXPECT", "FAIL", "wrong action", tag="wrong-action")
+    results = [
+        TrialResult("a03", 1, "pm", [oversize, Verdict("EXPECT", "PASS")]),
+        TrialResult("a03", 2, "pm", [oversize, wrong]),
+        TrialResult("a03", 3, "pm", [Verdict("I1", "PASS"),
+                                     Verdict("EXPECT", "PASS")]),
+    ]
+    (rep,) = build_report(results)
+    assert list(rep.failures) == ["I1:oversize", "EXPECT:wrong-action"], \
+        "precondition: encounter order must differ from alphabetical order"
+    assert render([rep]).splitlines()[-1] == \
+        "a03      1/3     EXPECT:wrong-action x1, I1:oversize x2"
 
 
 def test_report_renders_a_fraction_never_a_percentage():


### PR DESCRIPTION
Closes the `(a)` half of #41's fix.

`evals/report.py:60` did `failures=sorted(set(failures))`, so a case's FAIL tags were deduplicated and never tallied — three identical `EXPECT:wrong-action` failures rendered as one string. `evals/verdict.py`'s `tag` field exists "so triage does not start by re-reading transcripts"; the counts are what made that true.

Against the run #41 cites, `evals/traces/primary2`:

```
before:  a03      0/3     EXPECT:wrong-action
after:   a03      0/3     EXPECT:wrong-action x3
```

## What changed

- `CaseReport.failures` is a `Counter`; `format_failures()` renders `TAG xN` sorted by tag, matching `render()`'s existing `INCONCLUSIVE xN` idiom. Always emits `xN` including `x1`, and that is pinned rather than left a convention.
- `tests/test_evals_live.py:56` interpolated the raw list into a **Tier S assertion message**. On a `Counter` it keeps working and prints `Counter({...})` into the blocking assertion — a reader that keeps working is worse than one that breaks. Now uses `format_failures`.

## Review

Written test-first (red proven by stashing the implementation), then adversarially reviewed. The review planted two mutants that the first test round did not kill — deleting `sorted()`, and suppressing `x1` — both of which left the suite green. The added test puts two distinct tags at different counts on one case, the only shape that exercises the sort, the separator and the singleton, and carries a precondition assertion so the sort fails loudly rather than silently stopping being tested.

`make test`: 1183 passed, 1 skipped.

## Not included

Deliberately scoped to `(a)`. #41's `(b)`/`(d)` are in `docs/evals-saturation-open-coding`; `(c)` is separate.

Known and untouched: `python3 -m evals.report_cli` with no arguments crashes (filed as #59), which caps where this improved column is visible today. Confirmed pre-existing by stashing this diff.