### PR TITLE
feat: make dev-status — one tested read of droplet, broker and DB

### DIFF
--- a/.claude/health.md
+++ b/.claude/health.md
@@ -1,0 +1,54 @@
+---
+health_command: make dev-status
+suppress:
+  - degradations
+---
+
+# What healthy means in this repo
+
+`make dev-status` runs `scripts/dev_status.py` — read-only over the droplet,
+the broker and the database. It never writes, places, cancels, amends or
+deploys.
+
+## Interpreting the output
+
+- **`degradations` is suppressed.** `model_fallback_used` fires at severity 3
+  every day: it is an SDK auxiliary Haiku call on Sonnet-configured seats, not
+  a real fallback. Suppressed findings still appear, marked `[suppressed]` —
+  read them if something else looks wrong.
+- **`reflection` ok with an empty `resolutions` table is correct** until a
+  decision passes its 5-day horizon. The check knows the difference; a human
+  reading the table directly does not.
+- **`deploy_state` behind is normal** between a merge and a deploy. It matters
+  when the gap contains a gate or seat-surface change.
+- **`db_broker_agreement` currently reports itself unwired**, and that is
+  accurate rather than broken: `AlpacaSource` exposes no fill-history method,
+  so the comparison has no source. It warns instead of printing a green row
+  for a comparison nobody performed. It also diverges legitimately after any
+  manual out-of-gate order, which is the expected consequence of one, not a
+  bug in the check.
+- **`position_coverage` alerts when the broker could not be read.** An
+  unreachable broker yields an empty book, and "0 positions, every share
+  covered" is indistinguishable from a genuinely flat account. Unknown
+  exposure is never rendered as safety.
+- **`issue_coverage` is the loop from finding to tracked work.** An alert with
+  no open issue labelled `check:<id>` will be re-derived by the next session
+  and lost again. All 8 open issues currently carry zero labels, so this check
+  fires on everything until they are labelled — that is the intended first run,
+  not a bug.
+
+## Filing what this finds
+
+`docs/agents/issue-tracker.md` is the convention. Label a new issue
+`check:<check_id>` so the finding stops being re-derived:
+
+    gh issue create --label "check:position_coverage" --title "..." --body "..."
+
+An issue that describes production behaviour should say which check would go
+green when it is fixed.
+
+## Escalate, never act
+
+Broker mutations, droplet deploys, and gate thresholds are Benjamin's, in his
+own window. `~/.claude/align/fund/decisions.md` is the record; read it there
+rather than taking a peer's account of it.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # fund — see CLAUDE.md for what each mode means.
 
-.PHONY: test lint sim-day replay live-day live-paper close-pnl resolve schema-pin surface-pin score-day preflight
+.PHONY: test lint sim-day replay live-day live-paper close-pnl resolve schema-pin surface-pin score-day preflight dev-status
 .PHONY: staging-day staging-reset eval eval-report
 .PHONY: eval-critic-dev eval-critic-holdout
 
@@ -163,6 +163,18 @@ score-day: deps
 # safe to re-run — a decision that already resolved is not selected again.
 resolve: deps
 	$(PYTHON) scripts/resolve_day.py
+
+# Read-only production health check for developers: is every stated invariant
+# and Phase 2 acceptance criterion still true on the box that trades?
+#
+# Reads the droplet over ssh, the broker, and the live DB with mode=ro. Writes
+# NOTHING anywhere — no order, no deploy, no migration. Exit 0 always, so a
+# check that cannot run renders as a finding instead of hiding the rest.
+#
+# Attended, not scheduled. Every finding is for a human to act on; this is
+# developer context, not the fund's own alerting, which already works.
+dev-status: deps
+	$(PYTHON) scripts/dev_status.py
 
 # Eval suite: REAL LLM turns against the REAL charters, 6 cases x 3 trials.
 # Needs .env loaded. MEASURED 2026-08-17: 18 trials, $0.81 est., ~7 minutes.

--- a/devcheck/__init__.py
+++ b/devcheck/__init__.py
@@ -1,0 +1,9 @@
+"""Read-only production health checks for developers.
+
+Every check answers: is a stated invariant or a phase acceptance criterion
+still true on the box that trades? Incidents validate this list; they never
+source it. See docs/superpowers/specs/2026-08-21-day-bookends-design.md §2.4.
+
+Pure: no I/O, no clock, no LLM imports. scripts/dev_status.py is the only
+place that talks to a droplet, a broker, or a database.
+"""

--- a/devcheck/checks.py
+++ b/devcheck/checks.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from devcheck.model import Finding, Snapshot
+
+
+def check_paper_trading(s: Snapshot) -> Finding:
+    """Invariant 1 — paper only, everywhere.
+
+    Nothing else in the fund asserts this against the running host.
+    scripts/resolve_day.py guards its own startup, which protects that job
+    and says nothing about the box.
+    """
+    value = s.droplet_env.get("ALPACA_PAPER_TRADE")
+    if value == "true":
+        return Finding("paper_trading", "ok", "ALPACA_PAPER_TRADE=true on the droplet")
+    return Finding(
+        "paper_trading",
+        "alert",
+        f"ALPACA_PAPER_TRADE={value!r} on the droplet — invariant 1 requires 'true'",
+    )

--- a/devcheck/checks.py
+++ b/devcheck/checks.py
@@ -80,3 +80,47 @@ def check_db_broker_agreement(s: Snapshot) -> Finding:
         f"orders has {rows} row(s); broker has seen {s.broker_fill_count} fill(s) — "
         "the fund's record disagrees with the broker",
     )
+
+
+# Codes that mean "the pipeline degraded to its default and said so".
+# Invariant 4 makes these correct behaviour, not bugs — they warn so a
+# permanently degraded day cannot quietly become the normal one.
+_DEGRADATION_CODES = ("gate_error", "pm_timeout", "critic_timeout", "missing_signal")
+
+
+def check_degradations(s: Snapshot) -> Finding:
+    """Invariant 4 — every error resolves to HOLD. Correct, and worth seeing."""
+    seen = [c for c in s.scorecard_codes if c in _DEGRADATION_CODES]
+    if not seen:
+        return Finding("degradations", "ok", "no stage degraded to its default")
+    return Finding(
+        "degradations",
+        "warn",
+        f"degraded to default: {', '.join(sorted(set(seen)))} — correct per invariant 4, "
+        "but the day did not run clean",
+    )
+
+
+def check_checkpoints(s: Snapshot) -> Finding:
+    """Phase 2 acceptance — every checkpoint reaches `done`."""
+    unfinished = sorted({stage for _, stage, status in s.checkpoints if status != "done"})
+    if not unfinished:
+        return Finding("checkpoints", "ok", f"{len(s.checkpoints)} checkpoint(s), all done")
+    return Finding(
+        "checkpoints",
+        "alert",
+        f"stage(s) not done: {', '.join(unfinished)}",
+    )
+
+
+def check_journals(s: Snapshot) -> Finding:
+    """Phase 2 acceptance — each participating seat writes a journal entry.
+    design.md §7 makes memory load-bearing in this phase."""
+    missing = sorted(set(s.seats_participating) - set(s.journals_written))
+    if not missing:
+        return Finding("journals", "ok", "every participating seat wrote a journal entry")
+    return Finding(
+        "journals",
+        "warn",
+        f"participated but wrote no journal entry: {', '.join(missing)}",
+    )

--- a/devcheck/checks.py
+++ b/devcheck/checks.py
@@ -124,3 +124,22 @@ def check_journals(s: Snapshot) -> Finding:
         "warn",
         f"participated but wrote no journal entry: {', '.join(missing)}",
     )
+
+
+def check_reflection(s: Snapshot) -> Finding:
+    """Phase 2 acceptance — the nightly job writes `resolutions` at horizon.
+
+    An empty resolutions table is correct until a decision passes its horizon
+    and a dead job afterwards. The snapshot carries the decisions that are
+    already due, so the two cases cannot be confused: this is the shape that
+    fooled a session on 2026-08-21, which read the empty table as a failure.
+    """
+    if not s.due_unresolved:
+        return Finding("reflection", "ok", "no decision is past its horizon and unresolved")
+    ids = ", ".join(str(i) for i in s.due_unresolved)
+    return Finding(
+        "reflection",
+        "alert",
+        f"{len(s.due_unresolved)} decision(s) past horizon with no resolutions row "
+        f"(ids: {ids}) — the nightly reflection job is not landing",
+    )

--- a/devcheck/checks.py
+++ b/devcheck/checks.py
@@ -218,3 +218,33 @@ def check_services(s: Snapshot) -> Finding:
         return Finding("services", "ok", f"last run succeeded: {names}" if names else "no units read")
     parts = [f"{r.unit}: {r.result}" + (f" at {r.last_run}" if r.last_run else "") for r in bad]
     return Finding("services", "alert", "; ".join(sorted(parts)))
+
+
+def check_issue_coverage(s: Snapshot, findings: list[Finding]) -> Finding:
+    """docs/agents/issue-tracker.md — work in this repo lives as GitHub issues.
+
+    An alert nobody files disappears when the window closes. Only `alert`
+    participates: a `warn` that nagged every day would train the reader to
+    skip the report, which is the failure suppression exists to prevent.
+
+    A suppressed check is excluded for that same reason — it is declared
+    known noise, and this runs before apply_suppression() has downgraded it,
+    so the severity seen here is the raw one.
+    """
+    untracked = sorted(
+        f.check
+        for f in findings
+        if f.severity == "alert"
+        and f.check != "issue_coverage"
+        and f.check not in s.tracked_checks
+        and f.check not in s.suppressed
+    )
+    if not untracked:
+        return Finding("issue_coverage", "ok", "every alert is tracked by an issue")
+    hint = " ".join(f'gh issue create --label "check:{c}"' for c in untracked[:2])
+    return Finding(
+        "issue_coverage",
+        "alert",
+        f"alert(s) with no open issue: {', '.join(untracked)} — these die with this "
+        f"window. File them: {hint}",
+    )

