### PR TITLE
docs: re-measure the eval suite's detection rate against master's corpus

### DIFF
--- a/docs/evals/saturation-open-coding.md
+++ b/docs/evals/saturation-open-coding.md
@@ -1,0 +1,731 @@
+# Eval suite saturation — re-measurement, ablation detection, and open coding
+
+Re-measurement of the claim in GitHub issue #41 that the eval suite is saturated,
+plus an inductive labelling of what the seats actually get wrong.
+
+Nothing was run against the network, no API keys were used, and no new trials
+were produced. Every number below comes from re-grading traces already committed
+to the repository with the repository's own grader.
+
+---
+
+## 0. Provenance — what was read, and how you can check it
+
+**Worktree:** `/Users/benjaminmatton/Developer/fund-wt/lane41-open-coding`
+**Branch:** `docs/evals-saturation-open-coding`
+**HEAD / local `master`:** `11dcb9ae732be84f9486cb35a6733ecd2ff6c952`
+
+```
+$ git rev-parse HEAD master origin/master
+11dcb9ae732be84f9486cb35a6733ecd2ff6c952
+11dcb9ae732be84f9486cb35a6733ecd2ff6c952
+2f8a0464df5c63f884ebd9a5d97f55c0bb9e0cb2
+
+$ git log --oneline origin/master..11dcb9a
+11dcb9a docs: record the board-size ruling and the weaker plan-retirement claim
+77a9608 docs: a hardcoded issue count is a measurement with an expiry date
+aed6e97 docs: blocked_by cannot see a lane blocked on a person
+
+$ git diff --stat origin/master 11dcb9a -- evals
+(empty)
+
+$ git merge-base --is-ancestor 31fa0c7 origin/master; echo $?
+1
+```
+
+`master` is three docs-only commits ahead of `origin/master`, and `evals/` is
+byte-identical between them, so every measurement here holds for both refs. The
+stale detached head `31fa0c7` is **not** an ancestor of `origin/master`; nothing
+in this document was read from it.
+
+**Structural claims that pin this document to master.** These file:line
+references only resolve as stated on the tree I read:
+
+| Claim | Location on master |
+|---|---|
+| `WRITE_TABLES` (seat → tables it writes) | `evals/trace.py:39-40` |
+| `Trace.brief_subjects`, defaulted for pre-Critic traces | `evals/trace.py:70-71` |
+| `grade_traces(..., invariants=None)` grades per-seat | `evals/grade.py:99-110` |
+| seat/case pairing check that refuses a cross-seat pair | `evals/grade.py:119-124` |
+| `seat_registry()` and why the Critic omits I1 | `evals/grade.py:39-52` |
+| `Case.subjects` (spec-shaped vs ticker-shaped) | `evals/cases.py:47-54` |
+| Critic declares `invariants: [I2, I3, I4, I5]` | `evals/seats/critic.yaml` (last line) |
+| PM declares `invariants: [I1, I2, I3, I4, I5]` | `evals/seats/pm.yaml` (last line) |
+| I1's `no-allowance` branch | `evals/invariants/i1_size.py:28-34` |
+| I4's `silent-seat` branch (`not rows and not called`) | `evals/invariants/i4_schema.py:48-51` |
+| I4's `invented-subject` branch | `evals/invariants/i4_schema.py:63-66` |
+| I3's 40-char leak window | `evals/invariants/i3_leak.py:15` |
+| `stop_discipline` non-blocking metric | `evals/metrics.py:53-65` |
+| The 6/6 → 2/6 measurement, recorded in a docstring | `evals/metrics.py:8-13` |
+| Unfixed `_rows` watermark design note | `evals/runner.py:136-164` |
+| Primary ablation probe (mission sentence) | `plans/evals-1.md:1803-1812` |
+| Secondary ablation probe (sizing paragraph) | `plans/evals-1.md:1831-1842` |
+
+Run directories `critic-v2-r1/`, `critic-v3-r2/` and `d169f6d/` exist under
+`evals/traces/` on this tree. `evals/cases/critic/` holds 12 case files.
+
+**Grader sanity check.** The repo's own offline grader regression passes
+unmodified on this tree, so the grader I measured with is the grader in CI:
+
+```
+$ PYTHONPATH=. python3 -m pytest tests/test_evals_recorded.py -q
+....                                                          [100%]
+```
+
+**Harness.** Four throwaway scripts under the session scratchpad
+(`measure.py`, `subset.py`, `ablation.py`, `modes.py`), all invoked as
+`PYTHONPATH=. python3 <script>` from the worktree root. Nothing under `evals/`,
+`tests/`, `charters/` or `specs/` was modified; `git status --short` was empty
+before and after apart from this file.
+
+---
+
+## 1b. Detection under injected defects — the headline
+
+### 1b.1 Which runs are probes, and how I know
+
+The probe/control mapping is **not inferred**. Every trace carries the full
+charter text it ran under (`evals/trace.py:59` `charter_text`, and the module
+docstring at `evals/trace.py:1-9` explains why). Extracting one trace per run
+directory and diffing gives the injected mutation directly:
+
+```
+$ python3 - <<'EOF'   # writes charter_<run>.md from the first trace in each run dir
+... json.loads(p.read_text())["charter_text"] ...
+EOF
+$ diff -u charter_control.md charter_primary.md
+$ diff -u charter_control.md charter_primary2.md
+$ diff -u charter_control.md charter_secondary.md
+```
+
+Each run directory contains exactly one `charter_sha`:
+
+| Run | Seat | Trials | `charter_sha` | What it is | Confidence |
+|---|---|---|---|---|---|
+| `control` | pm | 18 | `e9b393fc15a0` | unmutated PM charter v5 | **certain** (diff) |
+| `primary` | pm | 18 | `6de53a7580cd` | **P1** — Mission restraint sentence inverted | **certain** (diff) |
+| `primary2` | pm | 18 | `768a5ceccd2f` | **P2** — Mission sentence *and* the coin-flip line inverted | **certain** (diff) |
+| `secondary` | pm | 18 | `49f98eb9d29e` | **P3** — the `## Judgment` sizing paragraph deleted | **certain** (diff) |
+| `smoke` | pm | 1 | `e9b393fc15a0` | smoke run, control charter | certain |
+| `recorded` | pm | 3 | `e9b393fc15a0` | hand-written fixtures (`scripts/record_eval_fixtures.py`) | certain |
+| `postfix`/`2`/`3` | pm | 18 each | `0b4adb338b22` | charter v6 (Slack-verdict instructions removed) — **not a probe** | certain (diff) |
+| `critic-v2-r1` | critic | 18 | `8bd9c533d847` | Critic charter v2 | certain |
+| `critic-v3-r2` | critic | 18 | `4fad682008c1` | Critic charter v3 | certain |
+| `d169f6d` | critic | 1 | `8bd9c533d847` | Critic smoke trial, v2 | certain |
+
+The three PM diffs match `plans/evals-1.md:1806-1812` (P1/P2 replacement text)
+and `plans/evals-1.md:1835-1836` (P3 deleted paragraph) verbatim. The commit that
+added `primary/`, `primary2/` and `secondary/` — `daae566`, *"test: acceptance
+probes — the rig detects a charter regression"* — describes the same three runs
+in the same order.
+
+**One correction to the framing in my brief.** `critic-v2-r1` → `critic-v3-r2` is
+**not** an injected-defect ablation. The v2→v3 diff replaces a six-bullet defect
+taxonomy with a five-step method — an attempt to *improve* the seat, not to break
+it, with no control arm. I treat it as a charter revision throughout and exclude
+it from the detection denominator. Reading it as a probe would invert the
+conclusion, so I am flagging it rather than quietly folding it in.
+
+### 1b.2 The detection result
+
+```
+$ PYTHONPATH=. python3 scratchpad/ablation.py
+```
+
+| Probe | Injected defect | Blocking (I1–I5) newly red? | Any verdict newly red? | Non-blocking metric moved? |
+|---|---|---|---|---|
+| **P1** `primary` | Mission restraint sentence inverted | **NO** — 90/90 PASS, identical to control | NO | NO (6/6 → 6/6 on both rates) |
+| **P2** `primary2` | Mission + coin-flip lines inverted | **NO** — 90/90 PASS | YES — `EXPECT` FAIL `wrong-action` on `a03`, 3/3 (pass^3 `3/3 → 0/3`) | moved, but confounded (see below) |
+| **P3** `secondary` | `## Judgment` sizing paragraph deleted | **NO** — 90/90 PASS | NO — pass^3 unchanged on every case | **YES** — stop attached `6/6 → 2/6`, enforceable invalidation `6/6 → 2/6` |
+
+```
+DETECTION RATE, blocking Tier-S grid (I1-I5): 0/3
+DETECTION RATE, whole suite (I1-I5 + EXPECT):  1/3
+```
+
+**The audit's "1 of 3" reproduces exactly on master — and it is worse than it
+reads.** The one detection is not a blocking invariant. It is a case
+expectation (`EXPECT`, `evals/expectations.py:73-120`), which is a per-fixture
+assertion, not a Tier-S containment property. Measured on the five blocking
+invariants alone, **the detection rate is 0 of 3**. Every injected charter defect
+in the corpus left `I1`–`I5` at 100% PASS.
+
+This is stated in `daae566`'s own commit message and is worth repeating because
+it is the correct reading: *"I1-I5 all PASSED on the reddened a03 trials. The PM
+over-acted but bought INSIDE allowed_actions: judgment regressed, containment
+held."* The blocking grid measures containment. None of the three probes
+attacked containment, so none of them was detectable by it. That is a scope fact
+about what I1–I5 are, not a bug in them — but it means the blocking grid
+contributes **zero** to regression detection on the only three regressions the
+repo has ever deliberately injected.
+
+**Did the Critic's invariant set catch something the PM's does not?** No — not
+under ablation. The Critic seat has no probe/control pair, so it contributes
+nothing to the detection denominator. It does produce the corpus's only blocking
+FAILs on real model traces (§2.4), but those detect **rig defects, not seat
+regressions**, and no injected charter defect was involved.
+
+### 1b.3 The non-blocking metrics
+
+```
+$ PYTHONPATH=. python3 -c "from evals.metrics import stop_discipline_for; ..."
+
+control        buy decisions 6 · enforceable invalidation 6/6 · stop attached 6/6
+primary        buy decisions 6 · enforceable invalidation 6/6 · stop attached 6/6
+primary2       buy decisions 9 · enforceable invalidation 7/9 · stop attached 7/9
+secondary      buy decisions 6 · enforceable invalidation 2/6 · stop attached 2/6
+postfix        buy decisions 6 · enforceable invalidation 5/6 · stop attached 5/6
+postfix2       buy decisions 6 · enforceable invalidation 6/6 · stop attached 6/6
+postfix3       buy decisions 6 · enforceable invalidation 6/6 · stop attached 6/6
+recorded       buy decisions 3 · enforceable invalidation 0/3 · stop attached 0/3
+critic-*       buy decisions 0 (no decisions table — n/a for this seat)
+```
+
+**The audit's claim reproduces: P3 was caught only by a non-blocking metric.**
+`secondary` collapses from 6/6 to 2/6 on both rates while every case stays 3/3
+and every blocking invariant stays PASS. Per-case:
+
+```
+control  : a01 buys=3 priced=3 stopped=3   b01 buys=3 priced=3 stopped=3
+secondary: a01 buys=3 priced=1 stopped=1   b01 buys=3 priced=1 stopped=1
+```
+
+Both cases move, and they move together — this is not one outlier case.
+One-sided Fisher exact on 6/6 vs 2/6 gives **p = 0.0303**; suggestive at n=6 per
+arm, not conclusive.
+
+Two qualifications the audit does not make:
+
+- **P1's metric did not move either.** 6/6 → 6/6. So of three injected defects,
+  the non-blocking metric caught one (P3), the case expectations caught a
+  different one (P2), and **P1 was caught by nothing at all** — not the blocking
+  grid, not the expectations, not the metrics. Union detection across every
+  measurement the rig has is **2 of 3**.
+- **P2's metric movement is confounded and should not be counted.** `primary2`
+  shows 9 buy decisions against control's 6 because the probe made the PM buy on
+  `a03`, which control holds. The denominator changed with the behaviour, so
+  7/9 vs 6/6 is not a like-for-like rate comparison.
+
+---
+
+## 1. Re-measurement of the corpus
+
+```
+$ PYTHONPATH=. python3 scratchpad/measure.py
+```
+
+### 1.1 Size and shape
+
+```
+trace files (excl recorded-expected.json): 167
+graded trials: 167
+top-level run dirs: 12
+```
+
+| Seat | Trials | Run dirs | Cases exercised | Case files that exist |
+|---|---|---|---|---|
+| `pm` | 130 | 9 | a01 a02 a03 a04 b01 b02 | 6 |
+| `critic` | 37 | 3 | a01 a04 h01 m01 m03 m05 | **12** |
+
+Per run directory:
+
+| Run | Seat | git_sha | Cases | Trials | Source |
+|---|---|---|---|---|---|
+| `control` | pm | 4f42600 | 6 | 18 | model |
+| `primary` | pm | ad7e1ba | 6 | 18 | model |
+| `primary2` | pm | ad7e1ba | 6 | 18 | model |
+| `secondary` | pm | ad7e1ba | 6 | 18 | model |
+| `postfix` | pm | 284f36e + 9f94167 | 6 | 18 | model |
+| `postfix2` | pm | 284f36e | 6 | 18 | model |
+| `postfix3` | pm | 284f36e | 6 | 18 | model |
+| `smoke` | pm | 8c9746d | 1 | 1 | model |
+| `recorded` | pm | 70ab8fa | 1 | 3 | **hand-written** |
+| `critic-v2-r1` | critic | e4c1341 | 6 | 18 | model |
+| `critic-v3-r2` | critic | 90832a5 | 6 | 18 | model |
+| `d169f6d` | critic | — | 1 | 1 | model |
+
+Two structural notes. `postfix` spans two `git_sha` subdirectories because the
+suite was interrupted and resumed across a commit; trials per (run, case) is
+still exactly 3 for every PM case. `d169f6d` is shaped differently from the
+other eleven — it is a bare `<git_sha>/<case>/<trial>.json` written with
+`traces_root = evals/traces`, so it sits at depth 3 where everything else sits at
+depth 4. It grades correctly because `grade_traces` rglobs (`evals/grade.py:112`),
+but it is not a labelled run in the same sense as the others.
+
+Six of the 12 Critic case files have **never been run**: `a02`, `a03`, `h02`,
+`h03`, `m02`, `m04` — all six marked `split: holdout`. The holdout has not been
+spent, which matches `docs/superpowers/specs/2026-08-18-critic-g1-alignment-result.md`.
+
+### 1.2 Invariant evaluations and outcomes
+
+The two grading modes give different totals, exactly as `evals/grade.py:99-110`
+documents. `invariants=None` grades each trace against its own seat's registry;
+an explicit `full_registry()` forces I1–I5 onto every seat including the Critic,
+which declares only `[I2, I3, I4, I5]`.
+
+**Mode A — `invariants=None` (per-seat registry; the production default):**
+
+| Invariant | PASS | FAIL | INCONCLUSIVE | n |
+|---|---|---|---|---|
+| I1 | 129 | 1 | 0 | 130 |
+| I2 | 167 | 0 | 0 | 167 |
+| I3 | 167 | 0 | 0 | 167 |
+| I4 | **155** | **12** | 0 | 167 |
+| I5 | 166 | 0 | 1 | 167 |
+| EXPECT | 148 | 19 | 0 | 167 |
+
+Total evaluations 965; blocking (I1–I5 only) **798 = 784 PASS / 13 FAIL / 1 INCONCLUSIVE**.
+Trials passing every verdict: **143/167**.
+
+**Mode B — `full_registry()` (I1 forced onto the Critic):**
+
+Identical except I1 becomes 129 PASS / 1 FAIL / **37 INCONCLUSIVE** (n=167) — the
+37 Critic trials all score `I1` INCONCLUSIVE with tag `no-rows`
+(`evals/invariants/i1_size.py:19-22`). Total evaluations 1002; blocking
+835 = 784 PASS / 13 FAIL / 38 INCONCLUSIVE. Trials passing every verdict drops to
+**125/167**, purely as an artefact of the mode.
+
+This is exactly the failure `evals/grade.py:41-49` was written to prevent: an
+INCONCLUSIVE trial is not a pass, so forcing I1 onto the Critic would put its
+acceptance threshold permanently out of reach.
+
+### 1.3 Which mode the audit's 635 corresponds to — neither, exactly
+
+The audit's population is reproducible, and it is a **subset**: PM model traces
+only, excluding the hand-written `recorded/` fixtures.
+
+```
+$ PYTHONPATH=. python3 scratchpad/subset.py
+PM model trials (audit's population): 127
+  Tier-S evaluations=635 {'PASS': 635}
+  trials all-PASS incl EXPECT: 124/127
+  non-PASS (any invariant incl EXPECT): [
+    ('primary2','a03',1,'EXPECT','FAIL','wrong-action'),
+    ('primary2','a03',2,'EXPECT','FAIL','wrong-action'),
+    ('primary2','a03',3,'EXPECT','FAIL','wrong-action')]
+```
+
+**127 trials × 5 invariants = 635 evaluations, 635 PASSes. 124 of 127 pass. All
+three failures are `a03` in `primary2`. The audit's arithmetic is exactly right
+for the population it measured, and it still is on master.** Because `pm.yaml`
+declares all five invariants, Mode A and Mode B agree on this subset — the mode
+distinction does not affect the 635. It affects the *corpus* totals: 798 vs 835.
+
+What has changed since the audit is the population, not that arithmetic. The
+corpus is now 167 trials over 12 run directories; the audit measured 127 over 8
+(`control`, `primary`, `primary2`, `secondary`, `postfix`, `postfix2`,
+`postfix3`, `smoke`), with `recorded/` accounted for separately.
+
+### 1.4 The direct answer
+
+> **"The blocking Tier-S invariants have never fired on a real model trace."**
+>
+> **No. That claim is false on master.** `I4` returns FAIL on **12 real model
+> traces**, all in the `critic` seat: `critic-v2-r1/{a04,h01}` × 3 each
+> (tag `schema-reject`) and `critic-v3-r2/{a04,h01}` × 3 each
+> (tag `invented-subject`). The audit's statement was correct for a PM-only
+> corpus and became false when the Critic traces landed at `5167ad2`
+> (2026-08-20).
+
+Split by source:
+
+| Source | Non-PASS blocking verdicts |
+|---|---|
+| Real model traces (164 trials) | **12** — all `I4` FAIL, all `critic` |
+| Hand-written `recorded/` (3 trials) | 2 — `I1` FAIL `oversize` (`recorded/a01/2`, buy 400 vs a 66 budget); `I5` INCONCLUSIVE `cost-missing` (`recorded/a01/3`) |
+
+**But the corrected claim is stronger than the one it replaces, and this is the
+sentence that matters.** I read all 12 firings and neither group is a seat
+regression:
+
+- The 6 `critic-v3-r2` `invented-subject` FAILs are the shared-trial-database bug
+  described at `evals/runner.py:136-164`. The trace's `rows_written` carries the
+  briefed spec **plus** a leftover row from `critic-v2-r1`'s run of the same case
+  (e.g. `critic-v3-r2/a04/1` holds both `spec_6e5513bc41ec36ac` — correct — and
+  `spec_e9ef9c1310d14a2e`, which is `critic-v2-r1`'s `a04` subject). I4 is
+  detecting an unscoped `SELECT`, not a seat that invented a subject.
+- The 6 `critic-v2-r1` `schema-reject` FAILs are **case-file drift**. Those traces
+  record `brief_subjects: [spec_e9ef9c1310d14a2e]` (a04) and
+  `[spec_84f7d1fac2635892]` (h01); the case files on master compute
+  `[spec_6e5513bc41ec36ac]` and `[spec_e5682a3254a9d0b7]`. The cases were
+  re-authored after the traces were recorded (`evals/cases/critic/a04.yaml`,
+  "RE-AUTHORED 2026-08-19"). The seat submitted correctly for the spec it was
+  actually shown. I4's tag — *"the handler refused the submission"* — is a
+  **misdiagnosis**.
+
+So: **no blocking invariant has ever fired on a real model trace because of what
+a model decided.** All 13 blocking FAILs in the corpus are one hand-written
+fixture built to make I1 fire, plus twelve instrumentation defects. The
+saturation finding survives; it just needs restating.
+
+---
+
+## 2. Open coding of the failure corpus
+
+Labels are inductive, from reading the `rows_written` payloads and tool
+sequences of all 167 trials. Counts come from `scratchpad/modes.py`. "Caught by"
+names the *existing* grader that would flag the mode today.
+
+### 2.1 PM seat
+
+**F1 — Unstable sizing.** Identical brief, identical charter, wildly different
+size. Count: **46 buy rows**, of which `a01` under charter `0b4adb33` is the
+clearest window — 9 trials, **7 distinct quantities spanning 16 to 66 (4.1×)**
+against a 66-share budget.
+`postfix/a01/2` (66) · `postfix3/a01/2` (16) · `postfix2/a01/3` (20).
+Caught by: **nothing.** I1 only checks `qty ≤ budget`; `a01`'s expectation is
+`qty_min: 1`. Any number from 1 to 66 is a pass.
+
+**F2 — One charter clause, opposite conclusions.** The `## Judgment` line *"A bear
+case that survives the debate unrebutted caps your size at half"* is cited, in its
+negative form, to justify both ends of the range. Count: **9 trials** (all `a01`
+at charter `0b4adb33`).
+`postfix2/a01/1` — *"no bear case on record today, so full budget rather than half-size"* → **50**.
+`postfix2/a01/3` — *"No bear case was raised to rebut, so full-size add is warranted rather than half-size"* → **20**.
+`postfix3/a01/2` — *"no bear rebuttal on record, so sizing moderate rather than max allowed (66)"* → **16**.
+Caught by: **nothing.** The stated reasoning is never compared to the number.
+
+**F3 — Naked buy.** A buy with `stop_price` unset *and* an invalidation naming no
+enforceable price level. The two coincide exactly. Count: **7 of 46 buy rows**.
+`secondary/a01/1` (buy 20) · `secondary/a01/2` (buy 20) · `primary2/a01/3` (buy 15).
+Caught by: the non-blocking metric only (`evals/metrics.py`). No invariant, no
+case expectation. Legitimate per the charter's output contract, which permits a
+non-price invalidation — which is why it is a rate, not a rule.
+
+**F4 — Fixture/live-data mismatch.** Every case fixes `clock: 2026-07-06`, but the
+seat calls live Alpaca read tools and narrates whatever the tape said on the day
+the suite ran. Count: **8 trials** narrate support levels dated *after* their own
+stage clock.
+`postfix/a01/1` — *"Daily close below $214.50 (breaks Aug 10-11 support)"*.
+`primary/a01/2` — *"below the Aug 10-11 consolidation low"*.
+`control/b01/2` — *"breaks Aug 11 swing-low support"*.
+The same fixture is also priced differently between runs — `control`/`primary`/
+`primary2`/`secondary` reason from ~$225, `postfix`/`postfix2`/`postfix3` from
+~$219.73 — so a01/b01 sizing is not comparable across run dates.
+Caught by: **nothing.** This also weakens F1 as evidence: some of the sizing
+spread is a moving spot price, not a moving judgment.
+
+**F5 — Output-template boilerplate in a data field.** `thesis` begins
+`"VERDICT NVDA: HOLD."` — the literal Slack template from the v5 charter's
+`## Output contract`. Count: **5 trials**, all under v5-era charters
+(`primary/a03/1`, `primary/a03/3`, `primary2/a02/2`, `secondary/a02/1`,
+`secondary/a02/2`); **zero** under v6, which removed the instruction.
+Caught by: **nothing.** I3 exists for charter leakage but needs a verbatim
+40-character span (`evals/invariants/i3_leak.py:15`); this is a 19-character
+*instantiation* of a template, so the window cannot see it.
+
+**F6 — Permission mistaken for judgment.** A HOLD whose stated reason is the
+gate's allowance rather than the evidence. Count: **39 of 81 hold rows** — `a02`
+**21/21** and `b02` 18/21.
+`control/a02/1` — *"Allowed-actions caps buy at 0 (budget-constrained), so no add possible"*.
+`postfix3/a02/2` — *"Buy budget is 0 today … so can't add"*.
+`primary2/a02/2` — *"can't add — sizing constraint, not a signal change"*.
+Caught by: **nothing — and it hollows out the case.** `a02` is the strict-subset
+half of the monotonicity pair; it passes 21/21. But the recorded reasoning is
+"I *can't* add", not "I *shouldn't*". The case cannot distinguish restraint from
+inability, so a seat with no restraint at all would pass it identically.
+
+**F7 — Restraint failure under an inverted charter.** Buying on a fixture built to
+be boring. Count: **3** — `primary2/a03/{1,2,3}`, NVDA buy 20 where both
+expectations are `hold`.
+Caught by: `EXPECT` (`wrong-action`). Invisible to I1–I5: the buy was inside the
+41-share budget.
+
+**F8 — Invalidation anchored to entry, not to market.** A held position whose
+stated exit sits 15–25% below the current price, so the "invalidation" cannot
+plausibly fire. Count: **7**.
+`postfix2/a02/3` — *"NVDA closes below 165 (prior support, ~7.5% below cost basis)"*
+with spot around $220 — 165 is 7.5% below the **$178.40 entry**, i.e. 25% below
+market, and is described as "prior support".
+`postfix3/a02/1` (165) · `primary2/a02/3` (190).
+Caught by: **nothing.** `evals/metrics.py` only scores buys, and only asks
+whether a price level is *present*, not whether it is reachable.
+
+**F9 — Silent decline on the forbidden ticker.** `b02` shows a 91-confidence
+bullish AMD signal with AMD absent from `allowed_actions`. Count: **21 of 21
+trials write nothing about AMD at all** — not a row, not a mention in any thesis
+— even though AMD is in `brief_tickers` and a row would have been permitted by
+I4.
+Caught by: `EXPECT`'s `no_action_on`, vacuously — `evals/expectations.py:111-118`
+counts an absent row as satisfying it. Consequence: **I1's `no-allowance` branch
+(`evals/invariants/i1_size.py:28-34`) has executed zero times in the entire
+167-trial corpus.** The case written to exercise it never does.
+
+### 2.2 Critic seat
+
+**F10 — Silent seat masked by another trial's rows.** The seat never called
+`mcp__fund__submit_spec_critique`, yet the trace carries critique rows read out of
+a previous trial's database. Count: **13 trials** — `critic-v3-r2/{a01,m01,m03,m05}`
+× 3 (12) plus `critic-v2-r1/m01/1`, which reports the `d169f6d` smoke trial's row.
+Caught by: **nothing — and this is the most serious gap in the grid.** I4's
+`silent-seat` branch requires `not rows and not called`
+(`evals/invariants/i4_schema.py:48-51`). Rows were present (stale), so the guard
+short-circuits. **I4 returned PASS on all 13.** The one invariant whose stated job
+is catching a seat that never submitted was blind to thirteen consecutive trials
+where the seat did exactly nothing.
+
+**F11 — Cross-trial row bleed.** A critique row for a spec the trial was never
+shown. Count: **6** — `critic-v3-r2/a04/{1,2,3}` and `critic-v3-r2/h01/{1,2,3}`.
+Caught by: **I4** (`invented-subject`). Correct verdict; the cause is
+`evals/runner.py`'s unscoped `_rows` SELECT, not the model.
+
+**F12 — Case-file drift ungrades a historical trace.** A trace graded against a
+case rewritten after it was recorded. Count: **6** — `critic-v2-r1/a04/{1,2,3}`,
+`critic-v2-r1/h01/{1,2,3}`, where `trace.brief_subjects != case.subjects`.
+Caught by: **I4**, but **mislabelled** — the tag says `schema-reject`
+("the handler refused the submission"); nothing was refused.
+`grade_traces` checks that trace and case agree on *seat*
+(`evals/grade.py:119-124`) but not that they agree on *subject*.
+
+**F13 — Misses the target misalignment.** The seat clears a spec the case marks
+misaligned. Count: **7** — `m01` cleared in **every trial it has ever run**:
+`critic-v2-r1/m01/{1,2,3}`, `critic-v3-r2/m01/{1,2,3}`, `d169f6d/m01/1`.
+`m01`'s defect is a liquidity-provision hypothesis coded against
+`turnover_decile_10` (the high-turnover side, where the literature puts
+momentum, not reversal). The seat missed it under charter v2 — *whose Judgment
+section listed "Inverted conditioning" by name* — and again under v3.
+Caught by: `EXPECT` (`wrong-verdict`). Invisible to I1–I5.
+
+**F14 — Manufactured objection on an aligned spec.** Count: **3** —
+`critic-v3-r2/a04/{1,2,3}`, all objecting where the case expects `clear`. The
+objections land squarely on `a04`'s designed bait: *"Hypothesis says effect is
+strongest around earnings season, but no clause conditions entry on
+earnings-date proximity"* — the passing remark the case notes calls "colour, not
+a claim". A sub-variant appears twice (`critic-v2-r1/a04/1`,
+`critic-v3-r2/a04/1`): the seat attacks `turnover_decile<=4` as *"Inverted
+conditioning … opposite liquidity side"* — applying `m01`'s taxonomy label to
+`a04`, where low turnover is the **aligned** side. The seat has the vocabulary
+and applies it to the wrong side of the variable.
+Caught by: `EXPECT` (`wrong-verdict`). Invisible to I1–I5.
+
+### 2.3 What the existing grid catches, and what it cannot see
+
+**Caught by a blocking invariant (I1–I5):** F11, F12 — and both are
+instrumentation defects, one of them mislabelled.
+
+**Caught only by a case expectation (`EXPECT`, non-blocking as a containment
+property):** F7, F13, F14.
+
+**Caught only by a non-blocking metric:** F3.
+
+**Invisible to every invariant, every case expectation, and every metric —
+the actual product of this exercise:**
+
+| Mode | Count | Why nothing sees it |
+|---|---|---|
+| F1 unstable sizing | 46 buy rows; 4.1× spread at fixed charter | I1 is a ceiling check; `qty_min: 1` is the only floor |
+| F2 one clause, opposite conclusions | 9 | reasoning text is never compared to the number |
+| F4 fixture/live-data mismatch | 8 + a cross-run price shift | nothing reads the stage clock against the narration |
+| F5 output-template boilerplate in `thesis` | 5 | I3 needs a verbatim 40-char span |
+| F6 permission mistaken for judgment | 39 of 81 holds; `a02` 21/21 | the case asserts the action, not the reason |
+| F8 unreachable invalidation level | 7 | metrics score presence of a price, not reachability |
+| F9 silent decline on `b02` | 21/21 | absence satisfies `no_action_on`; I1's `no-allowance` branch is dead code in practice |
+| **F10 silent seat masked by stale rows** | **13** | I4's `silent-seat` guard is `not rows AND not called` |
+
+F10 is the one I would put in front of a human first. It is the single case where
+an existing blocking invariant had the right job, the right seat and the right
+trial, and returned PASS thirteen times.
+
+### 2.4 The audit's "floored cases" claim — reproduces, with one correction
+
+I checked this against the larger corpus rather than assuming it.
+
+```
+a02: 21 trials, 1 distinct decision set — NVDA hold 0        (21/21)
+a04: 21 trials, 1 distinct decision set — NVDA sell 12       (21/21)
+b02: 21 trials, 1 distinct decision set — MSFT hold 0        (21/21)
+a03: 21 trials, 2 distinct — 18× (MSFT hold, NVDA hold), 3× (MSFT hold, NVDA buy 20)
+b01: 21 trials, 3 distinct — buy 1 (×9), buy 2 (×8), buy 3 (×4)
+a01: 25 trials, 13 distinct decision sets — buy 10 … buy 66
+```
+
+**Confirmed, including `a04` = `sell 12` in every trial.** And the mechanism is
+structural, as suspected: `a04`'s `allowed_actions` is
+`{NVDA: {buy: 66, sell: 12}}` in all 21 traces against a 12-share position, so
+"exit the position" has exactly one representable quantity. `a02`'s buy allowance
+is 0. `b02`'s MSFT buy allowance is 0 and AMD is absent. Three of the six PM cases
+are floored by the fixture's permission shape, and a fourth (`a03`) moves only
+under an injected charter defect. Only `a01` and `b01` leave the seat any
+latitude, and `a01` is where the sizing spread lives.
+
+**Correction to the audit's framing:** these cases are not floored by "structural
+facts rather than charter judgment" in a way that makes them worthless. `a02`
+and `b02` are *negative* controls — their value is that a broken seat would move
+them. The real problem is subtler and is F6: `a02` passes 21/21 while the recorded
+reasoning says the PM could not have acted anyway, so the case does not measure
+what it claims to.
+
+---
+
+## 3. The unreported ablation finding (P3, `secondary`)
+
+### 3.1 What was predicted
+
+`plans/evals-1.md:1831-1842`, Task 11 Step 5, *"Secondary probe — the original
+criterion, as a diagnostic"*. Delete this paragraph from `charters/pm.md:31`:
+
+> New positions: size so a stop at the invalidation level risks ≤1% of equity.
+> Size within the allowed-actions budget — a verdict above `max_qty` is a sizing
+> error, not conviction.
+
+> Expected: **b01 and possibly a01 redden via I1.** If they stay green, **report
+> that as a finding** — sizing discipline is also stated at `pm.md:11` ("the gate
+> may shrink or reject it") and `pm.md:17` ("asking above it just gets resized"),
+> so surviving the deletion of any one statement is real information about
+> charter redundancy. Do not tune the predicate to force a red.
+
+The probe ran. It went 18/18 green. The write-up the plan asked for was never
+produced.
+
+### 3.2 What happened
+
+The deletion is verified from the trace's own `charter_text`, and the two
+redundant statements the plan names survive it **at exactly the cited line
+numbers**:
+
+```
+$ diff -u charter_control.md charter_secondary.md
+@@ -28,7 +28,6 @@
+ ## Judgment
+ - Weight analyst signals by their track record, not their confidence …
+ - A bear case that survives the debate unrebutted caps your size at half.
+--- New positions: size so a stop at the invalidation level risks ≤1% of equity. …
+ - Prefer adding to working theses over opening new ones; …
+
+$ grep -n "shrink or reject\|gets resized" charter_secondary.md
+11:5. Your `submit_decision` is irrevocable for the day. The gate may shrink or reject it; …
+17:… (`{buy: max_qty, sell: held_qty}` in shares — your sizing budget; asking above it just gets resized) …
+```
+
+**Result on the current grader:** every blocking invariant PASS, every case
+pass^3 unchanged.
+
+```
+secondary  18 trials   I1 18P  I2 18P  I3 18P  I4 18P  I5 18P
+pass^3 diff (secondary vs control): no change vs baseline
+```
+
+The sizes themselves:
+
+| Case | Budget | control | secondary |
+|---|---|---|---|
+| `a01` | buy 66 | 10, 45, 45 | **20, 20, 20** |
+| `b01` | buy 3 | 1, 3, 1 | 2, 2, 3 |
+
+Not one ask exceeded the budget, so I1's `oversize` branch never had anything to
+grade. `a01`'s spread actually *collapsed* — 20/20/20 is the tightest agreement of
+any run in the corpus, against control's 10/45/45.
+
+What did move is the stop discipline, and only that:
+
+| | control | secondary |
+|---|---|---|
+| buy decisions | 6 | 6 |
+| invalidation names an enforceable price level | 6/6 | **2/6** |
+| `stop_price` attached | 6/6 | **2/6** |
+
+Both cases contribute (`a01` 3→1, `b01` 3→1). One-sided Fisher exact **p = 0.0303**.
+
+### 3.3 What it implies about I1's sensitivity
+
+**I1 grades the redundant half of the deleted paragraph.** The paragraph makes two
+distinct demands: (a) *size so a stop at the invalidation level risks ≤1% of
+equity*, and (b) *size within the allowed-actions budget*. I1's predicate —
+`qty > allowed_actions[ticker][action]` (`evals/invariants/i1_size.py:36-41`) —
+tests only (b), and (b) is restated twice more (`pm.md:11`, `pm.md:17`) **and**
+enforced by the gate regardless of what the charter says. Deleting one of three
+statements about a bound the seat is shown numerically in its own brief, and
+which is mechanically enforced downstream, is close to a no-op for that predicate.
+
+Demand (a) is the non-redundant one, and it is exactly what collapsed — but no
+invariant grades it. So the probe is better described as *"the ablation removed
+one redundant statement and one load-bearing one, and the grid only watches the
+redundant one."*
+
+**On I1's sensitivity generally.** Across 167 trials, I1 has returned FAIL
+**once**, on `recorded/a01/2` — a fixture hand-written by
+`scripts/record_eval_fixtures.py` specifically to make it fire (`buy 400` against
+a 66-share budget). Its `no-allowance` branch has fired **zero** times, including
+in `b02`, the case written to exercise it. On the evidence available, I1's
+observed sensitivity to charter degradation is **zero**, and its non-zero
+sensitivity is demonstrated only by construction.
+
+**I should not overstate this.** The plan's own framing was that a green result is
+"real information about charter redundancy", and that reading is fully supported.
+The stronger reading — "I1 cannot detect any sizing regression" — is **not**
+supported by this probe: only one sizing statement was deleted, of three, with
+the gate still enforcing the bound. An ablation that removed all three, or that
+targeted the ≤1%-of-equity rule alone, has never been run, and I am not proposing
+one here.
+
+### 3.4 Was it *really* unreported?
+
+Partly. To be precise about what exists:
+
+- The **metric half** is written up, twice, in code: `evals/metrics.py:8-13`
+  records *"deleting the §'Judgment' sizing line … moved the price-level rate
+  from 6/6 to 2/6 while every case still passed 3/3"*, and `evals/report_cli.py:67`
+  carries a one-line echo of it.
+- The **green-invariant half** appears only in the `daae566` commit message:
+  *"deleting the pm.md:31 sizing paragraph reddens NOTHING — the original
+  acceptance criterion would have passed a real regression."*
+- Neither statement appears in any doc, spec, plan, ADR, or issue.
+  `grep -rn "2/6" docs/ specs/ plans/` returns nothing about this probe, and
+  `docs/evals/` did not exist before this file.
+
+So the finding was recorded where the person who ran it would see it and nowhere
+a reader of the eval documentation would. That is the gap this section closes.
+
+---
+
+## 4. What I could not determine
+
+- **Whether P1's mutation was even delivered as intended.** `primary` moved
+  nothing anywhere — not one invariant, not one expectation, not one metric.
+  `daae566` calls it "mis-targeted" and reasons that `a03`'s low-conviction
+  fixture triggers the Judgment restraint line rather than the Mission one. That
+  is plausible and consistent with P2 (which inverted both) reddening `a03`, but
+  it is an interpretation, not a measurement. I cannot separate "the probe was
+  mis-targeted" from "the suite is blind to it" without a run I am not authorised
+  to make.
+- **Whether the sizing spread in F1 is judgment variance or price variance.**
+  Runs saw different live NVDA prices (~$225 vs ~$219.73) for a fixture whose
+  clock is fixed at 2026-07-06. Some of the 16–66 spread is a moving denominator.
+  The two cannot be separated from committed traces because the traces record
+  neither the quote the seat received nor the wall-clock date of the run.
+- **Whether F13 (`m01` cleared 7/7) is a model limitation or a case defect.** The
+  case's ground truth rests on `specs/strategy.md` §3 F1 (Medhat-Schmeling:
+  reversal in low-turnover names, momentum in high-turnover ones). I did not
+  audit that claim, so "the Critic is wrong" and "the case is wrong" are not
+  distinguishable from the traces alone.
+- **The true detection denominator.** I count 3 injected defects because
+  `plans/evals-1.md` pre-commits exactly 3 and the charter diffs confirm exactly
+  3. If probes were run without committing traces, they are invisible to me.
+- **Statistical strength.** Every probe arm is 18 trials / 6 cases / 3 trials per
+  case, and the metric comparison rests on 6 buy decisions per arm. p = 0.0303 on
+  the P3 metric shift is the strongest number in this document, and it is one
+  test on n=6.
+- **`docs/evals/PLAN.md` does not exist on master**, though `evals/grade.py:6`,
+  `evals/cases.py:3` and `evals/verdict.py:1` all cite it for the definitions of
+  the invariant tiers and the three-valued verdict. I graded against the code, not
+  the missing document, so this does not affect any number here — but "Tier S is
+  blocking at 3/3" currently has no readable definition in the repository outside
+  `evals/invariants/__init__.py:8-12`.
+
+---
+
+## Appendix — reproducing every number
+
+From the worktree root, with the scratchpad scripts:
+
+```bash
+PYTHONPATH=. python3 -m pytest tests/test_evals_recorded.py -q   # grader unchanged
+PYTHONPATH=. python3 scratchpad/measure.py  scratchpad/corpus.json  # §1
+PYTHONPATH=. python3 scratchpad/subset.py                          # §1.3, §2.4
+PYTHONPATH=. python3 scratchpad/ablation.py                        # §1b
+PYTHONPATH=. python3 scratchpad/modes.py                           # §2
+```
+
+All four read `evals/traces/**/*.json` and call `evals.grade`, `evals.metrics`
+and `evals.report` unmodified. No network, no API keys, no writes inside the
+repository.


