### PR TITLE
fix: derive eval_one's .env fallback instead of hardcoding a home path

### DIFF
--- a/scripts/eval_one.py
+++ b/scripts/eval_one.py
@@ -27,17 +27,25 @@ EVAL_KEYS = ("ANTHROPIC_API_KEY", "ALPACA_API_KEY", "ALPACA_SECRET_KEY",
 
 
 def _primary_checkout_env() -> Path | None:
-    """The primary checkout's .env, or None when git cannot say where it is."""
+    """The primary checkout's .env, or None when git cannot say where it is.
+
+    Must never raise: this runs at import, so anything escaping here takes
+    eval_one and every module that imports it down with it. ValueError covers
+    the two path-shaped ways that can happen — text=True decodes strict, so a
+    non-UTF-8 byte in the repo path raises UnicodeDecodeError (a ValueError),
+    and .resolve() on a NUL-bearing path raises ValueError. Both mean the same
+    thing this returns None for: git could not name a usable path.
+    """
     try:
         proc = subprocess.run(
             ["git", "-C", str(ROOT), "rev-parse", "--git-common-dir"],
             capture_output=True, text=True, timeout=5)
-    except (OSError, subprocess.SubprocessError):
-        return None                      # no git, or it hung
-    if proc.returncode != 0 or not proc.stdout.strip():
-        return None                      # not a repo, or nothing to report
-    # --git-common-dir may be relative to ROOT; ROOT / absolute is absolute.
-    return (ROOT / proc.stdout.strip()).resolve().parent / ".env"
+        if proc.returncode != 0 or not proc.stdout.strip():
+            return None                  # not a repo, or nothing to report
+        # --git-common-dir may be relative to ROOT; ROOT / absolute is absolute.
+        return (ROOT / proc.stdout.strip()).resolve().parent / ".env"
+    except (OSError, subprocess.SubprocessError, ValueError):
+        return None                      # no git, it hung, or an unusable path
 
 
 # .env.eval wins over .env when present. That is what lets eval credentials
@@ -46,13 +54,23 @@ def _primary_checkout_env() -> Path | None:
 # two barriers against the fund resurrecting there (PROGRESS.md "The Mac after
 # cutover"). Restoring a full `.env` to run evals would dissolve that barrier;
 # a file that cannot trade keeps it, by construction rather than by memory.
-# .env lives in the primary checkout; a worktree has none of its own, so we
-# fall back to the primary checkout's .env — derived, never hardcoded. Git
-# reports the main worktree's git dir as --git-common-dir (a linked worktree's
-# own git dir is .git/worktrees/<name> underneath it), and the primary checkout
-# is that dir's parent. Do not delete this as dead code: without it `make eval`
-# cannot run from a worktree at all. A checkout with no .env anywhere is the
-# normal fresh-clone case, not an error — main() reports it below.
+# .env lives in the primary checkout; a worktree has none of its own, so when
+# neither file sits next to this script we fall back to the primary checkout's
+# .env — derived, never hardcoded to anyone's home directory. Git reports the
+# main worktree's git dir as --git-common-dir (a linked worktree's own git dir
+# is .git/worktrees/<name> underneath it), and the primary checkout is that
+# dir's parent.
+#
+# That fallback is INERT on the Mac today, and will look like dead code: the
+# primary checkout has no `.env` post-cutover, only `.env.eval`, so it resolves
+# to a file that is not there and `make eval` still cannot run from a worktree.
+# Do not delete it on that evidence — the derivation is right, the missing leg
+# is the primary checkout's `.env.eval`, and whether to reach across a worktree
+# boundary for a real credentials file that tests/test_eval_env_cannot_trade.py
+# does not follow is the open question on issue #135.
+#
+# A checkout with no .env anywhere is the normal fresh-clone case, not an
+# error — main() reports it below.
 EVAL_ENV = ROOT / ".env.eval"
 ENV = EVAL_ENV if EVAL_ENV.exists() else ROOT / ".env"
 if not ENV.exists():

--- a/scripts/eval_one.py
+++ b/scripts/eval_one.py
@@ -10,6 +10,7 @@ Usage:  .venv/bin/python3 scripts/eval_one.py <case-id> [trial] [seat]
 from __future__ import annotations
 
 import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -24,17 +25,40 @@ sys.path.insert(0, str(ROOT))
 EVAL_KEYS = ("ANTHROPIC_API_KEY", "ALPACA_API_KEY", "ALPACA_SECRET_KEY",
              "ALPACA_PAPER_TRADE")
 
+
+def _primary_checkout_env() -> Path | None:
+    """The primary checkout's .env, or None when git cannot say where it is."""
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(ROOT), "rev-parse", "--git-common-dir"],
+            capture_output=True, text=True, timeout=5)
+    except (OSError, subprocess.SubprocessError):
+        return None                      # no git, or it hung
+    if proc.returncode != 0 or not proc.stdout.strip():
+        return None                      # not a repo, or nothing to report
+    # --git-common-dir may be relative to ROOT; ROOT / absolute is absolute.
+    return (ROOT / proc.stdout.strip()).resolve().parent / ".env"
+
+
 # .env.eval wins over .env when present. That is what lets eval credentials
 # live on a host the fund must never TRADE from — the Mac after the 2026-08-18
 # droplet cutover, where `.env` was renamed to `.env.MIGRATED-TO-VM` as one of
 # two barriers against the fund resurrecting there (PROGRESS.md "The Mac after
 # cutover"). Restoring a full `.env` to run evals would dissolve that barrier;
 # a file that cannot trade keeps it, by construction rather than by memory.