--- a/devcheck/checks.py
+++ b/devcheck/checks.py
@@ -143,3 +143,28 @@ def check_reflection(s: Snapshot) -> Finding:
         f"{len(s.due_unresolved)} decision(s) past horizon with no resolutions row "
         f"(ids: {ids}) — the nightly reflection job is not landing",
     )
+
+
+def check_position_coverage(s: Snapshot) -> Finding:
+    """design.md §5 — a ticket carrying a stop_price becomes a broker-side
+    stop leg, so a held position is expected to be covered.
+
+    Coverage is AGGREGATE: N shares covered by one or more live stops.
+    Partial cover is exposure; the uncovered remainder has no code path that
+    will protect it.
+    """
+    naked = [p for p in s.positions if p.covering_qty < p.qty]
+    if not naked:
+        return Finding(
+            "position_coverage",
+            "ok",
+            f"{len(s.positions)} position(s), every share covered",
+        )
+    parts = [
+        f"{p.symbol} {p.covering_qty:g} of {p.qty:g} covered" for p in naked
+    ]
+    return Finding(
+        "position_coverage",
+        "alert",
+        "; ".join(parts) + " — the uncovered shares have no code path that will protect them",
+    )

--- a/devcheck/checks.py
+++ b/devcheck/checks.py
@@ -170,11 +170,12 @@ def check_position_coverage(s: Snapshot) -> Finding:
     indistinguishable from a genuinely flat account.
     """
     if s.positions is None:
+        why = f" ({s.broker_error})" if s.broker_error else ""
         return Finding(
             "position_coverage",
             "alert",
-            "the broker's position book was not read, so live exposure is unknown "
-            "— spec §4 forbids inferring position state from the database",
+            f"the broker's position book was not read{why}, so live exposure is "
+            "unknown — spec §4 forbids inferring position state from the database",
         )
     naked = [p for p in s.positions if p.covering_qty < p.qty]
     if not naked:
@@ -218,6 +219,24 @@ def check_services(s: Snapshot) -> Finding:
         return Finding("services", "ok", f"last run succeeded: {names}" if names else "no units read")
     parts = [f"{r.unit}: {r.result}" + (f" at {r.last_run}" if r.last_run else "") for r in bad]
     return Finding("services", "alert", "; ".join(sorted(parts)))
+
+
+def check_database(s: Snapshot) -> Finding:
+    """Invariant 6 — SQLite is the source of truth, so a database nobody
+    could read means the day's record was never inspected.
+
+    This is the root cause the DB-derived checks defer to. It exists because
+    a query against a wrong-but-present path returns no rows with exit 0, and
+    "no rows" is how a healthy empty table also looks.
+    """
+    if s.db_read_ok:
+        return Finding("database", "ok", "the fund database was read")
+    return Finding(
+        "database",
+        "alert",
+        "the fund database could not be read — every check sourced from it is "
+        "reported unknown rather than healthy",
+    )
 
 
 def check_issue_coverage(s: Snapshot, findings: list[Finding]) -> Finding:

--- a/devcheck/checks.py
+++ b/devcheck/checks.py
@@ -70,8 +70,20 @@ def check_outbox(s: Snapshot) -> Finding:
 def check_db_broker_agreement(s: Snapshot) -> Finding:
     """Invariant 6 — the DB is the source of truth, so the broker having
     seen more fills than the DB has rows is a divergence, not a rounding
-    difference. Manual out-of-gate orders produce exactly this."""
+    difference. Manual out-of-gate orders produce exactly this.
+
+    An unread count is reported as unread. AlpacaSource exposes no fill
+    history, so this is a live state rather than a hypothetical: rendering it
+    as agreement would print a green row for a comparison nobody performed.
+    """
     rows = len(s.orders)
