### PR TITLE
docs: an index that says which file wins, and a name for the tier that lies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,8 @@ Multi-agent paper-trading firm on the Claude Agent SDK (Python). Agents communic
 
 ## Specs — read before implementing; schemas there are canonical
 
+A dated filename is a snapshot of the moment it was written, never current state. Current state is board issue #49 and `git log` on `master`. `specs/INDEX.md` maps the canonical files against the dated, derived ones and says which wins.
+
 - `specs/design.md` — full design doc (seats, daily cycle, gate math).
 - `specs/contracts.md` — DDL, pydantic models, tool schemas, state machines, failure semantics. **Do not invent fields.**
 - `specs/acceptance.md` — per-phase done-criteria. Implement its tests FIRST, then code until green.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -6,6 +6,15 @@ session. `README.md` explains what the system *is*; this file explains what the 
 
 Update it when a milestone lands or an open item closes — not per commit.
 
+> **⚠ STALE — a snapshot, not current state.** Despite "read this first" above, this file
+> has not been updated since 2026-08-20 (`git log -1 -- PROGRESS.md`). Nothing below is
+> current state, and this header deliberately quotes no commit, count, or phase number —
+> a number that depends on state outside this file will eventually be wrong inside it.
+>
+> For what is actually true right now: board issue **#49** and its children for what to work
+> on, open issues and PRs for what is in flight, `git log` on `master` for what shipped, and
+> `specs/acceptance.md` for the build order. See `specs/INDEX.md`.
+
 ---
 
 ## Status — 2026-08-19

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -1,0 +1,84 @@
+# Index — canonical specs, and where the derived designs live
+
+**This file is a map, not a source.** It carries no rules and no schemas.
+
+## Authority tiers
+
+Three tiers. A document's tier is decided by where it lives and whether its filename
+carries a date — never by how confident it sounds.
+
+| Tier | Where | Dated? | What it means |
+|---|---|---|---|
+| **Canonical** | `specs/`, `charters/`, `fixtures/`, `CLAUDE.md` | no | The contract. Changes only by deliberate human commit. |
+| **Derived** | `docs/`, `plans/`, `research/` | yes | One moment's reasoning, snapshotted. Never current state. |
+| **Live state** | GitHub board #49, open issues, PRs, `git log` | — | The only current truth. Not in this repo. |
+
+**The rule that makes it work: nothing in the repo may claim to be live state.** A derived
+document describes the moment it was written. When it disagrees with `git log` or board #49,
+those win and the document is stale — not wrong, stale. Say so in a status header rather than
+rewriting it, because its staleness is often itself the evidence.
+
+## Canonical — read these before implementing
+
+| File | What it settles |
+|---|---|
+| `design.md` | Seats, daily cycle, gate math, infrastructure, build order |
+| `contracts.md` | DDL, pydantic models, tool schemas, state machines, failure semantics. **Do not invent fields.** |
+| **`acceptance.md`** | **The build order.** Per-phase done-criteria; write these tests first |
+| `strategy.md` | Strategy lifecycle, backtest rules, gates G1–G4, allocation and kill rules |
+| `strategy-contracts.md` | Canonical ids/DDL/state machine for the strategy pipeline; overrides conflicts elsewhere |
+| `calibration.md` | Analyst scoring → deterministic PM weights |
+| `../charters/` | Seat system prompts; `_template.md` defines required sections |
+| `../fixtures/golden-day.md` | Worked example of one full day; its numbers are test vectors |
+
+## Derived designs — `docs/superpowers/specs/`
+
+Skill-generated (`brainstorming` writes here by default), so the directory holds fund designs
+and tooling designs side by side, ordered by date. That mixture is correct: the folder means
+*skill output*, not *one subject*. This index is how you find a fund design without reading
+fourteen filenames.
+
+**Fund — how a part of the system was designed**
+
+| Date | Design |
+|---|---|
+| 2026-07-12 | Phase 2 — the desk (PM + 2 analysts + real gate) |
+| 2026-08-12 | MVF — minimum viable firm, 3-day resume slice |
+| 2026-08-17 | Move the daily run to a Linux VM |
+| 2026-08-18 | G1 alignment gate — design, and its measured result |
+| 2026-08-18 | Improvement loops — the buildable half |
+| 2026-08-19 | Closing the missing-stop class |
+| 2026-08-20 | Account precondition drift detection |
+| 2026-08-21 | Day bookends — morning standup and EOD digest |
+| 2026-08-24 | Alert identity and the alert → issue filer |
+
+**Tooling — how the agents working this repo are organized**
+
+| Date | Design |
+|---|---|
+| 2026-08-24 | `morning-standup` ends in lanes owned |
+| 2026-08-25 | `owning-a-lane` — the shared overseer role |
+| 2026-08-26 | `morning-standup` dispatches a mix — remediate, decide, land (+ four competing candidates) |
+| — | Field brief + claims log: coordinating parallel agent sessions on one repo |
+
+**Every one of these defers to the canonical files above.** The Phase 2 desk design states it
+outright — *"companion canon (authoritative where they overlap)"*. A derived design that
+appears to extend a canonical file names the canonical file that must be edited first.
+
+## Other derived locations
+
+- `plans/` — the four hand-written foundational plans (`phase-1a`, `phase-1b`, `mvf`,
+  `evals-1`). Referenced by path in `CLAUDE.md`; kept separate from skill-generated plans.
+- `docs/superpowers/plans/` — skill-generated implementation plans.
+- `docs/adr/` — architecture decisions; immutable once accepted.
+- `docs/agents/` — how agents operate this repo (issue tracker, domain docs, devops).
+- `research/` — evidence base. Not loaded by agents by default.
+
+## Where current state actually lives
+
+- **What to work on** — GitHub issue **#49** (`wayfinder:map`) and its children.
+- **What is in flight** — open issues and PRs.
+- **What shipped** — `git log` on `master`.
+
+`PROGRESS.md`, `HANDOFF-LIVE.md`, and `KICKOFF.md` at the repo root are historical snapshots
+despite their names. `PROGRESS.md` carries a staleness header saying so.