-# .env lives in the primary checkout; a worktree has none of its own.
+# .env lives in the primary checkout; a worktree has none of its own, so we
+# fall back to the primary checkout's .env — derived, never hardcoded. Git
+# reports the main worktree's git dir as --git-common-dir (a linked worktree's
+# own git dir is .git/worktrees/<name> underneath it), and the primary checkout
+# is that dir's parent. Do not delete this as dead code: without it `make eval`
+# cannot run from a worktree at all. A checkout with no .env anywhere is the
+# normal fresh-clone case, not an error — main() reports it below.
 EVAL_ENV = ROOT / ".env.eval"
 ENV = EVAL_ENV if EVAL_ENV.exists() else ROOT / ".env"
 if not ENV.exists():
-    ENV = Path("/Users/benjaminmatton/Developer/fund/.env")
+    primary_env = _primary_checkout_env()
+    if primary_env is not None and primary_env.exists():
+        ENV = primary_env
 
 
 def load_env(path: Path) -> None:

--- a/tests/test_eval_one_env_resolution.py
+++ b/tests/test_eval_one_env_resolution.py
@@ -1,0 +1,70 @@
+"""_primary_checkout_env() must return None rather than raise, always.
+
+scripts/eval_one.py resolves ENV at module scope, so an exception escaping this
+helper is an import-time crash that takes eval_one, scripts/eval_suite.py and
+tests/test_eval_env_cannot_trade.py down with it — a failure mode with no
+relation to what the caller was doing. Its contract is "None when git cannot
+say where the primary checkout is"; these pin the ways it can fail that are
+NOT OSError, which an `except OSError` would let through.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import types
+
+import pytest
+
+from scripts.eval_one import _primary_checkout_env
+
+
+def _fake_run(monkeypatch, *, raises=None, returncode=0, stdout=""):
+    """Point the helper's subprocess.run at a canned outcome."""
+    def run(*args, **kwargs):
+        if raises is not None:
+            raise raises
+        return types.SimpleNamespace(returncode=returncode, stdout=stdout,
+                                     stderr="")
+    monkeypatch.setattr("scripts.eval_one.subprocess.run", run)
+
+
+def test_undecodable_git_output_returns_none(monkeypatch):
+    """text=True decodes strict. A non-UTF-8 byte in the repo path raises
+    UnicodeDecodeError, whose MRO is UnicodeError -> ValueError — neither
+    OSError nor SubprocessError. Unreachable on APFS, reachable on Linux."""
+    boom = UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte")
+    _fake_run(monkeypatch, raises=boom)
+    assert _primary_checkout_env() is None
+
+
+def test_nul_bearing_path_returns_none(monkeypatch):
+    """The other ValueError: .resolve() refuses an embedded null character.
+    Exercises the real Path arithmetic, not a mocked exception."""
+    _fake_run(monkeypatch, stdout="/tmp/re\0po/.git\n")
+    assert _primary_checkout_env() is None
+
+
+def test_missing_git_returns_none(monkeypatch):
+    _fake_run(monkeypatch, raises=FileNotFoundError("git"))
+    assert _primary_checkout_env() is None
+
+
+def test_hung_git_returns_none(monkeypatch):
+    _fake_run(monkeypatch, raises=subprocess.TimeoutExpired("git", 5))
+    assert _primary_checkout_env() is None
+
+
+@pytest.mark.parametrize("returncode, stdout", [(128, ""), (0, "  \n")])
+def test_git_that_names_nothing_returns_none(monkeypatch, returncode, stdout):
+    """Not a repo, or a success that carried no path."""
+    _fake_run(monkeypatch, returncode=returncode, stdout=stdout)
+    assert _primary_checkout_env() is None
+
+
+def test_the_happy_path_still_derives_the_parent(monkeypatch, tmp_path):
+    """The guard rails must not have eaten the behaviour they protect: the
+    primary checkout is the git common dir's parent. tmp_path, not a literal
+    — macOS resolves /tmp through a symlink to /private/tmp."""
+    primary = tmp_path / "primary"
+    _fake_run(monkeypatch, stdout=f"{primary / '.git'}\n")
+    assert _primary_checkout_env() == primary / ".env"