+    if s.broker_fill_count is None:
+        return Finding(
+            "db_broker_agreement",
+            "warn",
+            f"orders has {rows} row(s); the broker's fill count was not read, so the "
+            "two were never compared — AlpacaSource exposes no fill history",
+        )
     if rows == s.broker_fill_count:
         return Finding("db_broker_agreement", "ok", f"orders rows == broker fills ({rows})")
     return Finding(
@@ -152,7 +164,18 @@ def check_position_coverage(s: Snapshot) -> Finding:
     Coverage is AGGREGATE: N shares covered by one or more live stops.
     Partial cover is exposure; the uncovered remainder has no code path that
     will protect it.
+
+    An unread book is an alert, not a green row. "0 position(s), every share
+    covered" is what an unreachable broker would otherwise print, and it is
+    indistinguishable from a genuinely flat account.
     """
+    if s.positions is None:
+        return Finding(
+            "position_coverage",
+            "alert",
+            "the broker's position book was not read, so live exposure is unknown "
+            "— spec §4 forbids inferring position state from the database",
+        )
     naked = [p for p in s.positions if p.covering_qty < p.qty]
     if not naked:
         return Finding(

--- a/devcheck/checks.py
+++ b/devcheck/checks.py
@@ -168,3 +168,30 @@ def check_position_coverage(s: Snapshot) -> Finding:
         "alert",
         "; ".join(parts) + " — the uncovered shares have no code path that will protect them",
     )
+
+
+def check_deploy_state(s: Snapshot) -> Finding:
+    """Deployment state — is the code under test the code that is running.
+
+    Warn, not alert: being behind is the normal state between a merge and a
+    deploy. It is worth seeing because a green suite says nothing about the
+    box, and on 2026-08-21 four sessions each held a different answer.
+    """
+    if s.commits_behind == 0:
+        return Finding("deploy_state", "ok", f"droplet level with origin/master ({s.origin_master})")
+    return Finding(
+        "deploy_state",
+        "warn",
+        f"droplet at {s.droplet_head}, origin/master at {s.origin_master} — "
+        f"{s.commits_behind} commit(s) behind",
+    )
+
+
+def check_services(s: Snapshot) -> Finding:
+    """The scheduled units that constitute the fund actually running."""
+    bad = [r for r in s.services.values() if r.result != "success"]
+    if not bad:
+        names = ", ".join(sorted(s.services))
+        return Finding("services", "ok", f"last run succeeded: {names}" if names else "no units read")
+    parts = [f"{r.unit}: {r.result}" + (f" at {r.last_run}" if r.last_run else "") for r in bad]
+    return Finding("services", "alert", "; ".join(sorted(parts)))

--- a/devcheck/checks.py
+++ b/devcheck/checks.py
@@ -18,3 +18,65 @@ def check_paper_trading(s: Snapshot) -> Finding:
         "alert",
         f"ALPACA_PAPER_TRADE={value!r} on the droplet — invariant 1 requires 'true'",
     )
+
+
+def check_trading_toolset(s: Snapshot) -> Finding:
+    """Invariant 2 — only the Execution Trader holds the `trading` toolset."""
+    holders = sorted(seat for seat, has in s.seat_trading_toolsets.items() if has)
+    if holders == ["exec"]:
+        return Finding("trading_toolset", "ok", "only exec holds `trading`")
+    extra = [h for h in holders if h != "exec"]
+    if extra:
+        return Finding(
+            "trading_toolset",
+            "alert",
+            f"seats other than exec hold `trading`: {', '.join(extra)} — invariant 2",
+        )
+    return Finding(
+        "trading_toolset",
+        "alert",
+        "exec does not hold `trading` — no order can ever be placed",
+    )
+
+
+def check_order_idempotency(s: Snapshot) -> Finding:
+    """Invariant 5 — client_order_id is always a gate ticket id."""
+    orphans = [o.client_order_id for o in s.orders if o.client_order_id not in s.tickets]
+    if not orphans:
+        return Finding(
+            "order_idempotency",
+            "ok",
+            f"{len(s.orders)} order(s), every client_order_id is a ticket id",
+        )
+    return Finding(
+        "order_idempotency",
+        "alert",
+        f"client_order_id not matching any ticket: {', '.join(sorted(orphans))} — invariant 5",
+    )
+
+
+def check_outbox(s: Snapshot) -> Finding:
+    """Invariant 6 — Slack is a projection of SQLite. An undrained outbox
+    means the projection is silently behind the truth."""
+    if s.events_unposted == 0:
+        return Finding("outbox", "ok", "events outbox fully drained")
+    return Finding(
+        "outbox",
+        "alert",
+        f"{s.events_unposted} event(s) with posted_at IS NULL — Slack is stale",
+    )
+
+
+def check_db_broker_agreement(s: Snapshot) -> Finding:
+    """Invariant 6 — the DB is the source of truth, so the broker having
+    seen more fills than the DB has rows is a divergence, not a rounding
+    difference. Manual out-of-gate orders produce exactly this."""
+    rows = len(s.orders)
+    if rows == s.broker_fill_count:
+        return Finding("db_broker_agreement", "ok", f"orders rows == broker fills ({rows})")
+    return Finding(
+        "db_broker_agreement",
+        "alert",
+        f"orders has {rows} row(s); broker has seen {s.broker_fill_count} fill(s) — "
+        "the fund's record disagrees with the broker",
+    )

--- a/devcheck/evaluate.py
+++ b/devcheck/evaluate.py
@@ -17,6 +17,8 @@ CHECKS = (
     checks.check_journals,
     checks.check_reflection,
     checks.check_position_coverage,
+    checks.check_deploy_state,
+    checks.check_services,
 )
 
 

--- a/devcheck/evaluate.py
+++ b/devcheck/evaluate.py
@@ -15,6 +15,7 @@ CHECKS = (
     checks.check_degradations,
     checks.check_checkpoints,
     checks.check_journals,
+    checks.check_reflection,
 )
 
 

--- a/devcheck/evaluate.py
+++ b/devcheck/evaluate.py
@@ -21,6 +21,7 @@ CHECKS = (
     checks.check_position_coverage,
     checks.check_deploy_state,
     checks.check_services,
+    checks.check_database,
 )
 
 
@@ -39,9 +40,29 @@ def evaluate(snapshot: Snapshot) -> list[Finding]:
             out.append(result)
         else:
             out.extend(result)
+    out = _starve_db_derived(out, snapshot.db_read_ok)
     # Runs last: it reads the other checks' output, not just the snapshot.
     out.append(checks.check_issue_coverage(snapshot, out))
     return out
+
+
+# Checks whose entire input is the droplet's SQLite database. When that read
+# fails there is nothing true to say about them, and "ok" would be the false
+# green this package exists to remove. They warn rather than alert so one root
+# cause stays loud instead of five copies of it.
+DB_DERIVED = ("order_idempotency", "outbox", "checkpoints", "journals", "reflection")
+
+
+def _starve_db_derived(findings: list[Finding], db_read_ok: bool) -> list[Finding]:
+    """Rewrite DB-sourced verdicts to "unknown" when the database was unread."""
+    if db_read_ok:
+        return findings
+    return [
+        replace(f, severity="warn",
+                detail="the fund database was not read, so this was never checked")
+        if f.check in DB_DERIVED else f
+        for f in findings
+    ]
 
 
 def apply_suppression(findings: list[Finding], suppressed: frozenset[str]) -> list[Finding]:

--- a/devcheck/evaluate.py
+++ b/devcheck/evaluate.py
@@ -16,6 +16,7 @@ CHECKS = (
     checks.check_checkpoints,
     checks.check_journals,
     checks.check_reflection,
+    checks.check_position_coverage,
 )
 
 

--- a/devcheck/evaluate.py
+++ b/devcheck/evaluate.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from dataclasses import replace
+
 from devcheck import checks
 from devcheck.model import Finding, Snapshot
 
@@ -37,4 +39,19 @@ def evaluate(snapshot: Snapshot) -> list[Finding]:
             out.append(result)
         else:
             out.extend(result)
+    return out
+
+
+def apply_suppression(findings: list[Finding], suppressed: frozenset[str]) -> list[Finding]:
+    """Downgrade suppressed checks to ok and say so.
+
+    Never drops the row. A vanished row is indistinguishable from a check
+    that never ran, and the whole package exists to remove that ambiguity.
+    """
+    out = []
+    for f in findings:
+        if f.check in suppressed and f.severity != "ok":
+            out.append(replace(f, severity="ok", detail=f"{f.detail} [suppressed by .claude/health.md]"))
+        else:
+            out.append(f)
     return out

--- a/devcheck/evaluate.py
+++ b/devcheck/evaluate.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from devcheck import checks
+from devcheck.model import Finding, Snapshot
+
+# Ordered registry. Adding a check means adding it here and nowhere else.
+# Order is display order: invariants first, acceptance criteria second,
+# deployment state last.
+CHECKS = (
+    checks.check_paper_trading,
+)
+
+
+def evaluate(snapshot: Snapshot) -> list[Finding]:
+    """Run every check against one snapshot. Pure.
+
+    A check returning None means "nothing to say"; it is omitted rather than
+    rendered as an empty row.
+    """
+    out: list[Finding] = []
+    for check in CHECKS:
+        result = check(snapshot)
+        if result is None:
+            continue
+        if isinstance(result, Finding):
+            out.append(result)
+        else:
+            out.extend(result)
+    return out

--- a/devcheck/evaluate.py
+++ b/devcheck/evaluate.py
@@ -8,6 +8,10 @@ from devcheck.model import Finding, Snapshot
 # deployment state last.
 CHECKS = (
     checks.check_paper_trading,
+    checks.check_trading_toolset,
+    checks.check_order_idempotency,
+    checks.check_outbox,
+    checks.check_db_broker_agreement,
 )
 
 

--- a/devcheck/evaluate.py
+++ b/devcheck/evaluate.py
@@ -39,6 +39,8 @@ def evaluate(snapshot: Snapshot) -> list[Finding]:
             out.append(result)
         else:
             out.extend(result)
+    # Runs last: it reads the other checks' output, not just the snapshot.
+    out.append(checks.check_issue_coverage(snapshot, out))
     return out
 
 

--- a/devcheck/evaluate.py
+++ b/devcheck/evaluate.py
@@ -12,6 +12,9 @@ CHECKS = (
     checks.check_order_idempotency,
     checks.check_outbox,
     checks.check_db_broker_agreement,
+    checks.check_degradations,
+    checks.check_checkpoints,
+    checks.check_journals,
 )
 
 

--- a/devcheck/model.py
+++ b/devcheck/model.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Mapping, Sequence
+
+
+@dataclass(frozen=True)
+class Finding:
+    check: str        # stable id, greppable, never localised
+    severity: str     # "ok" | "warn" | "alert"
+    detail: str
+
+
+@dataclass(frozen=True)
+class Position:
+    symbol: str
+    qty: float
+    covering_qty: float      # shares covered by live stops, per design.md §5
+
+
+@dataclass(frozen=True)
+class OpenOrder:
+    symbol: str
+    side: str
+    qty: float
+    type: str
+    status: str
+
+
+@dataclass(frozen=True)
+class OrderRow:
+    client_order_id: str
+    symbol: str
+
+
+@dataclass(frozen=True)
+class ServiceResult:
+    unit: str
+    result: str          # "success" | "exit-code" | "unreachable" | ...
+    last_run: str        # ISO or "" when never
+
+
+@dataclass(frozen=True)
+class Snapshot:
+    """One complete read of production. Every field is data; nothing here
+    computes. Built by scripts/dev_status.py, consumed by evaluate()."""
+
+    droplet_env: Mapping[str, str]
+    seat_trading_toolsets: Mapping[str, bool]
+    orders: Sequence[OrderRow]
+    tickets: Mapping[str, str]          # ticket id -> symbol
+    events_unposted: int
+    broker_fill_count: int
+    checkpoints: Sequence[tuple[str, str, str]]   # (run_date, stage, status)
+    journals_written: frozenset[str] | set[str]
+    seats_participating: frozenset[str] | set[str]
+    scorecard_codes: Sequence[str]
+    positions: Sequence[Position]
+    open_orders: Sequence[OpenOrder]
+    due_unresolved: Sequence[int]       # decision ids past horizon with no resolution
+    droplet_head: str
+    origin_master: str
+    commits_behind: int
+    services: Mapping[str, ServiceResult]
+    suppressed: frozenset[str] = field(default_factory=frozenset)

--- a/devcheck/model.py
+++ b/devcheck/model.py
@@ -63,3 +63,4 @@ class Snapshot:
     commits_behind: int
     services: Mapping[str, ServiceResult]
     suppressed: frozenset[str] = field(default_factory=frozenset)
+    tracked_checks: frozenset[str] = field(default_factory=frozenset)

--- a/devcheck/model.py
+++ b/devcheck/model.py
@@ -62,5 +62,7 @@ class Snapshot:
     origin_master: str
     commits_behind: int
     services: Mapping[str, ServiceResult]
+    broker_error: str = ""             # why the book was unread, when it was
+    db_read_ok: bool = True            # False = the fund DB could not be read at all
     suppressed: frozenset[str] = field(default_factory=frozenset)
     tracked_checks: frozenset[str] = field(default_factory=frozenset)

--- a/devcheck/model.py
+++ b/devcheck/model.py
@@ -50,12 +50,12 @@ class Snapshot:
     orders: Sequence[OrderRow]
     tickets: Mapping[str, str]          # ticket id -> symbol
     events_unposted: int
-    broker_fill_count: int
+    broker_fill_count: int | None      # None = not read; never defaulted to agreement
     checkpoints: Sequence[tuple[str, str, str]]   # (run_date, stage, status)
     journals_written: frozenset[str] | set[str]
     seats_participating: frozenset[str] | set[str]
     scorecard_codes: Sequence[str]
-    positions: Sequence[Position]
+    positions: Sequence[Position] | None   # None = not read; never inferred
     open_orders: Sequence[OpenOrder]
     due_unresolved: Sequence[int]       # decision ids past horizon with no resolution
     droplet_head: str

--- a/devcheck/render.py
+++ b/devcheck/render.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+from devcheck.model import Finding
+
+_ORDER = {"alert": 0, "warn": 1, "ok": 2}
+_MARK = {"alert": "🔴", "warn": "🟡", "ok": "🟢"}
+
+
+def render(findings: Sequence[Finding]) -> str:
+    """Markdown, worst first. Every check appears, including the healthy ones:
+    a reader must be able to tell "checked and fine" from "not checked"."""
+    if not findings:
+        return "_no checks ran — this is itself a finding_\n"
+    lines = ["| | check | detail |", "|---|---|---|"]
+    for f in sorted(findings, key=lambda f: (_ORDER.get(f.severity, 3), f.check)):
+        lines.append(f"| {_MARK.get(f.severity, '⚪')} | `{f.check}` | {f.detail} |")
+    return "\n".join(lines) + "\n"

--- a/scripts/check_purity.py
+++ b/scripts/check_purity.py
@@ -57,7 +57,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 
 PURE_PACKAGES = ["gate", "stratgate", "fundbt", "calibration", "orchestrator",
-                 "state", "market", "slackkit"]
+                 "state", "market", "slackkit", "devcheck"]
 # Paths (relative to ROOT, posix) inside a pure package that are exempt.
 EXCLUDED_FILES = {"slackkit/real.py"}
 # Matched as dotted prefixes: "agents" covers agents.runtime, and

--- a/scripts/dev_status.py
+++ b/scripts/dev_status.py
@@ -138,6 +138,26 @@ def _seat_trading_toolsets() -> dict[str, bool]:
     return out
 
 
+def _tracked_checks() -> frozenset[str]:
+    """Open issues labelled check:<id>. Any gh failure means "nothing is
+    tracked" — the check then over-reports, which is the safe direction."""
+    try:
+        out = subprocess.run(
+            ["gh", "issue", "list", "--state", "open", "--limit", "100",
+             "--json", "labels", "-q", ".[].labels[].name"],
+            capture_output=True, text=True, timeout=20, cwd=str(ROOT),
+        )
+    except (OSError, subprocess.SubprocessError):
+        return frozenset()
+    if out.returncode != 0:
+        return frozenset()
+    return frozenset(
+        line.strip()[len("check:"):]
+        for line in out.stdout.splitlines()
+        if line.strip().startswith("check:")
+    )
+
+
 def _service(unit: str) -> ServiceResult:
     raw = _ssh(f"systemctl show {unit}.service -p Result -p ExecMainExitTimestamp --value")
     if raw is None:
@@ -257,6 +277,7 @@ def build_snapshot() -> Snapshot:
         commits_behind=behind,
         services={u: _service(u) for u in UNITS},
         suppressed=read_suppressed(HEALTH),
+        tracked_checks=_tracked_checks(),
     )
 
 

