### PR TITLE
feat: invoke the alert filer — chain it to the nightly backup pull

### DIFF
--- a/docs/agents/devops.md
+++ b/docs/agents/devops.md
@@ -36,7 +36,7 @@ it is the failure this doc itself shipped with.
 
 | Producer | Source | Reaches the tracker by | Status |
 |---|---|---|---|
-| Run alert | `events` rows `kind='alert'`, raised during the trading day | `scripts/file_alert_issues.py`, chained to the end of `ops/pull-backups.sh` | `[specced]` |
+| Run alert | `events` rows `kind='alert'`, raised during the trading day | `scripts/file_alert_issues.py`, chained to the end of `ops/pull-backups.sh` | `[live]`, once `FUND_FILER` is set in the launchd plist |
 | devcheck finding | `make dev-status`, read against the running host | `check_issue_coverage` names untracked findings; a human files them | `[live]` |
 | Audit finding | a human or agent auditing the repo | a human files it | `[live, manual]` |
 | Peer discovery | another session working this repo | a human files it | `[live, manual]` |

--- a/ops/pull-backups.sh
+++ b/ops/pull-backups.sh
@@ -16,3 +16,43 @@ mkdir -p "$LOCAL"
       -e 'ssh -o BatchMode=yes -o ConnectTimeout=10' \
       "${FUND_DROPLET}:/var/lib/fund/backups/" "$LOCAL/"
 echo "pull-backups: $(ls -1 "$LOCAL" | wc -l | tr -d ' ') files in $LOCAL"
+
+# File the day's alerts as GitHub issues (docs/agents/devops.md).
+#
+# Chained here rather than given its own timer: this is the one job that runs
+# daily on this machine and knows a fresh snapshot just landed, so "backup
+# pulled" implies "filer ran" with no clock to drift between the two. It runs
+# here rather than on the droplet because `gh` is not installed there, and a
+# repo-write token does not belong on the box that holds the broker keys.
+#
+# Unset FUND_FILER disables all of it. A machine that only mirrors backups
+# must not acquire a new way to fail.
+FILER="${FUND_FILER:-}"
+if [ -n "$FILER" ]; then
+    # Newest dated snapshot. `fund-predeploy-<ts>.sqlite` sorts after every
+    # `fund-<date>.sqlite`, so a plain `tail -1` would hand the filer an
+    # arbitrary-age preflight copy. The date-shaped glob excludes it, and
+    # excludes the `-wal`/`-shm` sidecars in the mirror for the same reason.
+    SNAPSHOT="$(ls -1 "$LOCAL"/fund-[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9].sqlite 2>/dev/null | tail -1 || true)"
+    if [ -z "$SNAPSHOT" ]; then
+        echo "pull-backups: no snapshot to file from"
+    else
+        # The window is the snapshot's own date, taken from the filename
+        # rather than a clock: the run covers exactly the day it pulled, and
+        # the script stays testable. A day the pull misses is a day nothing
+        # files — deliberate, so the case for a wider window is observed
+        # rather than assumed.
+        DAY="$(basename "$SNAPSHOT" .sqlite | sed 's/^fund-//')"
+        # Named, not counted. `--ignore-existing` means a stalled droplet
+        # backup transfers nothing and still exits 0, so the file count above
+        # cannot tell stale from fresh (#110). The snapshot's name can.
+        echo "pull-backups: filing from $(basename "$SNAPSHOT") (day $DAY)"
+        # `set -e` is in force and the filer exits 1 on a malformed payload —
+        # a routine data condition, not a failed pull. Capture the code and
+        # report it: a blanket `|| true` would swallow the tracker-unavailable
+        # case too, which is the one worth seeing.
+        RC=0
+        "$FILER" "$SNAPSHOT" --since "$DAY" --apply || RC=$?
+        [ "$RC" -eq 0 ] || echo "pull-backups: filer exited $RC"
+    fi
+fi

--- a/scripts/file_alert_issues.py
+++ b/scripts/file_alert_issues.py
@@ -158,10 +158,26 @@ def main(argv: list[str] | None = None, run=None) -> int:
                     help="actually file; without it this is a dry run")
     args = ap.parse_args(argv)
 
