### PR TITLE
chore: characterization tests for account_state's positions/prices comprehension

### DIFF
--- a/tests/test_source_alpaca_positions_characterization.py
+++ b/tests/test_source_alpaca_positions_characterization.py
@@ -9,6 +9,7 @@ just the one named for it. Nothing here endorses truncation.
 The four account_state tests in tests/test_source_alpaca_helpers.py all use a
 fake returning no positions, so the comprehension has never run with a position
 in it. Same fake style as that file, reusing its helpers."""
+import pytest
 from alpaca.trading.enums import PositionSide
 
 from tests.test_source_alpaca_helpers import _Clock, _bare_source
@@ -43,27 +44,32 @@ def test_characterization_whole_share_qty_is_carried_exactly_as_int():
     assert isinstance(state["positions"]["NVDA"], int)
 
 
-def test_characterization_fractional_qty_is_truncated_toward_zero():
+@pytest.mark.parametrize("qty, truncated", [
+    ("10.5", 10),
+    ("10.7", 10),
+    ("-10.5", -10),
+])
+def test_characterization_fractional_qty_is_truncated_toward_zero(qty,
+                                                                 truncated):
     """DEFECT, pinned as current behaviour: int(float("10.5")) is 10, so a
     fractional broker position silently loses its fraction. Known defect,
     tracked in #32, unruled — expected to change when #32 is ruled, and
     rewriting it is that fix's job.
 
-    Three fixtures, because "toward zero" is a directional claim and 10.5
-    alone cannot back it — int(), floor() and round() all give 10 there.
-    -10.5 separates int() from floor() (floor gives -11); 10.7 separates it
-    from round() (round gives 11). The fund is long-only today
-    (specs/design.md), so a negative qty is latent rather than live — and
-    state/protection.py:50 qty_of REFUSES negatives outright. Two readers of
-    one broker field disagreeing is #32's opening thesis."""
-    state = _source_holding(_position("NVDA", "10.5", "214.70")).account_state()
-    assert state["positions"] == {"NVDA": 10}
+    Three cases, because "toward zero" is a directional claim and 10.5 alone
+    cannot back it — int(), floor() and round() all give 10 there. -10.5
+    separates int() from floor() (floor gives -11); 10.7 separates it from
+    round() (round gives 11). The fund is long-only today (specs/design.md),
+    so a negative qty is latent rather than live — and state/protection.py:50
+    qty_of REFUSES negatives outright. Two readers of one broker field
+    disagreeing is #32's opening thesis.
 
-    state = _source_holding(_position("NVDA", "10.7", "214.70")).account_state()
-    assert state["positions"] == {"NVDA": 10}
-
-    state = _source_holding(_position("NVDA", "-10.5", "214.70")).account_state()
-    assert state["positions"] == {"NVDA": -10}
+    Parametrized, not three asserts in one body, because a #32 ruling may
+    treat positives and negatives DIFFERENTLY (carry the true value for
+    positives, refuse negatives as qty_of does). Sequential asserts would
+    report only the first, hiding the split behind a rerun."""
+    state = _source_holding(_position("NVDA", qty, "214.70")).account_state()
+    assert state["positions"] == {"NVDA": truncated}
 
 
 def test_characterization_sub_one_share_qty_becomes_zero_but_keeps_its_key():

--- a/tests/test_source_alpaca_positions_characterization.py
+++ b/tests/test_source_alpaca_positions_characterization.py
@@ -2,8 +2,9 @@
 
 These pin what market/source_alpaca.py:210 does TODAY, not what it should do.
 The truncation of a fractional broker quantity is a KNOWN DEFECT tracked in
-#32, still unruled, and these assertions are EXPECTED TO CHANGE when it is
-ruled. Nothing here endorses truncation.
+#32, still unruled. EVERY truncation assertion in this file is EXPECTED TO
+CHANGE when it is ruled -- four of the five tests below assert the defect, not
+just the one named for it. Nothing here endorses truncation.
 
 The four account_state tests in tests/test_source_alpaca_helpers.py all use a
 fake returning no positions, so the comprehension has never run with a position
@@ -34,6 +35,9 @@ def _source_holding(*positions):
 
 
 def test_characterization_whole_share_qty_is_carried_exactly_as_int():
+    """The isinstance is an assertion ABOUT the defect: int() is what makes it
+    an int. A #32 ruling that carries the true value reddens this line too.
+    Expected to change with the rest."""
     state = _source_holding(_position("NVDA", "80", "214.70")).account_state()
     assert state["positions"] == {"NVDA": 80}
     assert isinstance(state["positions"]["NVDA"], int)
@@ -42,10 +46,35 @@ def test_characterization_whole_share_qty_is_carried_exactly_as_int():
 def test_characterization_fractional_qty_is_truncated_toward_zero():
     """DEFECT, pinned as current behaviour: int(float("10.5")) is 10, so a
     fractional broker position silently loses its fraction. Known defect,