--- a/scripts/dev_status.py
+++ b/scripts/dev_status.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Read-only production health check for developers.
+
+    make dev-status
+
+Answers one question: is every stated invariant and Phase 2 acceptance
+criterion still true on the box that trades? The checks live in devcheck/ and
+are pure; this file is the only place that opens an ssh connection, a broker
+client, or the database.
+
+READ-ONLY, ALWAYS. Nothing here writes, places, cancels, amends or deploys.
+Every finding is for a human to act on.
+
+EXIT 0 ALWAYS. A check that cannot run renders as a finding. A non-zero exit
+would hide every other check behind the first failure, which is the opposite
+of the job.
+
+EVERY PRODUCTION READ IS AGAINST THE DROPLET, NOT THIS CHECKOUT. The local
+tree is not what trades — reading `agents/config/*.yaml` here would check the
+wrong host and always agree with the suite that just went green.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from devcheck.evaluate import apply_suppression, evaluate      # noqa: E402
+from devcheck.model import (                                   # noqa: E402
+    OrderRow,
+    Position,
+    ServiceResult,
+    Snapshot,
+)
+from devcheck.render import render                             # noqa: E402
+
+HEALTH = ROOT / ".claude" / "health.md"
+
+DROPLET = "root@138.197.47.97"
+REMOTE_ROOT = "/opt/fund"
+REMOTE_DB = "/var/lib/fund/fund.db"
+UNITS = ("fund-daily", "fund-pnl")
+SEATS = ("exec", "pm", "analyst", "news", "critic")
+
+
+def read_suppressed(path: Path) -> frozenset[str]:
+    """Parse `suppress:` from the descriptor's YAML front matter.
+
+    Absent file, absent key, or malformed front matter all mean "suppress
+    nothing" — never a crash. A descriptor problem must not be able to stop
+    the checks from running.
+    """
+    try:
+        text = path.read_text()
+    except OSError:
+        return frozenset()
+    if not text.startswith("---"):
+        return frozenset()
+    _, _, rest = text.partition("---")
+    front, _, _ = rest.partition("---")
+    out: set[str] = set()
+    in_block = False
+    for line in front.splitlines():
+        if line.strip().startswith("suppress:"):
+            in_block = True
+            continue
+        if in_block:
+            stripped = line.strip()
+            if stripped.startswith("- "):
+                out.add(stripped[2:].strip())
+            elif stripped:
+                break
+    return frozenset(out)
+
+
+def _ssh(cmd: str, timeout: int = 15) -> str | None:
+    """Run one read-only command on the droplet. None on any failure.
+
+    None means "could not read", never "read an empty result" — the callers
+    depend on that difference, because rendering absence as health is the
+    exact failure this package exists to prevent.
+    """
+    try:
+        out = subprocess.run(
+            ["ssh", "-o", "ConnectTimeout=10", "-o", "BatchMode=yes", DROPLET, cmd],
+            capture_output=True, text=True, timeout=timeout,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return out.stdout if out.returncode == 0 else None
+
+
+def _sql(query: str) -> list[list[str]] | None:
+    """One read-only SQLite query on the droplet's live database.
+
+    `mode=ro` is load-bearing: opening the live DB read-write would apply a
+    pending migration as a side effect of a health check (issue #17's shape).
+    """
+    raw = _ssh(
+        f"sqlite3 -separator '\\x1f' 'file:{REMOTE_DB}?mode=ro' \"{query}\"",
+        timeout=20,
+    )
+    if raw is None:
+        return None
+    return [line.split("\x1f") for line in raw.splitlines() if line.strip()]
+
+
+def _droplet_env() -> dict[str, str]:
+    raw = _ssh(
+        f"grep -hE '^ALPACA_PAPER_TRADE=' {REMOTE_ROOT}/.env /etc/fund/env 2>/dev/null | head -1"
+    )
+    if not raw or "=" not in raw:
+        return {}
+    _, _, value = raw.strip().partition("ALPACA_PAPER_TRADE=")
+    return {"ALPACA_PAPER_TRADE": value.strip().strip("'\"")}
+
+
+def _seat_trading_toolsets() -> dict[str, bool]:
+    """Which seats hold the `trading` toolset ON THE DROPLET.
+
+    Read remotely on purpose. The local checkout is not what runs, so a local
+    read would confirm the invariant against a file no seat ever loads.
+    An unreadable config yields no entry rather than a False, so a failed read
+    can never be mistaken for "this seat is safe".
+    """
+    raw = _ssh(f"grep -H '^alpaca_toolsets:' {REMOTE_ROOT}/agents/config/*.yaml 2>/dev/null")
+    if raw is None:
+        return {}
+    out: dict[str, bool] = {}
+    for line in raw.splitlines():
+        path, _, value = line.partition(":")
+        seat = Path(path).stem
+        if seat in SEATS:
+            out[seat] = "trading" in value.split("#")[0]
+    return out
+
+
+def _service(unit: str) -> ServiceResult:
+    raw = _ssh(f"systemctl show {unit}.service -p Result -p ExecMainExitTimestamp --value")
+    if raw is None:
+        return ServiceResult(unit, "unreachable", "")
+    parts = [p.strip() for p in raw.splitlines() if p.strip()]
+    result = parts[0] if parts else "unknown"
+    last = parts[1] if len(parts) > 1 else ""
+    return ServiceResult(unit, result, last)
+
+
+def _deploy_state() -> tuple[str, str, int]:
+    """(droplet HEAD, origin/master, commits the droplet is behind).
+
+    The count is computed locally against a freshly fetched origin/master, so
+    it cannot be stale in the way a hand-quoted SHA is. An unreachable droplet
+    yields a 0 count beside an empty head — `deploy_state` then reads ok while
+    `services` alerts unreachable, which is the honest split: nothing was
+    measured about the deploy, and the reason is already on the report.
+    """
+    head = (_ssh(f"git -C {REMOTE_ROOT} rev-parse HEAD") or "").strip()
+    subprocess.run(["git", "-C", str(ROOT), "fetch", "--quiet", "origin", "master"],
+                   capture_output=True, timeout=60, check=False)
+    origin = _run_local("git", "-C", str(ROOT), "rev-parse", "origin/master")
+    if not head:
+        return "unreadable", origin[:7], 0
+    behind = _run_local("git", "-C", str(ROOT), "rev-list", "--count", f"{head}..origin/master")
+    return head[:7], origin[:7], int(behind) if behind.isdigit() else 0
+
+
+def _run_local(*argv: str) -> str:
+    try:
+        out = subprocess.run(list(argv), capture_output=True, text=True, timeout=30)
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    return out.stdout.strip() if out.returncode == 0 else ""
+
+
+def _positions_and_coverage() -> tuple[list[Position] | None, list, int | None]:
+    """Positions with aggregate stop coverage, straight from the broker.
+
+    Coverage is computed by orchestrator.protection._covering_qty — the same
+    function the fund's own protection pass uses. Re-deriving it here would
+    be a second answer to a question that already has one, and its careful
+    'unreadable order means unknown, never a smaller number' behaviour is the
+    part a re-derivation would lose.
+    """
+    try:
+        from market.source_alpaca import AlpacaSource
+        from orchestrator.protection import _CLOSING_SIDE, _covering_qty, _qty
+    except Exception:
+        return None, [], None
+    try:
+        source = AlpacaSource()
+        raw_positions = source.open_positions()
+        raw_orders = source.open_orders()
+    except Exception:
+        return None, [], None
+
+    out: list[Position] = []
+    for raw in raw_positions:
+        p = raw if isinstance(raw, dict) else {}
+        symbol = str(p.get("symbol") or "?")
+        held = _qty(p.get("qty"))
+        closing_side = _CLOSING_SIDE.get(str(p.get("side") or "").lower())
+        if held is None or closing_side is None:
+            # Unreadable: report zero cover so it alerts. Never silently ok.
+            out.append(Position(symbol, qty=1.0, covering_qty=0.0))
+            continue
+        covered = _covering_qty(raw_orders, symbol, closing_side)
+        out.append(Position(symbol, float(held), float(covered) if covered is not None else 0.0))
+
+    # AlpacaSource has no fill-history method, so this stays None and
+    # db_broker_agreement reports itself unwired. Defaulting it to len(orders)
+    # would print a green row for a comparison nobody performed.
+    return out, raw_orders, None
+
+
+def build_snapshot() -> Snapshot:
+    """Build one Snapshot from production. The only I/O in the package.
+
+    Each reader is wrapped so a failure becomes data — an unreachable droplet
+    yields ServiceResult(result="unreachable"), never an exception that hides
+    the broker and database checks behind it.
+    """
+    orders_rows = _sql("select client_order_id, symbol from orders") or []
+    ticket_rows = _sql("select id, ticker from tickets") or []
+    unposted = _sql("select count(*) from events where posted_at is null")
+    checkpoint_rows = _sql(
+        "select run_date, stage, status from checkpoints "
+        "where run_date = (select max(run_date) from checkpoints)"
+    ) or []
+    due_rows = _sql(
+        "select d.id from decisions d left join resolutions r on r.decision_id = d.id "
+        "where r.id is null and d.action in ('buy','sell') "
+        "and date(d.run_date, '+7 day') <= date('now')"
+    ) or []
+
+    positions, _open_orders, broker_fills = _positions_and_coverage()
+    head, origin, behind = _deploy_state()
+
+    return Snapshot(
+        droplet_env=_droplet_env(),
+        seat_trading_toolsets=_seat_trading_toolsets(),
+        orders=[OrderRow(r[0], r[1] if len(r) > 1 else "") for r in orders_rows],
+        tickets={r[0]: (r[1] if len(r) > 1 else "") for r in ticket_rows},
+        events_unposted=int(unposted[0][0]) if unposted and unposted[0][0].isdigit() else 0,
+        broker_fill_count=broker_fills,
+        checkpoints=[(r[0], r[1], r[2]) for r in checkpoint_rows if len(r) >= 3],
+        journals_written=_journals_written(),
+        seats_participating={r[1] for r in checkpoint_rows if len(r) > 1} & set(SEATS),
+        scorecard_codes=_scorecard_codes(),
+        positions=positions,
+        open_orders=[],
+        due_unresolved=[int(r[0]) for r in due_rows if r[0].isdigit()],
+        droplet_head=head,
+        origin_master=origin,
+        commits_behind=behind,
+        services={u: _service(u) for u in UNITS},
+        suppressed=read_suppressed(HEALTH),
+    )
+
+
+def _journals_written() -> set[str]:
+    """Seats with a journal entry for the droplet's latest run date."""
+    raw = _ssh(f"ls {REMOTE_ROOT}/journals 2>/dev/null")
+    if raw is None:
+        return set()
+    return {Path(n.strip()).stem for n in raw.splitlines() if n.strip()} & set(SEATS)
+
+
+def _scorecard_codes() -> list[str]:
+    """Alert codes raised on the droplet's most recent run date."""
+    rows = _sql(
+        "select kind from events where date(created_at) = "
+        "(select max(date(created_at)) from events)"
+    ) or []
+    return [r[0] for r in rows if r]
+
+
+def main() -> int:
+    snapshot = build_snapshot()
+    findings = apply_suppression(evaluate(snapshot), read_suppressed(HEALTH))
+    print(render(findings))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev_status.py
+++ b/scripts/dev_status.py
@@ -21,6 +21,8 @@ wrong host and always agree with the suite that just went green.
 """
 from __future__ import annotations
 
+import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -41,7 +43,12 @@ HEALTH = ROOT / ".claude" / "health.md"
 
 DROPLET = "root@138.197.47.97"
 REMOTE_ROOT = "/opt/fund"
-REMOTE_DB = "/var/lib/fund/fund.db"
+# NOT a constant: the path is read from the droplet's own FUND_DB, because a
+# hardcoded guess is silently wrong rather than loudly wrong. The first guess
+# here was /var/lib/fund/fund.db, which EXISTS on the box as a 0-byte stray
+# file — so every query returned no rows with exit 0 and five checks rendered
+# green against an empty database.
+_ENV_CACHE: dict[str, str | None] = {}
 UNITS = ("fund-daily", "fund-pnl")
 SEATS = ("exec", "pm", "analyst", "news", "critic")
 
@@ -93,29 +100,63 @@ def _ssh(cmd: str, timeout: int = 15) -> str | None:
     return out.stdout if out.returncode == 0 else None
 
 
-def _sql(query: str) -> list[list[str]] | None:
-    """One read-only SQLite query on the droplet's live database.
+def _droplet_var(name: str) -> str | None:
+    """One variable from the droplet's own environment files.
 
-    `mode=ro` is load-bearing: opening the live DB read-write would apply a
-    pending migration as a side effect of a health check (issue #17's shape).
+    Every path this script reads comes from here rather than a constant. Both
+    hardcoded guesses in the first draft — the database and the journals root
+    — resolved to real but empty locations on the box, so the checks that
+    depended on them rendered green against nothing.
     """
-    raw = _ssh(
-        f"sqlite3 -separator '\\x1f' 'file:{REMOTE_DB}?mode=ro' \"{query}\"",
-        timeout=20,
-    )
+    if name not in _ENV_CACHE:
+        raw = _ssh(f"grep -h '^{name}=' /etc/fund/env {REMOTE_ROOT}/.env 2>/dev/null | head -1")
+        value = None
+        if raw and "=" in raw:
+            _, _, rest = raw.strip().partition(f"{name}=")
+            value = rest.strip().strip("'\"") or None
+        _ENV_CACHE[name] = value
+    return _ENV_CACHE[name]
+
+
+def _remote_db() -> str | None:
+    """The droplet's FUND_DB, read from the same env the fund itself uses."""
+    return _droplet_var("FUND_DB")
+
+
+def _sql(query: str) -> list[dict] | None:
+    """One read-only SQLite query on the droplet's live database, as JSON.
+
+    None means the read failed; the caller must never turn that into an empty
+    result. `mode=ro` is load-bearing twice over: opening the live DB
+    read-write would apply a pending migration as a side effect of a health
+    check (issue #17's shape), and it makes a missing file an ERROR rather
+    than an empty database sqlite3 helpfully creates.
+
+    -json rather than a separator. A `-separator '\\x1f'` passed through ssh
+    arrives as the four literal characters, so every multi-column row came
+    back unsplit as one string — checkpoints then filtered itself to zero and
+    printed "0 checkpoint(s), all done" against 56 real rows. JSON has no
+    separator to get wrong, and a malformed reply raises here rather than
+    quietly losing columns.
+    """
+    db = _remote_db()
+    if db is None:
+        return None
+    raw = _ssh(f"sqlite3 -json 'file:{db}?mode=ro' \"{query}\"", timeout=20)
     if raw is None:
         return None
-    return [line.split("\x1f") for line in raw.splitlines() if line.strip()]
+    if not raw.strip():
+        return []
+    try:
+        parsed = json.loads(raw)
+    except ValueError:
+        return None
+    return parsed if isinstance(parsed, list) else None
 
 
 def _droplet_env() -> dict[str, str]:
-    raw = _ssh(
-        f"grep -hE '^ALPACA_PAPER_TRADE=' {REMOTE_ROOT}/.env /etc/fund/env 2>/dev/null | head -1"
-    )
-    if not raw or "=" not in raw:
-        return {}
-    _, _, value = raw.strip().partition("ALPACA_PAPER_TRADE=")
-    return {"ALPACA_PAPER_TRADE": value.strip().strip("'\"")}
+    value = _droplet_var("ALPACA_PAPER_TRADE")
+    return {"ALPACA_PAPER_TRADE": value} if value is not None else {}
 
 
 def _seat_trading_toolsets() -> dict[str, bool]:
@@ -195,7 +236,7 @@ def _run_local(*argv: str) -> str:
     return out.stdout.strip() if out.returncode == 0 else ""
 
 
-def _positions_and_coverage() -> tuple[list[Position] | None, list, int | None]:
+def _positions_and_coverage() -> tuple[list[Position] | None, list, int | None, str]:
     """Positions with aggregate stop coverage, straight from the broker.
 
     Coverage is computed by orchestrator.protection._covering_qty — the same
@@ -207,14 +248,23 @@ def _positions_and_coverage() -> tuple[list[Position] | None, list, int | None]:
     try:
         from market.source_alpaca import AlpacaSource
         from orchestrator.protection import _CLOSING_SIDE, _covering_qty, _qty
-    except Exception:
-        return None, [], None
+    except Exception as exc:
+        return None, [], None, f"broker client unavailable: {exc}"
+
+    missing = [k for k in ("ALPACA_API_KEY", "ALPACA_SECRET_KEY") if not os.environ.get(k)]
+    if missing:
+        # Named explicitly: a local shell without credentials and a broker
+        # outage are different problems, and a red row that cannot tell them
+        # apart trains the reader to skip the row.
+        return None, [], None, (
+            f"{', '.join(missing)} not in this shell — run `set -a; source .env; set +a`"
+        )
     try:
         source = AlpacaSource()
         raw_positions = source.open_positions()
         raw_orders = source.open_orders()
-    except Exception:
-        return None, [], None
+    except Exception as exc:
+        return None, [], None, f"broker read failed: {exc}"
 
     out: list[Position] = []
     for raw in raw_positions:
@@ -232,7 +282,7 @@ def _positions_and_coverage() -> tuple[list[Position] | None, list, int | None]:
     # AlpacaSource has no fill-history method, so this stays None and
     # db_broker_agreement reports itself unwired. Defaulting it to len(orders)
     # would print a green row for a comparison nobody performed.
-    return out, raw_orders, None
+    return out, raw_orders, None, ""
 
 
 def build_snapshot() -> Snapshot:
@@ -242,6 +292,12 @@ def build_snapshot() -> Snapshot:
     yields ServiceResult(result="unreachable"), never an exception that hides
     the broker and database checks behind it.
     """
+    # A probe first: it distinguishes "the database has no rows" from "the
+    # database was never read", which every query below would otherwise
+    # collapse into the same empty list.
+    probe = _sql("select count(*) from orders")
+    db_read_ok = probe is not None
+
     orders_rows = _sql("select client_order_id, symbol from orders") or []
     ticket_rows = _sql("select id, ticker from tickets") or []
     unposted = _sql("select count(*) from events where posted_at is null")
@@ -255,35 +311,55 @@ def build_snapshot() -> Snapshot:
         "and date(d.run_date, '+7 day') <= date('now')"
     ) or []
 
