### PR TITLE
fix: refuse duplicate case ids instead of silently picking a winner

### DIFF
--- a/evals/cases.py
+++ b/evals/cases.py
@@ -82,4 +82,20 @@ def load_case(path: Path | str) -> Case:
 
 
 def load_cases(directory: Path | str) -> list[Case]:
-    return [load_case(p) for p in sorted(Path(directory).glob("*.yaml"))]
+    """Most consumers collapse this list to `{c.id: c}`, where a second file
+    reusing an id silently replaces the first case's expectation while
+    editing nothing; the rest keep the list and run that case twice. Refuse
+    rather than pick a winner."""
+    cases, seen = [], {}
+    for path in sorted(Path(directory).glob("*.yaml")):
+        case = load_case(path)
+        if case.id in seen:
+            raise ValueError(
+                f"duplicate case id {case.id!r} in {directory}:"
+                f" {seen[case.id]} and {path} — consumers that key on c.id"
+                " would take the second file's expectation for both;"
+                " consumers that keep the list would run this case twice."
+                " Give one of them a new id.")
+        seen[case.id] = path
+        cases.append(case)
+    return cases

--- a/tests/test_evals_case_ids.py
+++ b/tests/test_evals_case_ids.py
@@ -1,0 +1,77 @@
+"""Case ids are unique within a seat directory — checked for EVERY seat.
+
+`load_cases` returns a list ordered by filename. Consumers that key on `c.id`
+collapse it to `{c.id: c}`, so last one wins: a new file sorting after an
+existing one and reusing its `id:` silently replaces that case's expectation,
+editing nothing. That is the "update an expected value to make a test pass"
+CLAUDE.md forbids, performed without touching an expected value. Consumers
+that keep the list instead (scripts/eval_suite.py:60,
+scripts/dry_run_critic.py:72, most well-formedness loops) run and grade the
+shadowed case twice.
+
+The per-seat pins cannot see it, in two different disguises:
+  - tests/test_evals_cases.py:19 compares a SET of ids, and a duplicate
+    cannot change a set;
+  - the critic pins all route through `expect["verdict"]` without ever
+    pinning the vocabulary that field may take — :60-62 COUNT the canonical
+    "objections" and "clear", and :110 and :137 are equality FILTERS. A
+    shadow declaring a non-canonical verdict moves neither count and is
+    skipped by every filter, so it passes all of them. That directory was
+    unguarded, which is what issue #67 demonstrated.
+
+Neither is a check for duplicate ids, and both are per-directory. This
+enumerates the directories under evals/cases instead of naming them, so a
+third seat's set is pinned the day it lands rather than when someone
+remembers. `load_cases` raises as well, which protects call sites CI never
+runs — `scripts/critic_gate.py` is a gate invoked by hand.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from evals.cases import load_cases
+
+CASES = Path(__file__).resolve().parents[1] / "evals/cases"
+
+
+def test_load_cases_accepts_every_shipped_seat_directory():
+    """What this actually pins, now that load_cases raises: the shipped
+    directories load clean. The raise below fires first, so the uniqueness
+    assertion is unreachable in practice — it is kept as the second half of a
+    pair, so that removing the raise AND this assertion is still caught by
+    test_load_cases_refuses_a_duplicate_id."""
+    directories = sorted(p for p in CASES.iterdir() if p.is_dir())
+    assert directories, f"no seat case directories under {CASES}"
+    for directory in directories:
+        cases = load_cases(directory)
+        assert cases, f"no cases under {directory}"
+        ids = [c.id for c in cases]
+        assert len(ids) == len({c.id for c in cases}), \
+            f"{directory.name}: duplicated case ids" \
+            f" {sorted({i for i in ids if ids.count(i) > 1})}"
+
+
+def test_load_cases_refuses_a_duplicate_id(tmp_path):
+    """An operator acts on this message's text, so it pins both halves: the
+    id, and the ORDER of the two paths. The fixture ids deliberately differ
+    from their filenames — otherwise `"<id>" in message` would be satisfied
+    by the paths alone, and dropping the id from the message would go
+    unnoticed. Order matters because the message's own prose calls one file
+    "the second"; reversed, it points at the wrong file to delete."""
+    body = (CASES / "pm/b01.yaml").read_text().replace(
+        "id: b01", "id: shadow-me", 1)
+    first, second = tmp_path / "aa.yaml", tmp_path / "zz.yaml"
+    first.write_text(body)
+    second.write_text(body)
+
+    with pytest.raises(ValueError) as excinfo:
+        load_cases(tmp_path)
+
+    message = str(excinfo.value)
+    assert "shadow-me" in message, "the message must name the shadowed id"
+    assert str(first) in message and str(second) in message
+    assert message.index(str(first)) < message.index(str(second)), \
+        "the later file is the shadow; a reversed message blames the original"


### PR DESCRIPTION
Closes #67.

`load_cases()` returned a filename-sorted list with no duplicate check, and most consumers collapse it to `{c.id: c}`. **Adding a case file that sorts later and reuses an existing `id:` silently replaced that case's expectation — while editing nothing.**

Demonstrated: a copy of `evals/cases/pm/b01.yaml` with `expect` weakened makes `qty_max: {NVDA: 3}` — the sizing-discipline constraint the case exists to enforce — vanish from every consumer. Full suite green, tamper guard exit 0.

That is what CLAUDE.md's test invariants forbid (*"NEVER update a golden fixture, expected hash, or expected value to make a test pass"*), by a route no path-matching guard can see.

## Why a raise, not only a test

Uniqueness within a seat is **not a new rule**. `evals/runner.py:165` uses the id as a filesystem path component (`base / case.id / f"t{trial}"`), and `evals/grade.py:103-110` already states *"A case id identifies a case only WITHIN a seat"* — enforcing the **cross-seat** half with a descriptive `ValueError` at `:119-124`. This closes the **within-seat** half in the same idiom.

The raise matters beyond CI: `scripts/critic_gate.py:107` is a gate invoked by hand, and **a test protects what CI runs, not what a human runs**. A shadow there changes which trials the G-gate scores.

Call sites were enumerated — none legitimately loads a directory where a duplicate is meaningful.

## Why enumeration, not another per-directory pin

`tests/test_evals_case_ids.py` walks every directory under `evals/cases/`, with a guard against a vacuous pass on an empty enumeration.

Both existing pins bind one seat directory by construction, and **both were blind here for unrelated reasons**: `test_evals_cases.py:19` compares a *set* of ids, which a duplicate cannot change; every critic pin routes through `expect["verdict"]` while nothing pins that field's vocabulary, so a shadow declaring a non-canonical verdict moves neither count and is skipped by both equality filters. Neither author intended a gap. A third seat would have a third reason — a pin that must be extended by hand is a pin that will not be.

## Review

Test-first; red proven by building the shadow. Adversarially reviewed with mutation testing, which killed two surviving mutants: `assert "b01" in message` was satisfied by the *file path* even with the id removed from the raise (fixtures now carry an id differing from their filenames), and path order was unpinned, so a swap pointed an operator at the wrong file to delete.

`make test`: 1182 passed, 1 skipped.

## Left open, deliberately

**`evals/cases/critic` has no pin on the `verdict` vocabulary.** A case declaring `verdict: "objectons"` is silently excluded from every count and check, then FAILs at grade time against a value no test validated. This PR does not close it; it belongs with the same reading of the same file and is recorded on #67 rather than scattered into its own ticket.