-    # sqlite3.connect CREATES a missing file rather than raising, so an
-    # unreadable DB surfaces as "no such table: events" on the first query,
-    # not on connect. Both are caught below and both file nothing.
-    conn = sqlite3.connect(args.db)
+    # Named before anything else. Chained to the nightly pull this reads a
+    # mirror that cannot tell stale from fresh (#110), so which snapshot it
+    # worked from is the one fact a human needs to trust the run at all.
+    print(f"reading {Path(args.db).name}")
+
+    # READ-ONLY, ALWAYS. Unattended, against the only off-box copy of the
+    # fund's records: a read-write open applies a pending migration as a side
+    # effect, which is why dev_status.py opens every production read `mode=ro`,
+    # and the argument is stronger for a job nobody is watching.
+    #
+    # It also fixes a quieter thing. Plain sqlite3.connect CREATES a missing
+    # file rather than raising, so a wrong path used to surface as "no such
+    # table: events" on the first query — indistinguishable from a database
+    # with nothing in it, and leaving an empty file behind. The `mode=ro` URI
+    # raises on connect instead.
+    try:
+        conn = sqlite3.connect(f"file:{args.db}?mode=ro", uri=True)
+    except sqlite3.Error as e:
+        print(f"cannot read {args.db}: {e}", file=sys.stderr)
+        return 1
     conn.row_factory = sqlite3.Row
     tracker = GhTracker(args.repo, run=run)
     try:

--- a/tests/test_file_alert_issues.py
+++ b/tests/test_file_alert_issues.py
@@ -313,6 +313,32 @@ def test_an_unreadable_db_exits_non_zero_having_filed_nothing(tmp_path, capsys):
     assert run.calls == []
 
 
+def test_a_missing_db_is_not_created_by_the_connect(tmp_path):
+    """`sqlite3.connect` creates a missing file; the ro URI raises instead.
+
+    Chained to the nightly pull, this runs unattended against the only off-box
+    copy of the fund's records. dev_status.py opens every production read
+    `mode=ro` because a read-write open applies a pending migration as a side
+    effect of a health check — the same reasoning applies with more force to a
+    job nobody is watching. Asserted on the connect, not by writing to a
+    snapshot: a test that proves it cannot write is a test that corrupts a
+    backup on the day it fails."""
+    missing = tmp_path / "nope.sqlite"
+    _load().main([str(missing), "--since", "2026-08-24", "--apply"],
+                 run=RecordingRun())
+    assert not missing.exists()
+
+
+def test_it_names_the_database_it_read(db, db_path, capsys):
+    """The pull cannot tell a stale mirror from a fresh one (#110), so the
+    filer's own output has to say which snapshot it worked from — otherwise an
+    observation window against a month-old backup looks like a quiet month."""
+    _alert(db, "2026-08-24T13:37:54+00:00", code="unprotected_position",
+           ticker="NVDA", text=NVDA_0824)
+    _load().main([str(db_path), "--since", "2026-08-24"], run=RecordingRun())
+    assert db_path.name in capsys.readouterr().out
+
+
 def test_missing_gh_binary_during_planning_is_reported_not_a_traceback(db, db_path, capsys):
     """open_issue runs during plan_filings, before --apply is even consulted.
     A bare FileNotFoundError from subprocess.run must not escape main()."""

--- a/tests/test_ops_pull_backups.py
+++ b/tests/test_ops_pull_backups.py
@@ -17,15 +17,36 @@ def _fake_rsync(tmp_path: Path) -> tuple[Path, Path]:
     return fake, argv_log
 
 
-def _run(tmp_path, droplet="fund@203.0.113.10", local=None, rsync=None):
+def _fake_filer(tmp_path: Path, exit_code: int = 0) -> tuple[Path, Path]:
+    """A stand-in filer recording its argv and exiting with `exit_code`."""
+    argv_log = tmp_path / "filer-argv.txt"
+    fake = tmp_path / "filer"
+    fake.write_text(
+        f'#!/bin/sh\nprintf "%s\\n" "$@" > {argv_log}\nexit {exit_code}\n')
+    fake.chmod(0o755)
+    return fake, argv_log
+
+
+def _snapshots(local: Path, *names: str) -> Path:
+    local.mkdir(parents=True, exist_ok=True)
+    for n in names:
+        (local / n).write_text("")
+    return local
+
+
+def _run(tmp_path, droplet="fund@203.0.113.10", local=None, rsync=None,
+         filer=None):
     env = {k: v for k, v in os.environ.items()
-           if k not in ("FUND_DROPLET", "FUND_LOCAL_BACKUPS", "FUND_RSYNC")}
+           if k not in ("FUND_DROPLET", "FUND_LOCAL_BACKUPS", "FUND_RSYNC",
+                        "FUND_FILER")}
     if droplet is not None:
         env["FUND_DROPLET"] = droplet
     if local is not None:
         env["FUND_LOCAL_BACKUPS"] = str(local)
     if rsync is not None:
         env["FUND_RSYNC"] = str(rsync)