-    positions, _open_orders, broker_fills = _positions_and_coverage()
+    run_date = str(checkpoint_rows[0]["run_date"]) if checkpoint_rows else ""
+    participants = _sql(
+        "select distinct agent from costs where run_date = "
+        "(select max(run_date) from costs)"
+    ) or []
+
+    positions, _open_orders, broker_fills, broker_error = _positions_and_coverage()
     head, origin, behind = _deploy_state()
 
     return Snapshot(
         droplet_env=_droplet_env(),
         seat_trading_toolsets=_seat_trading_toolsets(),
-        orders=[OrderRow(r[0], r[1] if len(r) > 1 else "") for r in orders_rows],
-        tickets={r[0]: (r[1] if len(r) > 1 else "") for r in ticket_rows},
-        events_unposted=int(unposted[0][0]) if unposted and unposted[0][0].isdigit() else 0,
+        orders=[OrderRow(str(r["client_order_id"]), str(r.get("symbol") or "")) for r in orders_rows],
+        tickets={str(r["id"]): str(r.get("ticker") or "") for r in ticket_rows},
+        events_unposted=int(next(iter(unposted[0].values()))) if unposted else 0,
         broker_fill_count=broker_fills,
-        checkpoints=[(r[0], r[1], r[2]) for r in checkpoint_rows if len(r) >= 3],
-        journals_written=_journals_written(),
-        seats_participating={r[1] for r in checkpoint_rows if len(r) > 1} & set(SEATS),
+        checkpoints=[(str(r["run_date"]), str(r["stage"]), str(r["status"])) for r in checkpoint_rows],
+        journals_written=_journals_written(run_date),
+        seats_participating={str(r["agent"]) for r in participants} & set(SEATS),
         scorecard_codes=_scorecard_codes(),
         positions=positions,
         open_orders=[],
-        due_unresolved=[int(r[0]) for r in due_rows if r[0].isdigit()],
+        due_unresolved=[int(r["id"]) for r in due_rows],
         droplet_head=head,
         origin_master=origin,
         commits_behind=behind,
         services={u: _service(u) for u in UNITS},
+        broker_error=broker_error,
+        db_read_ok=db_read_ok,
         suppressed=read_suppressed(HEALTH),
         tracked_checks=_tracked_checks(),
     )
 
 