### PR DESCRIPTION
Closes the one outstanding item from `docs/superpowers/handoffs/2026-08-26-night-close.md` §6.

Authorized by the **2026-08-26 "doc structure: authority tiers"** entry in `~/.claude/align/fund/decisions.md`, which accepts the three-tier structure and specifies the route: the `CLAUDE.md` line "must go through a PR against `master` rather than a direct edit, because this checkout's `CLAUDE.md` is on a divergent HEAD and a direct edit would broadcast an unratified rule to every session started afterward." Hence this PR rather than a commit in the root checkout.

## What's here

- **`specs/INDEX.md`** (new, 84 lines) — the map. Canonical / derived / live-state tiers, which canonical file settles what, and where the dated designs live. Carries no rules and no schemas by construction, so it can't become a second source for anything it indexes.
- **`PROGRESS.md`** — staleness header. The file says "read this first" and was last updated 2026-08-20 (`git log -1 -- PROGRESS.md` → `5d661b0`), which made it the most load-bearing stale file in the repo.
- **`CLAUDE.md`** — one line under `## Specs`: a dated filename is a snapshot, never current state; current state is board #49 and `git log`; plus the pointer to the index.

## One deviation from the draft

The `PROGRESS.md` header I was handed baked in live state — `master is 5f594c2`, `43 issues open`, `22 children`. Both numbers were **already wrong** by the time I read them: `origin/master` is `074967d` (`5f594c2` is an ancestor), and `gh issue list --state open` returns **46**. A header ratifying "nothing in the repo may claim to be live state" cannot itself quote a SHA and an issue count. The version here names no commit, count, or phase number and points at board #49, open PRs, `git log` and `specs/acceptance.md` instead.

## Verification

- `make test` → **1342 passed, 1 skipped, 7 deselected in 34.04s**
- Every path `specs/INDEX.md` asserts was checked to exist on `master` via `git show origin/master:<path>` — all 13 present.
- Its claim that `plans/` is "referenced by path in `CLAUDE.md`" verified against **master's** `CLAUDE.md:90`, not the working tree.
- Its claim that `PROGRESS.md` carries a staleness header is made true by this PR.

## Not in this PR — needs a human

The root checkout `/Users/benjaminmatton/Developer/fund` has **uncommitted `CLAUDE.md` edits deleting three sections** that are present on `master`: `### Devops`, the "a rule is ratified only if `git show origin/master:CLAUDE.md` contains it" paragraph, and `### Regression ratchet`. (`git diff origin/master -- CLAUDE.md`. The night-close handoff §2 reports two of the three.)

`CLAUDE.md` is auto-loaded per session from the working tree, so every session started in that directory runs without those three rules and cannot tell — confirmed first-hand: my own loaded context is missing all three, as is that of the five other live sessions with that `cwd`. `decisions.md` carries a 2026-08-26 ruling *about* `docs/agents/regression-ratchet.md` while the only pointer to that file is deleted out from under every session in that cwd.

Deliberately not fixed here: `master`'s copy is already correct, the deletion is uncommitted work by an unknown author, and the rule being deleted is precisely the one saying this can't be settled by editing the file. It needs Benjamin, not a PR.