### PR DESCRIPTION
Replaces the hardcoded personal absolute path in `scripts/eval_one.py`'s `.env` fallback with a path
derived from git. From #45's audit list.

Before:

```python
if not ENV.exists():
    ENV = Path("/Users/<person>/Developer/fund/.env")
```

After: a new `_primary_checkout_env()` runs `git -C ROOT rev-parse --git-common-dir` and returns that
directory's parent + `.env`, or `None` on any failure; the fallback applies only if the derived path
exists.

`grep -rn "/Users/" scripts/ evals/ agents/ tests/` now returns nothing.

## This is a replacement, not a deletion — and that is the point

The fallback looks like dead code and is not. `.env` lives in the primary checkout and **a worktree has
none of its own**, so deleting it outright would remove the only way `make eval` can find credentials
from a worktree. The comment above it has been rewritten to say so explicitly, so the next reader does
not tidy it away.

## Verification

Not "it should work" — the six cases were executed. The author built a throwaway git repo plus a linked
worktree and ran the real resolution chain against each:

| case | result |
|---|---|
| primary checkout, `.env` present | local file wins; fallback never consulted |
| linked worktree, `.env` only in primary | derived correctly across the worktree boundary |
| no `.env` anywhere | unchanged path, `main()` reports and returns 2 — no crash |
| worktree with its own `.env.eval` | local `.env.eval` still wins; precedence unchanged |
| directory that is not a git repo | `rev-parse` exits nonzero → `None` → no exception |
| `git` absent from `PATH` | `FileNotFoundError` → `None` → no exception |

The last two matter more than they look: this resolution runs at **module import**, so an uncaught
exception there would be an import-time crash rather than a handled failure.

On this machine the derived path is byte-identical to the string that was hardcoded, so behaviour is
unchanged.

`make test` — 1466 passed, 1 skipped, 7 deselected. Purity and alert-code lints clean. Re-run by the
reviewer independently.

## What review found, and what was done about it