-def _journals_written() -> set[str]:
-    """Seats with a journal entry for the droplet's latest run date."""
-    raw = _ssh(f"ls {REMOTE_ROOT}/journals 2>/dev/null")
+def _journals_written(run_date: str) -> set[str]:
+    """Seats whose journal carries a `## <run_date>` entry.
+
+    The root comes from FUND_JOURNALS, not a constant: /opt/fund/journals
+    exists on the box and holds only a .gitkeep, so listing it reported every
+    seat silent while the real journals sat in /var/lib/fund.
+
+    Scoped to the run date on purpose. A seat that wrote an entry last week
+    has a file, and a check that only asked whether the file exists would go
+    green for a seat that said nothing today.
+    """
+    root = _droplet_var("FUND_JOURNALS")
+    if root is None or not run_date:
+        return set()
+    raw = _ssh(f"grep -l '^## {run_date}$' {root}/*.md 2>/dev/null")
     if raw is None:
         return set()
     return {Path(n.strip()).stem for n in raw.splitlines() if n.strip()} & set(SEATS)
@@ -295,7 +371,7 @@ def _scorecard_codes() -> list[str]:
         "select kind from events where date(created_at) = "
         "(select max(date(created_at)) from events)"
     ) or []
-    return [r[0] for r in rows if r]
+    return [str(r["kind"]) for r in rows if r.get("kind")]
 
 
 def main() -> int:

--- a/tests/test_dev_status_job.py
+++ b/tests/test_dev_status_job.py
@@ -1,0 +1,53 @@
+"""Offline tests for the dev-status job's seams.
+
+scripts/dev_status.py is a composition root like scripts/resolve_day.py, so
+main() is never called here — it opens ssh connections and a broker client.
+What is pinned is what the job DEPENDS on: every dependency it declares is a
+way for the job to go silent.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "dev_status.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("dev_status", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_script_exists():
+    assert SCRIPT.exists()
+
+
+def test_exposes_build_snapshot_and_main():
+    m = _load()
+    assert callable(m.build_snapshot)
+    assert callable(m.main)
+
+
+def test_reads_suppression_from_health_descriptor(tmp_path):
+    """The descriptor's front matter is the only source of suppression."""
+    m = _load()
+    health = tmp_path / "health.md"
+    health.write_text(
+        "---\n"
+        "health_command: make dev-status\n"
+        "suppress:\n"
+        "  - degradations\n"
+        "---\n\n"
+        "# prose\n"
+    )
+    assert m.read_suppressed(health) == frozenset({"degradations"})
+
+
+def test_missing_descriptor_suppresses_nothing(tmp_path):
+    """Negative control: no file means no suppression, never a crash."""
+    m = _load()
+    assert m.read_suppressed(tmp_path / "absent.md") == frozenset()

--- a/tests/test_devcheck_checks.py
+++ b/tests/test_devcheck_checks.py
@@ -10,7 +10,7 @@ passed, and two were caught by luck.
 from __future__ import annotations
 
 from devcheck.evaluate import evaluate
-from devcheck.model import Snapshot
+from devcheck.model import OrderRow, Snapshot
 
 
 def _snap(**over) -> Snapshot:
@@ -59,3 +59,66 @@ def test_paper_trading_missing_alerts():
     findings = evaluate(_snap(droplet_env={}))
     paper = [f for f in findings if f.check == "paper_trading"]
     assert paper[0].severity == "alert"
+
+
+def _only(findings, check):
+    matches = [f for f in findings if f.check == check]
+    assert len(matches) == 1, f"expected exactly one {check}, got {matches}"
+    return matches[0]
+
+
+def test_trading_toolset_exec_only_is_ok():
+    assert _only(evaluate(_snap()), "trading_toolset").severity == "ok"
+
+
+def test_trading_toolset_second_seat_alerts():
+    """Negative control for invariant 2."""
+    f = _only(evaluate(_snap(seat_trading_toolsets={"exec": True, "pm": True})), "trading_toolset")
+    assert f.severity == "alert"
+    assert "pm" in f.detail
+
+
+def test_trading_toolset_exec_missing_alerts():
+    """Exec losing `trading` is silent otherwise: the day just never fills."""
+    f = _only(evaluate(_snap(seat_trading_toolsets={"exec": False})), "trading_toolset")
+    assert f.severity == "alert"
+
+
+def test_order_idempotency_ok_when_every_coid_is_a_ticket():
+    s = _snap(orders=[OrderRow("t-1", "NVDA")], tickets={"t-1": "NVDA"})
+    assert _only(evaluate(s), "order_idempotency").severity == "ok"
+
+
+def test_order_idempotency_alerts_on_unknown_coid():
+    """Negative control for invariant 5 — a coid that is not a ticket id
+    means an order the gate did not authorise, or a minted retry id."""
+    s = _snap(orders=[OrderRow("free-form", "NVDA")], tickets={"t-1": "NVDA"})
+    f = _only(evaluate(s), "order_idempotency")
+    assert f.severity == "alert"
+    assert "free-form" in f.detail
+
+
+def test_outbox_ok_when_drained():
+    assert _only(evaluate(_snap()), "outbox").severity == "ok"
+
+
+def test_outbox_alerts_on_backlog():
+    """Negative control for invariant 6 — Slack is the projection, and an
+    undrained outbox means it is silently stale."""
+    f = _only(evaluate(_snap(events_unposted=3)), "outbox")
+    assert f.severity == "alert"
+    assert "3" in f.detail
+
+
+def test_db_broker_agreement_ok_when_counts_match():
+    s = _snap(orders=[OrderRow("t-1", "NVDA")], tickets={"t-1": "NVDA"}, broker_fill_count=1)
+    assert _only(evaluate(s), "db_broker_agreement").severity == "ok"
+
+
+def test_db_broker_agreement_alerts_when_broker_saw_more():
+    """Negative control for invariant 6 — SQLite is the source of truth, so
+    the broker having seen fills the DB has no row for is a divergence."""
+    s = _snap(orders=[OrderRow("t-1", "NVDA")], tickets={"t-1": "NVDA"}, broker_fill_count=3)
+    f = _only(evaluate(s), "db_broker_agreement")
+    assert f.severity == "alert"
+    assert "1" in f.detail and "3" in f.detail

--- a/tests/test_devcheck_checks.py
+++ b/tests/test_devcheck_checks.py
@@ -10,7 +10,7 @@ passed, and two were caught by luck.
 from __future__ import annotations
 
 from devcheck.evaluate import evaluate
-from devcheck.model import OrderRow, Snapshot
+from devcheck.model import OrderRow, Position, Snapshot
 
 
 def _snap(**over) -> Snapshot:
@@ -182,3 +182,29 @@ def test_reflection_alerts_when_something_is_due_and_unresolved():
     f = _only(evaluate(_snap(due_unresolved=[1, 2])), "reflection")
     assert f.severity == "alert"
     assert "2" in f.detail
+
+
+def test_coverage_ok_when_fully_covered():
+    s = _snap(positions=[Position("NVDA", qty=40, covering_qty=40)])
+    assert _only(evaluate(s), "position_coverage").severity == "ok"
+
+
+def test_coverage_alerts_on_a_naked_position():
+    """2026-08-21's actual state: 40 shares, zero open orders, no stop."""
+    s = _snap(positions=[Position("NVDA", qty=40, covering_qty=0)])
+    f = _only(evaluate(s), "position_coverage")
+    assert f.severity == "alert"
+    assert "NVDA" in f.detail and "0" in f.detail and "40" in f.detail
+
+
+def test_coverage_alerts_on_partial_cover():
+    """Aggregate protection: N shares covered by one or more stops. Partial
+    cover is exposure, not protection."""
+    s = _snap(positions=[Position("NVDA", qty=80, covering_qty=40)])
+    f = _only(evaluate(s), "position_coverage")
+    assert f.severity == "alert"
+
+
+def test_coverage_ok_with_no_positions():
+    """Flat is not exposed. The check must not fire on an empty book."""
+    assert _only(evaluate(_snap(positions=[])), "position_coverage").severity == "ok"