+    if filer is not None:
+        env["FUND_FILER"] = str(filer)
     return subprocess.run([str(SCRIPT)], capture_output=True, text=True, env=env)
 
 
@@ -61,3 +82,105 @@ def test_creates_the_local_dir_when_absent(tmp_path):
     local = tmp_path / "does" / "not" / "exist"
     assert _run(tmp_path, local=local, rsync=fake).returncode == 0
     assert local.is_dir()
+
+
+# --- the chained filer (docs/agents/devops.md) ---------------------------
+#
+# The pull is the only thing that runs daily on this machine and knows a fresh
+# snapshot just landed, so it is where the filer is invoked. `gh` is not
+# installed on the droplet and putting a repo-write token on the box that
+# holds broker keys is the thing this arrangement exists to avoid.
+
+
+def test_the_filer_runs_against_the_newest_snapshot_after_a_successful_pull(tmp_path):
+    rsync, _ = _fake_rsync(tmp_path)
+    filer, argv_log = _fake_filer(tmp_path)
+    local = _snapshots(tmp_path / "b", "fund-2026-08-24.sqlite",
+                       "fund-2026-08-26.sqlite", "fund-2026-08-25.sqlite")
+
+    proc = _run(tmp_path, local=local, rsync=rsync, filer=filer)
+    assert proc.returncode == 0, proc.stderr
+
+    argv = argv_log.read_text().splitlines()
+    assert str(local / "fund-2026-08-26.sqlite") in argv
+    assert "--apply" in argv
+    # The window is the snapshot's own date. Deliberately not a rolling one:
+    # a wider window is a design question this run exists to inform, and a
+    # narrow window that misses a skipped day makes that visible.
+    assert "--since" in argv and "2026-08-26" in argv
+
+
+def test_a_predeploy_snapshot_never_wins(tmp_path):
+    """`fund-predeploy-*` sorts after every dated snapshot, so the obvious
+    `tail -1` would hand the filer an arbitrary-age preflight copy."""
+    rsync, _ = _fake_rsync(tmp_path)
+    filer, argv_log = _fake_filer(tmp_path)
+    local = _snapshots(tmp_path / "b", "fund-2026-08-26.sqlite",
+                       "fund-predeploy-20260818T120000.sqlite")
+
+    assert _run(tmp_path, local=local, rsync=rsync, filer=filer).returncode == 0
+    argv = argv_log.read_text().splitlines()
+    assert str(local / "fund-2026-08-26.sqlite") in argv
+    # On the basename only: pytest's tmp_path is named after the test, so the
+    # substring "predeploy" is in every path here regardless of the answer.
+    assert not any(Path(a).name.startswith("fund-predeploy") for a in argv)
+
+
+def test_sidecar_files_are_not_mistaken_for_snapshots(tmp_path):
+    """The mirror carries `-wal`/`-shm` sidecars from past read-write opens."""
+    rsync, _ = _fake_rsync(tmp_path)
+    filer, argv_log = _fake_filer(tmp_path)
+    local = _snapshots(tmp_path / "b", "fund-2026-08-26.sqlite",
+                       "fund-2026-08-26.sqlite-wal",
+                       "fund-2026-08-26.sqlite-shm")
+
+    assert _run(tmp_path, local=local, rsync=rsync, filer=filer).returncode == 0
+    argv = argv_log.read_text().splitlines()
+    assert str(local / "fund-2026-08-26.sqlite") in argv
+
+
+def test_a_failing_filer_does_not_fail_the_pull(tmp_path):
+    """`main()` returns 1 on a malformed payload — a routine data condition,
+    not a failure of the pull. `set -eu` would otherwise kill the job, and a
+    blanket `|| true` would hide the tracker-unavailable case too."""
+    rsync, _ = _fake_rsync(tmp_path)
+    filer, _ = _fake_filer(tmp_path, exit_code=1)
+    local = _snapshots(tmp_path / "b", "fund-2026-08-26.sqlite")
+
+    proc = _run(tmp_path, local=local, rsync=rsync, filer=filer)
+    assert proc.returncode == 0, proc.stderr
+    # Asserted verbatim: pytest's tmp_path carries the test name, so a looser
+    # substring check passes on the path alone and proves nothing.
+    assert "pull-backups: filer exited 1" in proc.stdout
+
+
+def test_the_pull_reports_which_snapshot_it_read(tmp_path):
+    """`--ignore-existing` means a stalled droplet backup transfers nothing and
+    exits 0, so a file count cannot distinguish stale from fresh (#110). The
+    snapshot name is what makes the run falsifiable by a human reading the log."""
+    rsync, _ = _fake_rsync(tmp_path)
+    filer, _ = _fake_filer(tmp_path)
+    local = _snapshots(tmp_path / "b", "fund-2026-08-26.sqlite")
+
+    proc = _run(tmp_path, local=local, rsync=rsync, filer=filer)
+    assert "fund-2026-08-26.sqlite" in proc.stdout
+
+
+def test_no_snapshot_skips_the_filer_without_failing(tmp_path):
+    """A first run against an empty mirror, or a pull that fetched nothing."""
+    rsync, _ = _fake_rsync(tmp_path)
+    filer, argv_log = _fake_filer(tmp_path)
+    local = _snapshots(tmp_path / "b")
+
+    proc = _run(tmp_path, local=local, rsync=rsync, filer=filer)
+    assert proc.returncode == 0, proc.stderr
+    assert not argv_log.exists()
+    assert "no snapshot" in proc.stdout.lower()
+
+
+def test_the_filer_is_optional(tmp_path):
+    """FUND_FILER unset leaves the pull exactly as it was — the chaining must
+    not be able to break a backup pull on a machine that never files."""
+    rsync, _ = _fake_rsync(tmp_path)
+    local = _snapshots(tmp_path / "b", "fund-2026-08-26.sqlite")
+    assert _run(tmp_path, local=local, rsync=rsync).returncode == 0