-    tracked in #32, unruled — this assertion is expected to change when #32
-    is ruled, and rewriting it is that fix's job."""
+    tracked in #32, unruled — expected to change when #32 is ruled, and
+    rewriting it is that fix's job.
+
+    Three fixtures, because "toward zero" is a directional claim and 10.5
+    alone cannot back it — int(), floor() and round() all give 10 there.
+    -10.5 separates int() from floor() (floor gives -11); 10.7 separates it
+    from round() (round gives 11). The fund is long-only today
+    (specs/design.md), so a negative qty is latent rather than live — and
+    state/protection.py:50 qty_of REFUSES negatives outright. Two readers of
+    one broker field disagreeing is #32's opening thesis."""
     state = _source_holding(_position("NVDA", "10.5", "214.70")).account_state()
     assert state["positions"] == {"NVDA": 10}
+
+    state = _source_holding(_position("NVDA", "10.7", "214.70")).account_state()
+    assert state["positions"] == {"NVDA": 10}
+
+    state = _source_holding(_position("NVDA", "-10.5", "214.70")).account_state()
+    assert state["positions"] == {"NVDA": -10}
+
+
+def test_characterization_sub_one_share_qty_becomes_zero_but_keeps_its_key():
+    """The same defect at its sharpest. 0.4 shares does not lose a fraction,
+    it becomes 0 while NVDA remains a KEY — so the line passes every
+    truthiness check on the dict, contributes nothing to sector_book_value,
+    and offers no sellable shares. A 100% understatement of that holding.
+    Tracked in #32; expected to change when it is ruled."""
+    state = _source_holding(_position("NVDA", "0.4", "214.70")).account_state()
+    assert state["positions"] == {"NVDA": 0}
+    assert "NVDA" in state["positions"]
 
 
 def test_characterization_price_is_carried_as_float():
@@ -55,6 +84,9 @@ def test_characterization_price_is_carried_as_float():
 
 
 def test_characterization_every_position_in_the_payload_is_carried():