--- a/tests/test_devcheck_checks.py
+++ b/tests/test_devcheck_checks.py
@@ -10,7 +10,7 @@ passed, and two were caught by luck.
 from __future__ import annotations
 
 from devcheck.evaluate import evaluate
-from devcheck.model import OrderRow, Position, Snapshot
+from devcheck.model import OrderRow, Position, ServiceResult, Snapshot
 
 
 def _snap(**over) -> Snapshot:
@@ -208,3 +208,38 @@ def test_coverage_alerts_on_partial_cover():
 def test_coverage_ok_with_no_positions():
     """Flat is not exposed. The check must not fire on an empty book."""
     assert _only(evaluate(_snap(positions=[])), "position_coverage").severity == "ok"
+
+
+def test_deploy_state_ok_when_level():
+    assert _only(evaluate(_snap()), "deploy_state").severity == "ok"
+
+
+def test_deploy_state_warns_when_behind():
+    """Behind is normal and worth seeing — the box is not running the code
+    the suite just went green against."""
+    s = _snap(droplet_head="aaa1111", origin_master="bbb2222", commits_behind=22)
+    f = _only(evaluate(s), "deploy_state")
+    assert f.severity == "warn"
+    assert "22" in f.detail
+
+
+def test_services_ok_when_all_succeeded():
+    s = _snap(services={"fund-daily": ServiceResult("fund-daily", "success", "2026-08-21T09:35")})
+    assert _only(evaluate(s), "services").severity == "ok"
+
+
+def test_services_alert_on_failure():
+    """2026-08-21: fund-daily.service exited 1 at 09:38 and sat 8h."""
+    s = _snap(services={"fund-daily": ServiceResult("fund-daily", "exit-code", "2026-08-21T09:38")})
+    f = _only(evaluate(s), "services")
+    assert f.severity == "alert"
+    assert "fund-daily" in f.detail
+
+
+def test_services_alert_when_droplet_unreachable():
+    """Spec §4: droplet unreachable renders as a finding; other checks still
+    run. Absence of data is never rendered as health."""
+    s = _snap(services={"fund-daily": ServiceResult("fund-daily", "unreachable", "")})
+    f = _only(evaluate(s), "services")
+    assert f.severity == "alert"
+    assert "unreachable" in f.detail

--- a/tests/test_devcheck_checks.py
+++ b/tests/test_devcheck_checks.py
@@ -1,0 +1,61 @@
+"""Unit tests for devcheck's pure checks.
+
+Every check is a pure function of a Snapshot, so each test states a whole
+world and asserts one verdict. Each check gets a negative control: a world
+where it MUST fire. A check whose negative control also passes is not a
+check — three tests in this repo passed on 2026-08-21 because they always
+passed, and two were caught by luck.
+"""
+
+from __future__ import annotations
+
+from devcheck.evaluate import evaluate
+from devcheck.model import Snapshot
+
+
+def _snap(**over) -> Snapshot:
+    """A wholly healthy world. Each test darkens exactly one field."""
+    base = dict(
+        droplet_env={"ALPACA_PAPER_TRADE": "true"},
+        seat_trading_toolsets={"exec": True, "pm": False, "analyst": False, "news": False},
+        orders=[],
+        tickets={},
+        events_unposted=0,
+        broker_fill_count=0,
+        checkpoints=[],
+        journals_written=set(),
+        seats_participating=set(),
+        scorecard_codes=[],
+        positions=[],
+        open_orders=[],
+        due_unresolved=[],
+        droplet_head="abc1234",
+        origin_master="abc1234",
+        commits_behind=0,
+        services={},
+        suppressed=frozenset(),
+    )
+    base.update(over)
+    return Snapshot(**base)
+
+
+def test_paper_trading_true_is_ok():
+    findings = evaluate(_snap())
+    paper = [f for f in findings if f.check == "paper_trading"]
+    assert len(paper) == 1
+    assert paper[0].severity == "ok"
+
+
+def test_paper_trading_false_alerts():
+    """Negative control for invariant 1 — the most important line in CLAUDE.md."""
+    findings = evaluate(_snap(droplet_env={"ALPACA_PAPER_TRADE": "false"}))
+    paper = [f for f in findings if f.check == "paper_trading"]
+    assert paper[0].severity == "alert"
+    assert "invariant 1" in paper[0].detail
+
+
+def test_paper_trading_missing_alerts():
+    """Absent is not the same as false, and both must alert."""
+    findings = evaluate(_snap(droplet_env={}))
+    paper = [f for f in findings if f.check == "paper_trading"]
+    assert paper[0].severity == "alert"

--- a/tests/test_devcheck_checks.py
+++ b/tests/test_devcheck_checks.py
@@ -243,3 +243,30 @@ def test_services_alert_when_droplet_unreachable():
     f = _only(evaluate(s), "services")
     assert f.severity == "alert"
     assert "unreachable" in f.detail
+
+
+def test_db_broker_agreement_warns_when_the_broker_could_not_be_read():
+    """Absence is never rendered as health (spec §4).
+
+    AlpacaSource exposes no fill history, so this count can genuinely be
+    unread. Defaulting an unread count to len(orders) would print 🟢 for a
+    comparison nobody performed — the exact "signal that changes meaning
+    without changing appearance" shape this package exists to remove.
+    """
+    s = _snap(orders=[OrderRow("t-1", "NVDA")], tickets={"t-1": "NVDA"}, broker_fill_count=None)
+    f = _only(evaluate(s), "db_broker_agreement")
+    assert f.severity == "warn"
+    assert "not read" in f.detail
+
+
+def test_coverage_alerts_when_the_book_could_not_be_read():
+    """The false green this check is most dangerous to have.
+
+    An unreachable broker yields no positions, and "0 position(s), every
+    share covered" is indistinguishable from a genuinely flat book. Spec §4:
+    a failed broker call renders as a finding, and position state is never
+    inferred. On 2026-08-21 an unknown exposure sat eight hours.
+    """
+    f = _only(evaluate(_snap(positions=None)), "position_coverage")
+    assert f.severity == "alert"
+    assert "not read" in f.detail

--- a/tests/test_devcheck_checks.py
+++ b/tests/test_devcheck_checks.py
@@ -321,3 +321,41 @@ def test_issue_coverage_does_not_nag_about_a_suppressed_check():
         tracked_checks=frozenset(),
     )
     assert _only(evaluate(s), "issue_coverage").severity == "ok"
+
+
+def test_unreadable_database_alerts_once_and_marks_its_checks_unknown():
+    """A failed DB read must not render as five green rows.
+
+    Found live: the script queried a path that existed as a 0-byte file, so
+    every query returned no rows with exit 0 and `order_idempotency`,
+    `outbox`, `checkpoints`, `journals` and `reflection` all printed 🟢. One
+    root cause alerts; the checks it starved say they were never checked,
+    rather than claiming health nobody measured.
+    """
+    findings = evaluate(_snap(db_read_ok=False))
+    assert _only(findings, "database").severity == "alert"
+    for check in ("order_idempotency", "outbox", "checkpoints", "journals", "reflection"):
+        f = _only(findings, check)
+        assert f.severity == "warn", f"{check} claimed {f.severity} off an unread database"
+        assert "not read" in f.detail
+
+
+def test_readable_database_is_ok_and_leaves_its_checks_alone():
+    """Negative control: the same checks keep their real verdicts."""
+    findings = evaluate(_snap())
+    assert _only(findings, "database").severity == "ok"
+    assert _only(findings, "outbox").severity == "ok"
+
+
+def test_unread_book_names_why_it_could_not_be_read():
+    """A red row whose cause is "no credentials in this shell" and one whose
+    cause is "the broker is down" must not look identical.
+
+    Without the distinction every local run shows a red top row for a local
+    setup reason, and a reader learns to skip the most important check in the
+    report inside a week — the same trained blindness suppression exists for.
+    """
+    f = _only(evaluate(_snap(positions=None, broker_error="no ALPACA_API_KEY in this shell")),
+              "position_coverage")
+    assert f.severity == "alert"
+    assert "no ALPACA_API_KEY in this shell" in f.detail

--- a/tests/test_devcheck_checks.py
+++ b/tests/test_devcheck_checks.py
@@ -122,3 +122,48 @@ def test_db_broker_agreement_alerts_when_broker_saw_more():
     f = _only(evaluate(s), "db_broker_agreement")
     assert f.severity == "alert"
     assert "1" in f.detail and "3" in f.detail
+
+
+def test_degradations_ok_when_none():
+    assert _only(evaluate(_snap()), "degradations").severity == "ok"
+
+
+def test_degradations_warn_on_gate_error():
+    """Invariant 4 says a gate_error resolves to HOLD, which is correct
+    behaviour — so this warns, it does not alert. The day was not wrong;
+    it was degraded, and a degraded day that nobody sees becomes normal."""
+    f = _only(evaluate(_snap(scorecard_codes=["gate_error"])), "degradations")
+    assert f.severity == "warn"
+    assert "gate_error" in f.detail
+
+
+def test_degradations_warn_on_pm_timeout():
+    f = _only(evaluate(_snap(scorecard_codes=["pm_timeout"])), "degradations")
+    assert f.severity == "warn"
+
+
+def test_checkpoints_ok_when_all_done():
+    s = _snap(checkpoints=[("2026-08-21", "research", "done"), ("2026-08-21", "gate", "done")])
+    assert _only(evaluate(s), "checkpoints").severity == "ok"
+
+
+def test_checkpoints_alert_on_unfinished_stage():
+    """Negative control — Phase 2 acceptance requires every checkpoint done."""
+    s = _snap(checkpoints=[("2026-08-21", "research", "done"), ("2026-08-21", "gate", "running")])
+    f = _only(evaluate(s), "checkpoints")
+    assert f.severity == "alert"
+    assert "gate" in f.detail
+
+
+def test_journals_ok_when_every_participant_wrote():
+    s = _snap(seats_participating={"pm", "analyst"}, journals_written={"pm", "analyst"})
+    assert _only(evaluate(s), "journals").severity == "ok"
+
+
+def test_journals_warn_when_a_participant_did_not_write():
+    """Phase 2 acceptance: after a day each participating seat has a journal
+    entry. Memory is load-bearing in this phase, so a silent seat matters."""
+    s = _snap(seats_participating={"pm", "analyst"}, journals_written={"pm"})
+    f = _only(evaluate(s), "journals")
+    assert f.severity == "warn"
+    assert "analyst" in f.detail

