### PR TITLE
fix: a pooled news limit lets one ticker starve the others

### DIFF
--- a/agents/config/news.yaml
+++ b/agents/config/news.yaml
@@ -3,9 +3,13 @@ model: claude-haiku-4-5-20251001
 fallback_model: claude-sonnet-5
 max_budget_usd: 0.50
 # Same P1 cost bound as the analyst seat. The measured analyst day (2026-08-17,
-# 2 tickers) was 7 turns / $0.0504, and this seat's charter budgets the same
-# shape of work — one brief call plus roughly two calls per ticker — so 16
-# carries the same headroom at the 3-ticker watchlist.
+# 2 tickers) was 7 turns / $0.0504. Charter v3 budgets one brief call plus
+# roughly three calls per ticker — its own single-symbol get_news, price
+# context, submit_signal — where v2 shared one pooled get_news across the whole
+# set. Measured production under v2 was 7-8 turns; the extra per-ticker call
+# puts the 3-ticker watchlist near 9-10, so 16 still carries headroom.
+# Note this now scales linearly with watchlist size where the pooled call was
+# constant, so the headroom shrinks as tickers are added.
 # INHERITED, NOT MEASURED: right-size from THIS seat's first live
 # ResultMessage.num_turns rather than leaving the analyst's number here
 # permanently. A news-heavy ticker may need more calls than a price-only one,

--- a/charters/news.md
+++ b/charters/news.md
@@ -1,4 +1,4 @@
-# News/Sentiment Analyst — v2
+# News/Sentiment Analyst — v3
 
 ## Identity
 You are **Marcus Ellery**, news and sentiment analyst. Ten years on a macro
@@ -38,12 +38,36 @@ to guess.
 - Alpaca read-only (`news`, `stock-data`): headlines for the ticker, plus enough
   price context (latest quote, ≤10 daily bars) to judge whether a story is
   already in the tape. Budget your calls: aim for ≤4 tool calls per ticker.
-- `get_news` — call it with **`symbols` only**. Its default window is the start
-  of the current day, which is exactly the window you want. **NEVER pass `start`
-  and `end` as the same date.** Both resolve to midnight, so the interval is
-  zero-width, and Alpaca returns an empty list with a clean success and no error
-  — indistinguishable from a genuinely quiet day. On 2026-08-19 that returned
-  nothing on a day carrying 30 articles across the watchlist.
+- `get_news` — **one call per ticker: exactly one symbol, plus an explicit
+  `limit` of 50** (50 is the maximum the tool accepts). The shape, every time:
+  `get_news(symbols="AAPL", limit=50)` — one bare ticker, cap named, no `start`,
+  no `end`. `symbols` is a comma-separated *string*, which is exactly why it
+  accepts a pool and why you must give it only one name.
+  Its defaults are half friend, half trap. The default *window* is the start of
+  the current day, which is exactly the window you want — so pass no `start` and
+  no `end`, and **in particular never pass `start` and `end` as the same date**.
+  Both resolve to midnight, so the interval is zero-width, and Alpaca returns an
+  empty list with a clean success and no error — indistinguishable from a
+  genuinely quiet day. On 2026-08-19 that returned nothing on a day carrying 30
+  articles across the watchlist.
+  But there is no default *`limit`*, and omitting it does not mean "uncapped":
+  Alpaca applies its own cap of **10 articles, newest first, pooled across every
+  symbol you named**. One busy ticker then eats the whole budget and its quieter
+  neighbours come back with nothing, silently and with a clean success. On
+  2026-08-24 NVDA's earnings eve took 9 of the 10 slots and AAPL returned 0 of
+  the 3 articles it had. A single-symbol call cannot be starved by another
+  symbol; a pooled call can, at any `limit`, because the cap is shared. So never
+  batch tickers into one call, and never let the `limit` default.
+- **`next_page_token` is the truth-in-advertising field — read it on every
+  `get_news` response.** Non-null means the result is **truncated**: more
+  articles matched than you were handed. That is a third outcome, distinct from
+  a full result and from an empty one, and it changes what you may conclude.
+  **Do NOT follow the token.** `page_token` exists, but paginating turns one
+  bounded call per ticker into an unbounded loop against a 16-turn ceiling, and
+  a clipped turn yields no measurement at all rather than a smaller one. At
+  `limit=50` on a single symbol, truncation means one ticker published more than
+  50 stories in a day — rare, and the newest 50 are the ones that matter anyway.
+  Report the truncation and stop. See Judgment.
 - `submit_signal` — REQUIRED, once per ticker: direction bullish/bearish/neutral,
   confidence 0–100, summary ≤500 chars citing the 2–3 specific headlines that
   drove it, each with its recency. With `get_stage_brief` these are the only two
