### PR TITLE
docs: the health descriptor claimed a live issue count, which was wrong within five days

### DIFF
--- a/.claude/health.md
+++ b/.claude/health.md
@@ -33,9 +33,10 @@ deploys.
   exposure is never rendered as safety.
 - **`issue_coverage` is the loop from finding to tracked work.** An alert with
   no open issue labelled `check:<id>` will be re-derived by the next session
-  and lost again. All 8 open issues currently carry zero labels, so this check
-  fires on everything until they are labelled — that is the intended first run,
-  not a bug.
+  and lost again. It fires on every alert that has no such issue yet, which on
+  a repo that has not adopted the `check:` labels means all of them — that is
+  the intended first run, not a bug. Read the current state from
+  `gh issue list`, never from this file.
 
 ## Filing what this finds
 


### PR DESCRIPTION
`.claude/health.md`, merged an hour ago in #101, asserted:

> All 8 open issues currently carry zero labels

The repo has **30+ open issues** and a working taxonomy — `severity:critical/high/medium`,
`audit:2026-08-25`, `wayfinder:task`, `needs-decision`, `documentation`. The sentence was already
false when it merged. I copied it from the plan, which was written 2026-08-21, and did not re-check
it against the tracker.

`CLAUDE.md` on master now states the rule this breaks: *"A dated filename is a snapshot of the
moment it was written, never current state."* A descriptor read at the start of every standup and
close-out is the worst place to keep a decaying count.

The fix keeps the durable half — what the check does and why the first run is loud — and sends the
reader to `gh issue list` for anything countable.

Found while filing #102, which is the first issue to actually use the `check:<id>` scheme this
paragraph describes.