--- a/tests/test_devcheck_checks.py
+++ b/tests/test_devcheck_checks.py
@@ -167,3 +167,18 @@ def test_journals_warn_when_a_participant_did_not_write():
     f = _only(evaluate(s), "journals")
     assert f.severity == "warn"
     assert "analyst" in f.detail
+
+
+def test_reflection_ok_when_nothing_is_due():
+    """2026-08-21: resolutions empty, nothing past horizon. Correct, silent."""
+    assert _only(evaluate(_snap(due_unresolved=[])), "reflection").severity == "ok"
+
+
+def test_reflection_alerts_when_something_is_due_and_unresolved():
+    """2026-08-24: same empty table, decisions now past horizon. Dead job.
+
+    This pair is the point of the check — identical `resolutions` content,
+    opposite verdicts, distinguished only by whether anything is due."""
+    f = _only(evaluate(_snap(due_unresolved=[1, 2])), "reflection")
+    assert f.severity == "alert"
+    assert "2" in f.detail

--- a/tests/test_devcheck_checks.py
+++ b/tests/test_devcheck_checks.py
@@ -34,6 +34,7 @@ def _snap(**over) -> Snapshot:
         commits_behind=0,
         services={},
         suppressed=frozenset(),
+        tracked_checks=frozenset(),
     )
     base.update(over)
     return Snapshot(**base)
@@ -270,3 +271,53 @@ def test_coverage_alerts_when_the_book_could_not_be_read():
     f = _only(evaluate(_snap(positions=None)), "position_coverage")
     assert f.severity == "alert"
     assert "not read" in f.detail
+
+
+def test_issue_coverage_ok_when_alert_is_tracked():
+    s = _snap(
+        positions=[Position("NVDA", qty=40, covering_qty=0)],   # raises an alert
+        tracked_checks=frozenset({"position_coverage"}),
+    )
+    assert _only(evaluate(s), "issue_coverage").severity == "ok"
+
+
+def test_issue_coverage_alerts_when_an_alert_is_untracked():
+    """Negative control — the finding exists and nothing will remember it."""
+    s = _snap(
+        positions=[Position("NVDA", qty=40, covering_qty=0)],
+        tracked_checks=frozenset(),
+    )
+    f = _only(evaluate(s), "issue_coverage")
+    assert f.severity == "alert"
+    assert "position_coverage" in f.detail
+    assert "gh issue create" in f.detail
+
+
+def test_issue_coverage_ignores_warn_and_ok():
+    """Only alerts nag. A warn that nagged daily would train the reader to
+    skip the report, which is the failure suppression exists to prevent."""
+    s = _snap(commits_behind=22, tracked_checks=frozenset())   # deploy_state warns
+    assert _only(evaluate(s), "issue_coverage").severity == "ok"
+
+
+def test_issue_coverage_does_not_report_itself():
+    """Without this it alerts about its own alert, forever."""
+    s = _snap(positions=[Position("NVDA", qty=1, covering_qty=0)], tracked_checks=frozenset())
+    f = _only(evaluate(s), "issue_coverage")
+    assert "issue_coverage" not in f.detail
+
+
+def test_issue_coverage_does_not_nag_about_a_suppressed_check():
+    """Suppression means "known noise in this repo". Demanding a GitHub issue
+    for known noise re-creates the nagging suppression exists to remove.
+
+    issue_coverage runs inside evaluate(), before apply_suppression() has
+    downgraded anything, so it must consult the snapshot's suppression set
+    itself rather than the severity it happens to see.
+    """
+    s = _snap(
+        positions=[Position("NVDA", qty=40, covering_qty=0)],   # raises an alert
+        suppressed=frozenset({"position_coverage"}),
+        tracked_checks=frozenset(),
+    )
+    assert _only(evaluate(s), "issue_coverage").severity == "ok"

--- a/tests/test_devcheck_render.py
+++ b/tests/test_devcheck_render.py
@@ -1,0 +1,46 @@
+"""Render and suppression.
+
+Suppression must DOWNGRADE and annotate, never delete: a row that vanishes is
+indistinguishable from a check that never ran, which is the failure this whole
+package exists to prevent.
+"""
+
+from __future__ import annotations
+
+from devcheck.model import Finding
+from devcheck.render import render
+
+
+def test_render_groups_by_severity_worst_first():
+    out = render([
+        Finding("a", "ok", "fine"),
+        Finding("b", "alert", "broken"),
+        Finding("c", "warn", "degraded"),
+    ])
+    assert out.index("broken") < out.index("degraded") < out.index("fine")
+
+
+def test_render_names_every_check_id():
+    out = render([Finding("position_coverage", "alert", "NVDA 0 of 40 covered")])
+    assert "position_coverage" in out
+
+
+def test_render_handles_no_findings():
+    assert render([]).strip() != ""
+
+
+def test_suppressed_finding_is_downgraded_not_dropped():
+    from devcheck.evaluate import apply_suppression
+    findings = [Finding("degradations", "warn", "degraded to default: model_fallback_used")]
+    out = apply_suppression(findings, frozenset({"degradations"}))
+    assert len(out) == 1
+    assert out[0].severity == "ok"
+    assert "suppressed" in out[0].detail
+
+
+def test_unsuppressed_finding_is_untouched():
+    """Negative control: same finding, empty suppression set, still warns."""
+    from devcheck.evaluate import apply_suppression
+    findings = [Finding("degradations", "warn", "degraded to default: model_fallback_used")]
+    out = apply_suppression(findings, frozenset())
+    assert out[0].severity == "warn"


### PR DESCRIPTION
Builds `docs/superpowers/plans/2026-08-21-dev-status.md` against
`docs/superpowers/specs/2026-08-21-day-bookends-design.md`, both recovered to master by PR #97.

## What

`devcheck/` — a frozen `Snapshot`, a `Finding`, and one pure function per check. No I/O, no clock,
no LLM imports; added to `PURE_PACKAGES` so `scripts/check_purity.py` enforces that.
`scripts/dev_status.py` is the composition root (the `resolve_day.py` ↔ `resolve.py` split), and
`make dev-status` runs it. Read-only throughout; exit 0 always, so a check that cannot run renders
as a finding instead of hiding the rest.

Twelve checks, each derived from a stated invariant or a Phase 2 acceptance criterion per the
design's derivation rule — invariants 1, 2, 4, 5 and 6; checkpoints, journals and reflection;
position coverage; deploy state and services; and `issue_coverage`, the loop from an alert to
tracked work.

## Verified end to end

Run against the live droplet and broker, read-only. Real reads: `ALPACA_PAPER_TRADE=true`, only
exec holds `trading`, both units succeeded, droplet 8 behind master, `orders` 1 row, NVDA 40 long
against a 40-share sell stop — fully covered.

`make test`: **1391 passed, 1 skipped, 7 deselected** (49 new).

## Four defects found while wiring it, all of the shape the design exists to remove

The first live run printed five 🟢 rows against nothing. Each cause was a plausible guess that
resolved to a real but empty location:

1. **`FUND_DB` guessed as `/var/lib/fund/fund.db`** — that path *exists* on the box as a 0-byte
   stray file, so every query returned no rows with exit 0. The real DB is `fund.sqlite`.
2. **`-separator '\x1f'` arrives over ssh as four literal characters**, so every multi-column row
   came back unsplit. `checkpoints` filtered itself to zero and reported "0 checkpoint(s), all
   done" against 56 real rows. Now `-json`, which has no separator to get wrong.
3. **`FUND_JOURNALS` guessed as `/opt/fund/journals`** — exists, holds only a `.gitkeep`, so every
   seat read as silent.
4. **`seats_participating` was read from checkpoint *stages***, which are never seat names, so the
   journals check could not fire at all. Now from `costs.agent`.

Every path now comes from the droplet's own environment rather than a constant.

## Deviations from the plan, and why

- **`broker_fill_count` is `int | None`.** `AlpacaSource` exposes no fill-history method, so the
  plan's field has no honest source. It reports itself unwired rather than printing a green row for
  a comparison nobody performed. **This check is not yet doing its job** — wiring it needs a broker
  method that does not exist.
- **`positions` is `Sequence[Position] | None`.** An unreachable broker yielded `[]`, which rendered
  "0 position(s), every share covered" — indistinguishable from a genuinely flat account, on the
  check that guards live exposure. Unread now alerts and names why, so "no credentials in this
  shell" and "the broker is down" do not look identical.
- **`db_read_ok`, and `check_database`.** One root cause alerts; the five DB-sourced checks it
  starves report themselves unchecked rather than healthy.
- **`issue_coverage` skips suppressed checks.** It ran before `apply_suppression`, so a suppressed
  alert would still have demanded an issue — reintroducing the nagging suppression exists to stop.
- **`devcheck` added to `PURE_PACKAGES`.** The plan's global constraints require it; the lint's own
  docstring invites adding a package before it is written.

## Not in this PR

`/eod-digest` and the `morning-standup` health step are in the skills repo, on `feat/eod-digest`.