The reviewer built its own throwaway repo and observed real `git rev-parse` output rather than
reasoning about it. Three things worth carrying:

- **The derivation is right for the two cases that occur** — a normal clone (`--git-common-dir`
  returns the relative `.git`) and a linked worktree (returns an absolute path). `ROOT / <absolute>`
  correctly discards `ROOT` under pathlib semantics, so both land on the right directory.
- **It is wrong for a bare repo, a submodule, and `--separate-git-dir`** — and harmless in all three,
  because the `primary_env.exists()` gate turns every wrong answer into a no-op. Worth being explicit
  that **the gate is what makes this safe, not the derivation.** Same containment covers an exported
  `GIT_DIR`/`GIT_COMMON_DIR`, which git honours over `-C`.
- **`make test` now shells out to git at collection.** `scripts/eval_suite.py:26` and
  `tests/test_eval_env_cannot_trade.py:21` both import this module, and the resolution runs at import.
  Measured at 6 ms, and it only fires when no local `.env`/`.env.eval` exists. `scripts/` is outside
  `PURE_PACKAGES`, so no purity invariant is involved, and nothing touches the network.

Two changes were made in response:

1. **The explanatory comment was softened.** The first draft asserted that without the fallback
   *"`make eval` cannot run from a worktree at all"* — which is not true today (see below), so it was
   defending a path it described inaccurately. It now says what the code does, why the fallback
   exists, and that the path is currently inert, pointing at #135.
2. **An import-time crash was closed.** `text=True` decodes strict, so a non-UTF-8 repo path would
   raise `UnicodeDecodeError` — which is a `ValueError`, so it escaped an `except` catching only
   `OSError`/`SubprocessError` and would have propagated at **module import**, taking `eval_one`,
   `eval_suite` and `tests/test_eval_env_cannot_trade.py` with it. Unreachable on APFS, reachable on
   Linux. Returning `None` there matches the function's stated contract — "None when git cannot say
   where it is."

Deliberately **not** done: adding a `.env.eval` leg to the fallback. See below.

## Known, filed, and deliberately not fixed here — #135

**The fallback is inert on this machine, and was before this change too.** The derived path is the
primary checkout's `.env`, and that file does not exist: it was renamed to `.env.MIGRATED-TO-VM` at the
2026-08-18 cutover. So running `eval_one` from a worktree still fails — for a different reason than the
hardcoded path.

The tempting follow-on is to have the fallback also reach the primary checkout's `.env.eval`, which
**does** exist. That is not in this PR for two reasons:

1. "Make evals runnable from a worktree" is a different request from "remove a hardcoded personal
   path." #45 asked for the second; every changed line here traces to that.
2. It moves toward a barrier that was built on purpose. `PROGRESS.md:460-465` records the Mac being
   double-disarmed after cutover — the launchd plist moved out **and** `.env` renamed, deliberately two
   independent barriers. The property that keeps the second one real is pinned by
   `tests/test_eval_env_cannot_trade.py`, which reads key **names** only and never a value. But that
   test's file-reading case resolves `.env.eval` against **its own checkout**, so it skips in a
   worktree — meaning the guard is checkout-local while the proposed reach would be cross-checkout.

That asymmetry, and the question of whether the guard should resolve the primary checkout's `.env.eval`
through the same derivation this PR adds, are #135.

## Why this says "Part of" and not "closes"

`closes #45` would be false here. #45 is a bundle of 13 items: eleven are split out (#123, #124, #125,
#126, #127, #128, #130, #132, #133, #134, and #135 found on the way), this PR is item 11, and the
sibling PR on `fix/staging-env-unread-app-token` is item 12.

The thirteenth — *delete `evals/_work/audit-src.tar.gz`* — is untracked and gitignored, so deleting it
is an empty diff and **no merge can close it**. It needs a human to run `rm` and confirm. #45 therefore
cannot be closed by a PR, and neither of these two claims otherwise.

Part of #45