+    """Both lines are carried. NVDA's 10.5 truncates to 10 HERE TOO, so this
+    test asserts the #32 defect as well and is expected to change with it —
+    the expected value below is not independent of that ruling."""
     state = _source_holding(
         _position("NVDA", "10.5", "214.70"),
         _position("MSFT", "36", "400.00"),

--- a/tests/test_source_alpaca_positions_characterization.py
+++ b/tests/test_source_alpaca_positions_characterization.py
@@ -1,0 +1,63 @@
+"""Characterization tests for account_state()'s positions/prices comprehension.
+
+These pin what market/source_alpaca.py:210 does TODAY, not what it should do.
+The truncation of a fractional broker quantity is a KNOWN DEFECT tracked in
+#32, still unruled, and these assertions are EXPECTED TO CHANGE when it is
+ruled. Nothing here endorses truncation.
+
+The four account_state tests in tests/test_source_alpaca_helpers.py all use a
+fake returning no positions, so the comprehension has never run with a position
+in it. Same fake style as that file, reusing its helpers."""
+from alpaca.trading.enums import PositionSide
+
+from tests.test_source_alpaca_helpers import _Clock, _bare_source
+
+
+def _position(symbol: str, qty: str, current_price: str):
+    """One alpaca-py Position as account_state reads it. Shape copied from the
+    open_positions fake; qty and current_price arrive as STRINGS."""
+    return _Clock(symbol=symbol, qty=qty, current_price=current_price,
+                  side=PositionSide.LONG)
+
+
+def _source_holding(*positions):
+    class Trading:
+        def get_account(self):
+            return _Clock(equity="101500", last_equity="101000", cash="30000",
+                          long_market_value="71500")
+        def get_all_positions(self):
+            return list(positions)
+
+    src = _bare_source()
+    src._trading = Trading()
+    return src
+
+
+def test_characterization_whole_share_qty_is_carried_exactly_as_int():
+    state = _source_holding(_position("NVDA", "80", "214.70")).account_state()
+    assert state["positions"] == {"NVDA": 80}
+    assert isinstance(state["positions"]["NVDA"], int)
+
+
+def test_characterization_fractional_qty_is_truncated_toward_zero():
+    """DEFECT, pinned as current behaviour: int(float("10.5")) is 10, so a
+    fractional broker position silently loses its fraction. Known defect,
+    tracked in #32, unruled — this assertion is expected to change when #32
+    is ruled, and rewriting it is that fix's job."""
+    state = _source_holding(_position("NVDA", "10.5", "214.70")).account_state()
+    assert state["positions"] == {"NVDA": 10}
+
+
+def test_characterization_price_is_carried_as_float():
+    state = _source_holding(_position("NVDA", "80", "214.70")).account_state()
+    assert state["prices"] == {"NVDA": 214.70}
+    assert isinstance(state["prices"]["NVDA"], float)
+
+
+def test_characterization_every_position_in_the_payload_is_carried():
+    state = _source_holding(
+        _position("NVDA", "10.5", "214.70"),
+        _position("MSFT", "36", "400.00"),
+    ).account_state()
+    assert state["positions"] == {"NVDA": 10, "MSFT": 36}
+    assert state["prices"] == {"NVDA": 214.70, "MSFT": 400.00}


### PR DESCRIPTION
## What

Five characterization tests for `account_state()`'s positions/prices comprehension at
`market/source_alpaca.py:210`. Test file only — no source file is modified.

```python
"positions": {p.symbol: int(float(p.qty)) for p in pos},
"prices": {p.symbol: float(p.current_price) for p in pos},
```

## Why

That comprehension has never executed with a position in it. All four existing `account_state`
tests (`tests/test_source_alpaca_helpers.py:134, 156, 171, 188`) use a fake whose
`get_all_positions()` returns `[]`. The only fake in that file returning a real position belongs
to the `open_positions()` test. This closes that coverage gap and nothing else.

New file: `tests/test_source_alpaca_positions_characterization.py`

- `test_characterization_whole_share_qty_is_carried_exactly_as_int`
- `test_characterization_fractional_qty_is_truncated_toward_zero` — `10.5`, `10.7` and `-10.5`
- `test_characterization_sub_one_share_qty_becomes_zero_but_keeps_its_key` — `0.4`
- `test_characterization_price_is_carried_as_float`
- `test_characterization_every_position_in_the_payload_is_carried`

It reuses `_Clock` and `_bare_source` from `tests/test_source_alpaca_helpers.py` and the position
shape from that file's `open_positions()` fake, rather than introducing a new harness.

## These tests pin CURRENT behaviour, and are expected to change

`int(float("10.5"))` is `10`, so a fractional broker position is silently truncated. That is a
**known defect, tracked in #32, currently unruled**. These tests assert that truncation is what the
code does today. They do **not** assert that truncation is correct. The module docstring, the test
names, and each truncation test's own docstring all say so at the call site, so the next reader does
not mistake a characterization test for the spec.

**Read this before the ratchet stops you.** `CLAUDE.md` says *"NEVER update a golden fixture,
expected hash, or expected value to make a test pass. STOP and ask."* That rule is about not
weakening a test so failing code passes, and it stands. It does not cover this file: **rewriting the
truncation assertions in this file is the #32 fix's deliverable**, not a fixture update — the visible
record of a deliberate behaviour change.

**Four of the five tests assert the defect, not just the one named for it.** Mutating line 210 to
`float(p.qty)` — the direction the decision package on #32 actually recommends — reddens:

```
FAILED ..._whole_share_qty_is_carried_exactly_as_int
FAILED ..._fractional_qty_is_truncated_toward_zero[10.5-10]
FAILED ..._fractional_qty_is_truncated_toward_zero[10.7-10]
FAILED ..._fractional_qty_is_truncated_toward_zero[-10.5--10]
FAILED ..._sub_one_share_qty_becomes_zero_but_keeps_its_key
FAILED ..._every_position_in_the_payload_is_carried
```

All four are authorized to change under a #32 ruling. Only
`test_characterization_price_is_carried_as_float` is independent of it. The whole-share test fails on
its `isinstance(..., int)` and the multi-position test on its expected `"NVDA": 10` — both are
assertions about the defect even though neither is named for it. Changing any of them without a
ruling on #32 is still out of bounds.

**Mutation-checked**, so the pin is not vacuous — each of these reddens
`..._fractional_qty_is_truncated_toward_zero`:

| Mutant of line 210 | Killed by |
|---|---|
| `float(p.qty)` (carry true value) | all four above, as 6 case ids |
| `int(float(p.qty)//1)` (floor) | the `[-10.5--10]` case — floor gives `-11` |
| `round(float(p.qty))` (round) | the `[10.7-10]` case — round gives `11` |

The `10.5` fixture alone backs none of these: `int()`, `floor()` and `round()` all give `10` there,
so "toward zero" needed the other two fixtures to be a claim the test can actually support.

The fractional test is `parametrize`d rather than three asserts in one body, because a plausible #32
ruling treats positives and negatives **differently** — carry the true value for positives, refuse
negatives as `state/protection.py:50` `qty_of` does. Sequential asserts would report only the first
and hide that split behind a rerun; parametrized, all three cases report at once and the failing
quantity is in the test id.

## Scope

This is not a remedy for the defect in #32 and does not prejudge it. #32 stays open and `needs-decision` pending a human
ruling; the decision package on that issue lays out the options and what each one forecloses. This
PR is item §7 of that package — the part that decides nothing.

`make test`: `1473 passed, 1 skipped, 7 deselected in 36.48s`