### PR DESCRIPTION
**Stacked on #113** (doc-only). Base is `docs/devops-loop`; GitHub retargets to `master` when #113 merges. Review that one first.

## The defect

`scripts/file_alert_issues.py` has never run. 213 lines, 376-line suite, no caller anywhere — not `ops/`, the Makefile, a unit, or CI. The proof: no `alert:*` label has ever existed on this repo, and the script calls `ensure_label` before every create.

`docs/agents/devops.md` described it as the mechanism by which an alert becomes an issue.

## The change

One block at the end of `ops/pull-backups.sh` — the only job that runs daily on this machine and knows a fresh snapshot just landed, so "backup pulled" implies "filer ran" with no clock between them. Not on the droplet: `gh` is not installed there, and a repo-write token does not belong on the box holding broker keys.

`FUND_FILER` unset disables the whole thing. A machine that only mirrors backups must not gain a new way to fail.

Three fixes to code the invocation newly exercises:

| Fix | Why |
|---|---|
| Read-only DB open (`file:…?mode=ro`) | Unattended against the only off-box copy of the fund's records; a read-write open applies a pending migration as a side effect — `dev_status.py` spells this out for production reads. It also stops a wrong path being silently created and read as an empty day |
| Deterministic snapshot selection | `fund-predeploy-<ts>.sqlite` sorts after every dated snapshot, so `tail -1` would hand the filer an arbitrary-age preflight copy. The date-shaped glob also excludes the `-wal`/`-shm` sidecars already in the mirror |
| Return-code handling | `main()` exits 1 on a malformed payload — routine data, not a failed pull. `set -e` would kill the job; a blanket `|| true` would swallow the tracker-unavailable case, which is the one worth seeing |

**The filer names the snapshot it read.** `--ignore-existing` means a stalled droplet backup transfers nothing and still exits 0, so the existing file count cannot tell stale from fresh (#110). Without the name, an observation window against a month-old backup looks like a quiet month.

**Window is the snapshot's own date**, parsed from the filename rather than read off a clock. A day the pull misses files nothing — deliberate: it makes the case for a rolling window observable instead of assumed.

## What is deliberately not here

Reopen-on-recurrence, a unified label namespace, shared suppression, the EOD sweep, a liveness stamp. All designed, all cut after adversarial review, all deferred with named blockers in the spec's §4. Three of the five are blocked on defects, not on scope.

**The accepted cost:** launchd has no `OnFailure`, so a filer that silently stops filing is caught by a human reading the log or not at all. Accepted for a two-week observation window, not solved, and stated in the doc.

## Evidence

`make test`: **1418 passed, 1 skipped**.

Nine new tests. Two runtime dry runs against a real pulled backup (`fund-2026-08-25.sqlite`), output identical both times:

```
MALFORMED (not filed): 2026-08-24T13:37:54+00:00: no code — NVDA 40 was ticketed with a stop…
MALFORMED (not filed): 2026-08-24T13:37:54+00:00: no code — NVDA: the fund's own orders account…
reading fund-2026-08-25.sqlite
rc=1
```

That `rc=1` is the case the chaining exists to handle: those alerts predate the coded-alert deploy, so they are malformed to the filer, and a bare call under `set -e` would have failed the backup pull.

## To activate

`FUND_FILER` must be added to the launchd plist. Until then this is inert — the doc's status column says so.