### PR TITLE
fix: import protection helpers from where they now live in dev-status

### DIFF
--- a/scripts/dev_status.py
+++ b/scripts/dev_status.py
@@ -247,7 +247,8 @@ def _positions_and_coverage() -> tuple[list[Position] | None, list, int | None, 
     """
     try:
         from market.source_alpaca import AlpacaSource
-        from orchestrator.protection import _CLOSING_SIDE, _covering_qty, _qty
+        from orchestrator.protection import _covering_qty
+        from state.protection import CLOSING_SIDE, qty_of
     except Exception as exc:
         return None, [], None, f"broker client unavailable: {exc}"
 
@@ -270,8 +271,8 @@ def _positions_and_coverage() -> tuple[list[Position] | None, list, int | None, 
     for raw in raw_positions:
         p = raw if isinstance(raw, dict) else {}
         symbol = str(p.get("symbol") or "?")
-        held = _qty(p.get("qty"))
-        closing_side = _CLOSING_SIDE.get(str(p.get("side") or "").lower())
+        held = qty_of(p.get("qty"))
+        closing_side = CLOSING_SIDE.get(str(p.get("side") or "").lower())
         if held is None or closing_side is None:
             # Unreadable: report zero cover so it alerts. Never silently ok.
             out.append(Position(symbol, qty=1.0, covering_qty=0.0))


### PR DESCRIPTION
closes #119

## What broke

`scripts/dev_status.py:250` imported three names from `orchestrator.protection`:

```python
from orchestrator.protection import _CLOSING_SIDE, _covering_qty, _qty
```

**Two of the three were gone, not one.** The protection-record change moved them
to `state/protection.py` and deleted the originals:

| old | now |
|---|---|
| `orchestrator.protection._CLOSING_SIDE` | `state.protection.CLOSING_SIDE` (`state/protection.py:30`) |
| `orchestrator.protection._qty` | `state.protection.qty_of` (`state/protection.py:50`) |
| `orchestrator.protection._covering_qty` | still there (`orchestrator/protection.py:51`) — body rewritten in the same move to delegate to the shared helpers, behaviour identical |

The error message undercounts the damage, because Python raises on the **first**
missing name only:

```
cannot import name '_CLOSING_SIDE' from 'orchestrator.protection'
```

Fixing just that one name would have shipped a second, identical failure on
`_qty`. Checked directly:

```
missing on orchestrator.protection: ['_CLOSING_SIDE', '_qty']
```

## Consequence

`_positions_and_coverage()` catches the `ImportError` and returns
`broker client unavailable: ...`, so `make dev-status` renders
`position_coverage` RED and **live exposure is unknown** — the check that is
supposed to tell us every position has a stop reports nothing at all.

## Verification

`make test`: `1466 passed, 1 skipped, 7 deselected in 38.84s`.

The import path itself is exercised without needing broker access — with
`ALPACA_API_KEY`/`ALPACA_SECRET_KEY` unset, the call must now get *past* the
import and reach the credentials branch:

```
$ env -u ALPACA_API_KEY -u ALPACA_SECRET_KEY python3 -c '...; print(_positions_and_coverage())'
(None, [], None, 'ALPACA_API_KEY, ALPACA_SECRET_KEY not in this shell — run `set -a; source .env; set +a`')
```

That distinguishes "import fixed" from "still broken". No other module imports
the deleted names (`git grep -nE "_CLOSING_SIDE|[^_a-z]_qty\(" -- '*.py'` returns
only a stale prose reference in a `market/source_alpaca.py` comment — left alone,
out of scope).

## Why this stands alone rather than folding into #106

**This fix does not fold into #106.** #106 is about the `dev-status` composition
root being exempt from tests and carries an unresolved ruling; this is a two-line
import repair with a known-correct target. Folding it in would park a live blind
spot — unknown position coverage in production — behind an undecided design lane.

The bug is nevertheless **the fifth instance #106 predicted**: "Anyone extending
`dev-status` will add the fifth." It is exactly the class of defect that lands
because `main()` and its helpers are untested. That is evidence for #106, not a
reason to delay the repair.

**This PR deliberately does not resolve #106's open question.** No test here
calls `main()` or otherwise exercises the composition root; the exemption
documented in `docs/superpowers/specs/2026-08-21-day-bookends-design.md` §5
stands untouched, for #106 to settle.

## Related but distinct

- **#104** (`broker_fill_count` unwired) — a *missing capability*: `AlpacaSource`
  has no fill-history method, so the value stays `None` by design. Not a broken
  import, and not fixed here.
- The **`normalized()` divergence** noted in #119's body is
  [retracted as incorrect](https://github.com/benjaminematton/fund/issues/119#issuecomment-5442286189).
  There is no divergence: `normalized()` applies only to *order* fields, while the
  *position* side is plain-lowercased identically in `orchestrator/protection.py:121`
  and `scripts/dev_status.py:274`. The two agree. **No follow-up issue is needed.**