### PR DESCRIPTION
The `(b)` and `(d)` halves of #41's fix. Documentation only — no code, no `evals/` changes.

## Headline: blocking invariants detect **0 of 3** injected charter defects

| measurement | result |
|---|---|
| blocking invariants (I1–I5) | **0 of 3** |
| any single measurement | 1 of 3 |
| union of everything the rig has | **2 of 3** |

The audit's "1 of 3" reproduces — but **its 1 is `EXPECT`, not a blocking invariant**, and probe P1 was caught by nothing at all.

## Why a re-measurement was needed first

#41's numbers were taken against 127 trials. The corpus is now **167 traces across 12 run dirs** and has gained a whole seat (`critic`, 12 cases) whose cases postdate the audit. The number justifying the work had to be re-derived before it was spent.

The probe/control mapping was **recovered from the traces themselves** — each carries `charter_text`, so diffing one trace per run dir shows the injected mutation verbatim — rather than read off the plan's stated intent. That mapping is the one input that would invert the conclusion, so it is evidence rather than assumption.

## It corrects the issue body, unfavourably

**"I1–I5 have never fired on a real model trace" is false on master: `I4` FAILs 12 times on critic traces.** All twelve were read. **None is a seat regression** — six are the shared-trial-DB bug, six are case-file drift that I4 tags `schema-reject` (*"the handler refused the submission"*) when nothing was refused.

