### PR TITLE
Declare where this repo's intent lives, so the standup can propose a day

### DIFF
--- a/.claude/standup.md
+++ b/.claude/standup.md
@@ -1,0 +1,27 @@
+---
+intent_sources:
+  - docs/superpowers/specs/2026-08-26-devops-loop-design.md
+  - specs/acceptance.md
+  - PROGRESS.md
+---
+
+# Intent sources for morning-standup Phase 0c
+
+Read only what each source marks as next or open:
+
+- A spec's **Landing order** section: the first step not yet landed.
+- `specs/acceptance.md`: unticked `- [ ]` items in the current phase (Phase 2) only.
+- `PROGRESS.md`: entries under the **Open items** heading.
+
+These feed the standup's Today proposal as flagged intent items. They are not
+lanes and are not dispatched; an off-board item enters work only when the human
+confirms it in the Today reply or files it as an issue.
+
+## Keeping this list current
+
+The spec entry is a dated file and goes stale by design — a dated filename is a
+snapshot, never current state. When a newer design spec becomes the one being
+landed, replace that line; do not accumulate them. `specs/acceptance.md` and
+`PROGRESS.md` are standing sources and stay. When the current phase advances
+past Phase 2, update the phase named above — the standup reads this file, not
+the board, to know which phase's boxes matter.


### PR DESCRIPTION
Adds `.claude/standup.md` — one file, no code.

## Why

`morning-standup` Phase 0c (landed upstream as claude-skills#4) reads `intent_sources` from this file. **Absent, it skips silently** and the morning's Today proposal draws from the issue board alone.

The board doesn't carry a spec's next landing step, an unticked Phase 2 acceptance box, or a `PROGRESS.md` open item — all real next-steps that exist before anyone files an issue for them.

## The three sources, verified against this branch

| Source | Marker the descriptor promises | Present |
|---|---|---|
| `docs/superpowers/specs/2026-08-26-devops-loop-design.md` | `## 9. Landing order` | line 226 |
| `specs/acceptance.md` | `## Phase 2 — The desk` | line 28 |
| `PROGRESS.md` | `## Open items` | line 528 |

Phase 2 is the current phase: Phase 1 is 9/10 ticked, Phase 2 is 0/10.

## Scope

Intent items are **reported and offered, never dispatched**. An off-board item enters work only when a human confirms it in the Today reply or files it as an issue. No lane is bound from this file.

Sits beside `.claude/health.md` — same descriptor pattern: the repo declares its own layout, the skill never guesses at it.

## One addition beyond the starting example

A "Keeping this list current" section. The spec entry is a dated file and goes stale by design; the section says to replace rather than accumulate, and to update the phase name when the current phase advances past Phase 2.

No Python touched, so no `make test` run — say the word if you want it anyway.