@@ -61,18 +85,29 @@ Per ticker: one Slack-visible line `<TICKER>: <direction> (<confidence>/100) —
 - One outlet repeating another is ONE source. Count distinct reporting, not
   distinct URLs.
 - Absence of news is information **only once you have established it**. A big
-  move with no story is usually noise — but you may say that only after a call
-  that actually returned stories for the period and none of them bear on the
-  move. **An empty result is not evidence of absence; it is evidence you did not
-  measure.** Saying "no news published" when the tool returned nothing is a
-  claim about the world made from a fact about your query.
+  move with no story is usually noise — but you may say that only after a
+  **full, untruncated** call that returned stories for the period and none of
+  them bear on the move. A truncated call also returns stories, and it does not
+  satisfy this test. **An empty result is not evidence of absence; it is
+  evidence you did not measure.** Saying "no news published" when the tool
+  returned nothing is a claim about the world made from a fact about your query.
 - If tools error, or a call returns nothing at all, **you have not measured**.
   Submit neutral with low confidence and say the data was **unavailable** —
   never that there was no news, and never reason onward from the silence.
   A confident false negative reads as diligence and is harder to catch than an
   invented headline, so it is the more dangerous of the two.
+- **A truncated result is a partial measurement — the third state.** A non-null
+  `next_page_token` means articles matched that you were not given. What you
+  read is real evidence and you may cite it; what you did not read is unknown
+  and can cut either way. So a truncated page is NEVER the day's full news flow,
+  and you may not reason from anything missing from it: a ticker or a topic that
+  does not appear in a truncated page has not been measured as quiet — it has
+  not been measured at all. Say the coverage was partial in that ticker's
+  summary, and keep confidence **between 25 and 75** — both tails are
+  conviction, so a uniformly negative partial page overclaims at 12 exactly as
+  a uniformly positive one does at 88.
 - Never guess a headline you did not read, and never assert a silence you did
   not verify.
 
 ---
-changelog: v1 initial (second Phase 2 analyst seat; see docs/adr/0001); v2 get_news is called with symbols only — start==end is a zero-width interval that returns empty with no error — and an empty result is unmeasured, never measured-as-nothing (2026-08-19: the seat asserted "No news published" on a day carrying 30 articles; issue #6)
+changelog: v1 initial (second Phase 2 analyst seat; see docs/adr/0001); v2 get_news is called with symbols only — start==end is a zero-width interval that returns empty with no error — and an empty result is unmeasured, never measured-as-nothing (2026-08-19: the seat asserted "No news published" on a day carrying 30 articles; issue #6); v3 get_news is called once per ticker with an explicit limit of 50, because the omitted limit has no default and Alpaca's own cap of 10 is pooled across symbols — and a non-null next_page_token means truncated, a third state that licenses no claim from absence (2026-08-24: NVDA's earnings eve took 9 of 10 pooled slots, AAPL returned 0 of its 3 articles and the seat reported "No AAPL news published today"; issue #6)

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -210,7 +210,7 @@ def test_charter_version_comes_from_the_header():
     from agents.seats import charter_version_for
 
     assert charter_version_for({"seat": "pm"}) == "v6"
-    assert charter_version_for({"seat": "news"}) == "v2"
+    assert charter_version_for({"seat": "news"}) == "v3"
 
 
 def test_an_unparseable_header_is_unknown_not_a_crash():


### PR DESCRIPTION
Fixes the second defect in #6. **Not deployed by this PR** — see "What this does not do".

## The defect

On **2026-08-24** the news seat wrote into production `signals`:

> **AAPL** — neutral 50 — "No AAPL news published today. Price modestly up (+0.47%), consistent with broad market noise. No material evidence to shift from prior neutral."

**Three AAPL articles existed in the window that run covered.**

The seat had complied with charter v2 exactly. v2 told it to call `get_news` with **`symbols` only**, which fixed the earlier zero-width-interval bug (PR #29). But `limit` has **no default** in the pinned `alpaca-mcp-server@2.2.1` OpenAPI spec, and `get_news` is generated by `FastMCP.from_openapi` without an entry in `market_data_overrides.py` — where bars, quotes and trades each get an injected limit. So omitting `limit` does not mean uncapped; it means **Alpaca's own cap of 10 applies, newest-first, pooled across every symbol in the call.**

NVDA's earnings eve took 9 of the 10 slots. AAPL got zero.

Replayed read-only over the same window each run covered:

| Date | `limit` | Returned | NVDA | MSFT | AAPL | More pages |
|---|---|---|---|---|---|---|
| 08-24 | **10 (default)** | 10 | 9 | 2 | **0** | yes |
| 08-24 | 50 | 22 | 17 | 6 | **3** | no |
| 08-25 | **10 (default)** | 10 | 7 | 2 | 2 | yes |
| 08-25 | 50 | 22 | 16 | 5 | 4 | no |

The default-limit-10 rows reproduce both days' output ticker-for-ticker.

**Same failure family as #6, one layer over:** a clean 200 carrying a *truncated* list read as a fact about the world, where the original was a clean 200 carrying an *empty* one.

## The fix

**One `get_news` call per ticker — one symbol, explicit `limit: 50`.**

A pooled call at any limit keeps the cap *shared*, so starvation is postponed rather than removed. The decisive point is not that it starves but how: **a ticker that got zero slots in a pooled result is byte-identical to a ticker with no news.** The seat cannot distinguish them even in principle. A single-symbol call cannot be starved by another symbol, and if it truncates it truncates only the depth on the name you asked about.

**Truncation is now a third state**, distinct from full and from empty. A non-null `next_page_token` means articles matched that were not returned: cite what you read, never call it the day's news flow, draw no conclusion from what is absent within it, and clamp confidence to 25–75. **Do not follow the token** — stated explicitly rather than left to inference, because at `limit=50` on a single symbol truncation means >50 articles on one ticker in one day, while an unbounded follow-loop against `max_turns: 16` is a live hazard whose failure mode (a clipped turn yields *no* measurement) is strictly worse.

**v2's measured-vs-unmeasured rule is untouched** — verified as a pure insertion, zero deletions in that section. It fixes a different defect and had to survive.

### The review's main finding: the fix initially carried the defect inside itself

The first draft added the truncation rule but left v2's `charters/news.md:81` standing verbatim — *"you may say that only after a call that actually returned stories for the period."* **A truncated call does return stories.** Both rules were in force at once and the reader picked.

`:81` is now **amended, not supplemented**. The general form, which is why this is called out here:

> A correction that adds a new rule without retracting the old permission leaves both in force, and the reader picks.

## The one-line test change, and why it is not a re-record

`tests/test_migrations.py` bumps the news seat's expected charter version `"v2"` → `"v3"`, in a **separate commit** so it stays legible as a distinct step.

`CLAUDE.md` says never to update an expected value to make a test pass — **stop and ask**. We stopped, and the repo owner ruled explicitly that this line may move. The justification, verified independently three times:

- the test's own docstring: *"charters/_template.md: 'bump the header on any change'. The header is therefore the source of truth, not a second field to keep in sync."*
- `agents/seats.py:37-53` simply regexes `v(\d+)` off line 1 of the charter;
- commit `8cbaa1e` made exactly this one-line `"v1"`→`"v2"` change when the charter went to v2.

The expected value is a **mirror** of the header, not an independent fact the header must satisfy. Note `tests/test_migrations.py:201` also asserts `== "v2"` in an unrelated test — the edit was anchored on the full `charter_version_for({"seat": "news"})` expression, and the diff confirms only line 213 moved.

## Verification

```
1234 passed, 1 skipped, 7 deselected
```

Run at `10c2d32`, rebased onto `03f2809`. Clean rebase, no conflicts; the full patch text was byte-compared pre- and post-rebase and is identical. `agents/config/news.yaml` is **comment-only** — verified mechanically by filtering the diff to non-comment, non-blank lines, which returns empty. `max_turns` is untouched.

Master moved twice while this was in flight (`11dcb9a` → `0dcf77c` → `03f2809`), so this verification is fresh but perishable.

## A risk this introduces, deliberately not mitigated here

v3 makes the seat's calls **linear in active-set size** where the pooled call was constant.

- `tests/test_run_day.py:200-202` caps the **watchlist** at ≤3 — only the watchlist.
- `market/features.py:145-150` builds market inputs as **watchlist ∪ tickers currently held**, so an open position outside the watchlist raises N.

At N=4 the charter's own ≤4-calls-per-ticker budget is ~17 calls ≈ 18 turns against `max_turns: 16`; realistic arithmetic is ~13–14. **A one-ticker margin** — and `agents/config/news.yaml` notes a clipped turn "yields no measurement rather than a smaller one," so the failure mode is every ticker falling to neutral/0.

`max_turns` is **not** changed here. Raising a ceiling to fit a shape nobody has measured is the error the `max_turns` knock-on is being held to avoid, and doing it inside the change that alters the shape would bake in a number derived from arithmetic rather than from a run. The comment that justified `16` with "roughly two calls per ticker" is corrected, because a file asserting reasoning its own charter falsifies is worse than a stale number.

## What this does not do

- **It does not deploy.** The droplet still runs the defective charter until a human ships it. The fix existing is not the fix landing.
- **It does not close #6.** #6 closes on a verified-good production trace, not on a merged fix.
- **Nothing in `evals/` catches a regression of v2 or v3.** Per #18, the `news-seat-eval` branch's N1/N2 graders are not landing — they were found not to implement their own docstrings, scoring the incident sentence itself as a PASS. Right call, but this is the second charter fix shipping into a seat with no eval coverage. Recorded as accepted exposure, not overlooked.

## Also filed from this work

- **#53** — `Trace` records `tool_names` but not tool arguments, so compliance with this charter is unobservable.
- **#65** — the analyst seat holds the `news` toolset with **no** `get_news` guidance, so it has neither protection.
- **#66** — no test pins the `get_news` facts this wording now depends on (`limit` max 50, `next_page_token`).

Refs #6.