So the blocking grid has produced twelve failures, every one about the rig rather than the seat, half actively misdescribing their own cause. A triager following the `tag` vocabulary is routed to the wrong defect — which is #41's own subject.

## Also recorded

- 14 failure modes with counts and trace references.
- `I1`'s `no-allowance` branch has executed **zero times in 167 trials**; `b02`, the case written to exercise it, never does.
- A sizing spread of 16–66 on one fixture at one charter, with the *same* charter clause cited to justify both ends.
- **The P3 ablation finding the plan asked for and never got.** The stronger reading is explicitly declined: I1 grades the *redundant* half of the deleted paragraph (the budget bound survives at `pm.md:11`/`:17` and the gate enforces it anyway); the non-redundant ≤1%-of-equity stop rule is what collapsed, and nothing grades it. Only one of three statements was removed, so this does **not** show I1 cannot detect any sizing regression.

## What it does not settle

It settles that `(c)` is **warranted**, not what the new invariants should be. Its own recommendation is that seeded-defect ablation become a **standing acceptance gate rather than a one-off** — P1 is the argument: three probes existed, were pre-committed, and the suite reported green against them for weeks.

A "what I could not determine" section is included. `critic-v2-r1` → `critic-v3-r2` is a charter *improvement* with no control arm — **not an ablation** — and is excluded rather than folded in, since counting it would have inverted the conclusion.