### PR TITLE
fix: bound every seat turn by wall clock

### DIFF
--- a/evals/runner.py
+++ b/evals/runner.py
@@ -72,7 +72,13 @@ def git_sha() -> str:
 
 
 def _sdk_session(options, prompt, state):
-    """The live session. Mirrors scripts/run_day.py:_seat_session exactly."""
+    """The live session. Same client and same run_seat_turn call as
+    scripts/run_day.py:_seat_session, with ONE deliberate difference: no
+    wall-clock bound. run_day wraps its session in _bounded(SEAT_MAX_WALL_S)
+    because a hung turn there hangs an unattended trading day while holding the
+    flock, so the next day's timer exits 0 and the stall reads as a closed
+    market (#44). This harness is manual: a hang here is in front of an
+    operator, and Ctrl-C is the bound."""
     import asyncio
 
     from claude_agent_sdk import ClaudeSDKClient

--- a/scripts/run_day.py
+++ b/scripts/run_day.py
@@ -111,6 +111,21 @@ LOCK_NAME = "run_day.lock"
 # the unit's 30 for every non-turn thing underneath: the broker snapshot, the
 # market-data fetch, reconcile's 90s wait, the audit and the drains.
 #
+# Beating that SIGTERM is also what makes an abandoned EXEC turn recoverable
+# rather than lost, which is the strongest safety argument for this bound:
+#   * agents/runtime.py's record_order is `async def` with NO await in its
+#     body, so once the PostToolUse hook starts it runs to its commit —
+#     cancelling the turn mid-flight cannot tear it in half.
+#   * the window that IS real is a response lost between the broker accepting
+#     the order and the hook seeing it. orchestrator/daily.py's run_day runs
+#     run_execution and then the reconciliation stage IN THE SAME PROCESS, and
+#     reconcile_stage calls reconcile.recover_lost_orders first — the issue-#40
+#     repair pass for exactly that row.
+#   * under the unit's SIGTERM the process DIES, so that repair never runs and
+#     the order is permanently unrecorded. Under this bound the turn raises,
+#     the day continues, and reconciliation recovers it. Abandoning a turn is
+#     therefore strictly LESS harmful than the 30min timeout it pre-empts.
+#
 # ONE ceiling for all seats, not six tuned numbers. Only pm (5 turns/$0.1161),
 # analyst (7/$0.0504) and exec (3/$0.0332) have a measured basis at all;
 # critic is PROVISIONAL, news is "INHERITED, NOT MEASURED", and reflect's 4 is
@@ -262,12 +277,43 @@ async def _bounded(coro, wall_s: float):
     blows it. Wraps the COROUTINE, inside asyncio.run: a bound needs a running
     loop, so it cannot wrap asyncio.run itself.
 
-    asyncio.timeout rather than asyncio.wait_for because both raise the same
-    TimeoutError and only `.expired()` tells OUR bound apart from one the
-    session itself raised — and the session raises exactly that today
-    (await_servers_connected's 30s MCP-connect wait, an SDK stream timeout).
-    Conflating them would relabel a connect failure as a hang and lose the
-    exception text the seat_turn_failed alert reports."""
+    asyncio.timeout rather than asyncio.wait_for because `.expired()` is the
+    only reliable way to tell OUR expiry from a TimeoutError raised INSIDE the
+    turn. wait_for reports both as a bare TimeoutError and offers nothing to
+    separate them: not the type, and not the message either — an inner one
+    keeps its text where an expiry's is empty, but that is a property of
+    whoever raised it, not a contract, so it is no discriminator. The
+    consequence is already pinned: three tests in tests/test_run_day.py raise
+    TimeoutError("session never connected") from inside the turn and assert
+    the alert stays seat_turn_failed carrying that text, and a blanket
+    `except TimeoutError` would relabel all three as hangs.
+
+    Nothing under agents/, orchestrator/ or scripts/ raises TimeoutError today
+    — agents/exec_turn.py's await_servers_connected raises ExecTurnViolation,
+    not TimeoutError — but the SDK, an HTTP client or a broker call can
+    (tests/test_order_recovery.py already models a gateway TimeoutError), so
+    the discriminator has to be structural rather than a source audit. Note
+    that await_servers_connected's 30s is not a wall-clock bound at all: it
+    accumulates `elapsed += poll_s` across an injected sleep, so a
+    get_mcp_status() that itself hangs never reaches the check. That is one
+    more hang THIS bound is the only thing covering.
+
+    NOT a hard ceiling: asyncio.timeout cancels ONCE. _seat_session exits
+    through `async with ClaudeSDKClient(...)`, whose __aexit__ tears down the
+    CLI subprocess and the MCP servers, and nothing re-arms the bound around
+    that teardown — a teardown that ignored the cancel would run past wall_s
+    (measured: 3.05s against a 0.05s bound). Left unbounded deliberately, on
+    two measurements: the SDK's own transport close() bounds every await
+    (~20s) and documents that its anyio shield does NOT hold against a raw
+    asyncio cancel, so it aborts here rather than hanging; and for a teardown
+    that truly refused cancellation no in-process bound helps, because
+    asyncio.run's own shutdown re-awaits the same task — a task+grace rewrite
+    measured 3.06s against the same 3.05s. The residual is a hang inside SDK
+    teardown only; #44's defect — a stalled model stream or MCP tool call,
+    the common case — is closed. The cost of that abort is a CLI child that
+    skips the terminate/kill escalation; the SDK keeps it in _ACTIVE_CHILDREN
+    for its atexit reaper, so at most one per timed-out turn survives to the
+    end of the day's single process."""
     try:
         async with asyncio.timeout(wall_s) as bound:
             return await coro
@@ -277,6 +323,28 @@ async def _bounded(coro, wall_s: float):
         raise SeatTurnTimeout(
             f"no result after {wall_s:g}s (max_wall_s ceiling); the turn was"
             " abandoned mid-flight") from None
+
+
+def seat_wall_s(seat: str, cfg: dict) -> float:
+    """This seat's ceiling, validated. agents/seats.py's load_seat_config is a
+    bare yaml.safe_load with no schema, so `max_wall_s: 0` — or a stray unit
+    like '4m' — arrives here unchecked, and a non-positive bound expires every
+    turn instantly: a whole trading day of stage defaults, one
+    seat_turn_timeout per stage, and nothing naming the one yaml line that did
+    it. Invariant 4 makes HOLD the answer to genuine ambiguity; a config typo
+    is not ambiguity, so it stops the day loudly instead."""
+    raw = cfg.get("max_wall_s", SEAT_MAX_WALL_S)
+    try:
+        wall_s = float(raw)
+    except (TypeError, ValueError):
+        wall_s = float("nan")
+    if not wall_s > 0:                  # also rejects nan
+        raise SystemExit(
+            f"run_day: seat {seat!r} has max_wall_s={raw!r} — it must be a"
+            " positive number of seconds. Fix agents/config/"
+            f"{seat}.yaml or drop the key to take the"
+            f" {SEAT_MAX_WALL_S:g}s default.")
+    return wall_s
 
 
 def emit_trace_guarded(seat: str, cfg: dict, run_date: str, turn_seq,
@@ -330,6 +398,11 @@ def make_turn(seat: str, cfg: dict, db_path: str, clock, conn, run_date: str,
     `alert` and lets the stage's own default land (invariant 4). The cost is
     recorded BEFORE the exec seat's tool-call assertions run — a violating
     turn still spent real money."""
+    # Resolved HERE rather than inside run(): make_turn is called from
+    # _trading_day's wiring, so a bad max_wall_s stops the day before the
+    # first stage — inside guarded(), which alerts and drains — instead of
+    # after the gate has already minted tickets.
+    wall_s = seat_wall_s(seat, cfg)
 
     def run() -> None:
         try:
@@ -337,14 +410,14 @@ def make_turn(seat: str, cfg: dict, db_path: str, clock, conn, run_date: str,
                 _seat_session(cfg, db_path, clock, prompt, snapshot,
                               journals_root,
                               expected_decision_id=expected_decision_id),
-                float(cfg.get("max_wall_s", SEAT_MAX_WALL_S))))
+                wall_s))
         except SeatTurnTimeout as exc:
-            # Its own code and text: TimeoutError's repr is the EMPTY string,
-            # so falling through the handler below would post
-            # "pm_turn_failed — TimeoutError: ; stage default applies",
-            # naming neither the seat's budget nor how long it burned. A hang
-            # and a crash also want different fixes, and the alert filer opens
-            # one issue per code.
+            # Its own code, because the alert filer opens one issue per code
+            # and a hang and a crash want different fixes — the handler below
+            # would file this beside genuine crashes. Its own text, because
+            # the generic one reports only the exception class, while this
+            # names the seat, the ceiling it blew and that the turn was
+            # abandoned mid-flight.
             _alert(conn, clock, "seat_turn_timeout",
                    f"{seat}_turn_timeout — {exc}; stage default applies"
                    " (default is HOLD)")

--- a/scripts/run_day.py
+++ b/scripts/run_day.py
@@ -16,6 +16,8 @@ Posture (invariant 4: the default is HOLD):
   * market closed / clock unreadable  -> log, exit 0, trade nothing
   * a seat turn that raises            -> one `alert`, then the stage's own
                                           default (neutral/0, pm_timeout hold)
+  * a seat turn that HANGS             -> abandoned at SEAT_MAX_WALL_S, then
+                                          the same `alert`-and-default path
   * anything the audit flags           -> `alert` posted to Slack, exit 1
   * anything ELSE that raises after    -> one `alert`, drained to Slack, then
     connect() (a stage body, the           exit 1 — nobody is watching a
@@ -95,6 +97,28 @@ SEATS = {"research": ("analyst", "news"),
          "decision": ("pm",),
          "execution": ("exec",)}
 LOCK_NAME = "run_day.lock"
+# Wall-clock ceiling for ONE seat turn (issue #44). max_turns and
+# max_budget_usd bound turns and dollars; a stalled MCP tool call or model
+# stream spends neither, so without this a hung turn hangs the whole day —
+# holding the flock, so tomorrow's timer finds the lock and exits 0, which
+# reads exactly like a market-closed day.
+#
+# Sized to fire BEFORE ops/fund-daily.service's TimeoutStartSec=30min, whose
+# SIGTERM can land between the broker accepting a place_stock_order and the
+# PostToolUse recorder committing the row. SEATS runs four turns a day
+# (analyst, news, pm, exec) — a count fixed by the stages, not by how many
+# tickers are active — so the worst case is 4 x 240s = 16min, leaving 14min of
+# the unit's 30 for every non-turn thing underneath: the broker snapshot, the
+# market-data fetch, reconcile's 90s wait, the audit and the drains.
+#
+# ONE ceiling for all seats, not six tuned numbers. Only pm (5 turns/$0.1161),
+# analyst (7/$0.0504) and exec (3/$0.0332) have a measured basis at all;
+# critic is PROVISIONAL, news is "INHERITED, NOT MEASURED", and reflect's 4 is
+# reasoned from the turn's shape. Three invented ceilings sitting beside three
+# measured numbers would read as measured. #44's defect is UNBOUNDED, not
+# mis-bounded, so one conservative bound closes it and per-seat tuning is
+# separate work. Overridable per seat with an optional `max_wall_s` key.
+SEAT_MAX_WALL_S = 240.0
 
 
 def log(msg: str) -> None:
@@ -229,6 +253,32 @@ async def _seat_session(cfg: dict, db_path: str, clock, prompt: str,
         return await run_seat_turn(client, prompt, REQUIRED_SERVERS)
 
 
+class SeatTurnTimeout(Exception):
+    """A seat turn abandoned at its wall-clock ceiling (issue #44)."""
+
+
+async def _bounded(coro, wall_s: float):
+    """`coro` under a wall-clock ceiling, raising SeatTurnTimeout when it
+    blows it. Wraps the COROUTINE, inside asyncio.run: a bound needs a running
+    loop, so it cannot wrap asyncio.run itself.
+
+    asyncio.timeout rather than asyncio.wait_for because both raise the same
+    TimeoutError and only `.expired()` tells OUR bound apart from one the
+    session itself raised — and the session raises exactly that today
+    (await_servers_connected's 30s MCP-connect wait, an SDK stream timeout).
+    Conflating them would relabel a connect failure as a hang and lose the
+    exception text the seat_turn_failed alert reports."""
+    try:
+        async with asyncio.timeout(wall_s) as bound:
+            return await coro
+    except TimeoutError:
+        if not bound.expired():
+            raise                       # the session's own, not ours
+        raise SeatTurnTimeout(
+            f"no result after {wall_s:g}s (max_wall_s ceiling); the turn was"
+            " abandoned mid-flight") from None
+
+
 def emit_trace_guarded(seat: str, cfg: dict, run_date: str, turn_seq,
                        snapshot, names, result, trace_sink, conn=None) -> None:
     """Record one seat turn as a Trace. Never costs the day.
@@ -283,10 +333,22 @@ def make_turn(seat: str, cfg: dict, db_path: str, clock, conn, run_date: str,
 
     def run() -> None:
         try:
-            names, result = asyncio.run(
+            names, result = asyncio.run(_bounded(
                 _seat_session(cfg, db_path, clock, prompt, snapshot,
                               journals_root,
-                              expected_decision_id=expected_decision_id))
+                              expected_decision_id=expected_decision_id),
+                float(cfg.get("max_wall_s", SEAT_MAX_WALL_S))))
+        except SeatTurnTimeout as exc:
+            # Its own code and text: TimeoutError's repr is the EMPTY string,
+            # so falling through the handler below would post
+            # "pm_turn_failed — TimeoutError: ; stage default applies",
+            # naming neither the seat's budget nor how long it burned. A hang
+            # and a crash also want different fixes, and the alert filer opens
+            # one issue per code.
+            _alert(conn, clock, "seat_turn_timeout",
+                   f"{seat}_turn_timeout — {exc}; stage default applies"
+                   " (default is HOLD)")
+            return
         except Exception as exc:
             _alert(conn, clock, "seat_turn_failed",
                    f"{seat}_turn_failed — {type(exc).__name__}: {exc};"

--- a/scripts/run_day.py
+++ b/scripts/run_day.py
@@ -126,13 +126,10 @@ LOCK_NAME = "run_day.lock"
 #     the day continues, and reconciliation recovers it. Abandoning a turn is
 #     therefore strictly LESS harmful than the 30min timeout it pre-empts.
 #
-# ONE ceiling for all seats, not six tuned numbers. Only pm (5 turns/$0.1161),
-# analyst (7/$0.0504) and exec (3/$0.0332) have a measured basis at all;
-# critic is PROVISIONAL, news is "INHERITED, NOT MEASURED", and reflect's 4 is
-# reasoned from the turn's shape. Three invented ceilings sitting beside three
-# measured numbers would read as measured. #44's defect is UNBOUNDED, not
-# mis-bounded, so one conservative bound closes it and per-seat tuning is
-# separate work. Overridable per seat with an optional `max_wall_s` key.
+# ONE ceiling for every seat, applied unconditionally — there is no per-seat
+# knob. Only half the seats have a measured turn cost, and an invented ceiling
+# sitting beside a measured one reads as measured. #44's defect is UNBOUNDED,
+# not mis-bounded, so one conservative bound closes it; per-seat tuning is #131.
 SEAT_MAX_WALL_S = 240.0
 
 
@@ -321,30 +318,8 @@ async def _bounded(coro, wall_s: float):
         if not bound.expired():
             raise                       # the session's own, not ours
         raise SeatTurnTimeout(
-            f"no result after {wall_s:g}s (max_wall_s ceiling); the turn was"
-            " abandoned mid-flight") from None
-
-
-def seat_wall_s(seat: str, cfg: dict) -> float:
-    """This seat's ceiling, validated. agents/seats.py's load_seat_config is a
-    bare yaml.safe_load with no schema, so `max_wall_s: 0` — or a stray unit
-    like '4m' — arrives here unchecked, and a non-positive bound expires every
-    turn instantly: a whole trading day of stage defaults, one
-    seat_turn_timeout per stage, and nothing naming the one yaml line that did
-    it. Invariant 4 makes HOLD the answer to genuine ambiguity; a config typo
-    is not ambiguity, so it stops the day loudly instead."""
-    raw = cfg.get("max_wall_s", SEAT_MAX_WALL_S)
-    try:
-        wall_s = float(raw)
-    except (TypeError, ValueError):
-        wall_s = float("nan")
-    if not wall_s > 0:                  # also rejects nan
-        raise SystemExit(
-            f"run_day: seat {seat!r} has max_wall_s={raw!r} — it must be a"
-            " positive number of seconds. Fix agents/config/"
-            f"{seat}.yaml or drop the key to take the"
-            f" {SEAT_MAX_WALL_S:g}s default.")
-    return wall_s
+            f"no result after {wall_s:g}s (SEAT_MAX_WALL_S ceiling); the turn"
+            " was abandoned mid-flight") from None
 
 
 def emit_trace_guarded(seat: str, cfg: dict, run_date: str, turn_seq,
@@ -398,19 +373,13 @@ def make_turn(seat: str, cfg: dict, db_path: str, clock, conn, run_date: str,
     `alert` and lets the stage's own default land (invariant 4). The cost is
     recorded BEFORE the exec seat's tool-call assertions run — a violating
     turn still spent real money."""
-    # Resolved HERE rather than inside run(): make_turn is called from
-    # _trading_day's wiring, so a bad max_wall_s stops the day before the
-    # first stage — inside guarded(), which alerts and drains — instead of
-    # after the gate has already minted tickets.
-    wall_s = seat_wall_s(seat, cfg)
-
     def run() -> None:
         try:
             names, result = asyncio.run(_bounded(
                 _seat_session(cfg, db_path, clock, prompt, snapshot,
                               journals_root,
                               expected_decision_id=expected_decision_id),
-                wall_s))
+                SEAT_MAX_WALL_S))
         except SeatTurnTimeout as exc:
             # Its own code, because the alert filer opens one issue per code
             # and a hang and a crash want different fixes — the handler below

--- a/specs/acceptance.md
+++ b/specs/acceptance.md
@@ -57,6 +57,7 @@ Testing splits LLM **decisions** (expensive, non-deterministic) from tool **exec
 - [ ] Chaos tests: Alpaca MCP down at execution (retry→expire→alert), Slack down mid-day (outbox drains after recovery), agent container kill mid-debate (session resume, turn re-assigned).
 - [ ] Full-week sim under `SimClock` acceleration completes: 5 days, ≥1 resolution cycle, scoreboard posted.
 - [ ] Budget: any seat hitting `max_budget_usd` degrades gracefully (stage default applies, day completes, alert posted).
+- [ ] Wall clock: a seat turn that never returns is abandoned at `SEAT_MAX_WALL_S` and degrades the same way (stage default applies, day completes, `seat_turn_timeout` alert posted naming the seat and the ceiling). The ceiling binds every seat unconditionally — no per-seat opt-in — and a full day's four turns of it still fires before `ops/fund-daily.service`'s `TimeoutStartSec`.
 - [ ] 30-day paper burn-in (manual, not CI): zero invariant violations in DB audit query; est. cost within budget.
 
 ## Phase 5 — The lab (strategy platform, per `specs/strategy.md`)

--- a/specs/design.md
+++ b/specs/design.md
@@ -116,7 +116,7 @@ Debate mechanics (TradingAgents' proven core): shared thread transcript, turn-sc
 - **Session lifecycle:** new session each morning seeded with a journal summary; `session_id` captured from `ResultMessage` and persisted; crash within the day → `resume=session_id`.
 - **Settings:** `setting_sources=["project"]` so `CLAUDE.md` loads for every seat. `system_prompt` = charter string.
 - **Models:** two tiers — fast (Haiku) for analysts/trader/ops, strong (Sonnet/Opus) for PM, researchers, risk. Per-seat `model=` + `fallback_model` in `agents/config/*.yaml`, never hardcoded. Pin exact model ids there.
-- **Cost control:** `max_budget_usd` per session, `max_turns` caps. `ResultMessage.total_cost_usd` is a **client-side estimate** — sum into the digest labeled "est." Budget exhaustion degrades to the stage default (day completes). Expect low single-digit $/day at 3–5 tickers.
+- **Cost control:** `max_budget_usd` per session, `max_turns` caps. `ResultMessage.total_cost_usd` is a **client-side estimate** — sum into the digest labeled "est." Budget exhaustion degrades to the stage default (day completes). Neither caps *seconds*, and a stalled tool call or model stream spends neither, so every seat turn also runs under a wall-clock ceiling (`SEAT_MAX_WALL_S`, `scripts/run_day.py`) and a turn that blows it is abandoned into the same stage default. Expect low single-digit $/day at 3–5 tickers.
 - **Pinned deps:** Python 3.12, `claude-agent-sdk`, `slack_bolt`, `pydantic` v2 — versions in `pyproject.toml`.
 
 ### Slack

--- a/tests/test_run_day.py
+++ b/tests/test_run_day.py
@@ -12,7 +12,9 @@ Never calls main(): that builds real clients.
 
 from __future__ import annotations
 
+import asyncio
 import importlib.util
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -646,6 +648,91 @@ def test_seat_turn_failure_uses_a_literal_code_not_the_seat_name(
     payload = _alert_payloads(conn)[-1]
     assert payload["code"] == "seat_turn_failed"
     assert payload["text"].startswith("analyst_turn_failed —")
+
+
+# --- a seat turn that HANGS is a different failure from one that raises -----
+
+def test_a_seat_turn_that_never_returns_is_abandoned_at_its_wall_clock_bound(
+        wired, monkeypatch):
+    """Issue #44. max_turns and max_budget_usd bound turns and dollars; a
+    stalled MCP tool call or model stream spends neither, so before this the
+    turn simply never came back. The stage default is triggered by an
+    EXCEPTION and by nothing else (orchestrator/daily.py's run_stage calls
+    body() with no time budget), so a hang reached no default at all: the day
+    hung forever holding the flock, and the next day's timer found the lock
+    and exited 0 — indistinguishable from a market-closed day.
+
+    The 30s sleep stands in for "never returns": it is 600x the bound this
+    test configures, so any pass is the bound firing and not the sleep
+    finishing — while an unbounded regression still ENDS the suite (with a
+    red assertion) instead of hanging it."""
+    conn, _, clock = wired
+
+    async def _hang(*a, **k):
+        await asyncio.sleep(30)
+
+    monkeypatch.setattr(run_day_script, "_seat_session", _hang)
+    run = _turn(conn, clock, seat="pm", cfg={"max_wall_s": 0.05})
+    started = time.monotonic()
+    run()                                    # must NOT raise, must NOT hang
+    assert time.monotonic() - started < 5    # abandoned at the bound
+
+    payload = _alert_payloads(conn)[-1]
+    assert payload["code"] == "seat_turn_timeout"
+    assert payload["text"].startswith("pm_turn_timeout —")
+    assert "0.05s" in payload["text"] and "max_wall_s" in payload["text"]
+    assert "default is HOLD" in payload["text"]
+
+    # ...and because it now RAISES, the stage's own default finally lands:
+    # the ticker gets hold/0 instead of the day stopping dead.
+    from orchestrator.daily import StageCtx, run_decision
+    run_decision(StageCtx(conn=conn, run_date="2026-07-06", clock=clock,
+                          slack=None, research_seats=(),
+                          run_turn={"decision": run}), ["NVDA"])
+    row = conn.execute("SELECT action, qty FROM decisions"
+                       " WHERE run_date = '2026-07-06' AND ticker = 'NVDA'"
+                       ).fetchone()
+    assert (row["action"], row["qty"]) == ("hold", 0)
+
+
+def test_a_seat_with_no_max_wall_s_still_gets_the_default_ceiling(
+        wired, monkeypatch):
+    """max_wall_s is optional and resolved from ONE named constant, so a seat
+    yaml that never mentions it is still bounded. A `cfg["max_wall_s"]`
+    subscript would instead leave every one of today's six configs unbounded —
+    the exact defect #44 reports."""
+    conn, _, clock = wired
+    seen = {}
+
+    async def _capture(*a, **k):
+        return [], _Result()
+
+    def _spy(coro, wall_s):
+        seen["wall_s"] = wall_s
+        return coro
+
+    monkeypatch.setattr(run_day_script, "_seat_session", _capture)
+    monkeypatch.setattr(run_day_script, "_bounded", _spy)
+    _turn(conn, clock, seat="analyst", cfg={})()
+
+    assert seen["wall_s"] == run_day_script.SEAT_MAX_WALL_S
+
+
+def test_the_seat_wall_clock_ceiling_fires_before_systemd_sigterms_the_unit():
+    """The whole point of a per-seat bound is that it beats
+    ops/fund-daily.service's TimeoutStartSec=30min — that SIGTERM can land
+    between the broker accepting a place_stock_order and the PostToolUse
+    recorder committing the row. A day runs at most four seat turns (the two
+    research seats, the PM, the trader), so the ceiling must leave real room
+    for the non-turn work underneath: the broker snapshot, the market-data
+    fetch, reconcile's 90s wait, the audit and the drains."""
+    turns_per_day = sum(len(seats) for seats in run_day_script.SEATS.values())
+    assert turns_per_day == 4
+    worst_case_s = turns_per_day * run_day_script.SEAT_MAX_WALL_S
+    assert worst_case_s <= 0.6 * 30 * 60          # >= 40% of the unit's budget
+    # ...and still far above any turn ever observed (exec's measured live turn
+    # was 3 tool-calling turns), so a slow real turn is not culled as a hang.
+    assert run_day_script.SEAT_MAX_WALL_S >= 120
 
 
 def test_an_exec_tool_call_violation_is_alerted_after_the_cost_is_recorded(

--- a/tests/test_run_day.py
+++ b/tests/test_run_day.py
@@ -665,14 +665,17 @@ def test_a_seat_turn_that_never_returns_is_abandoned_at_its_wall_clock_bound(
     The 30s sleep stands in for "never returns": it is 600x the bound this
     test configures, so any pass is the bound firing and not the sleep
     finishing — while an unbounded regression still ENDS the suite (with a
-    red assertion) instead of hanging it."""
+    red assertion) instead of hanging it. The bound is shortened by patching
+    the module constant, which IS the production knob — there is no config
+    key to inject."""
     conn, _, clock = wired
 
     async def _hang(*a, **k):
         await asyncio.sleep(30)
 
     monkeypatch.setattr(run_day_script, "_seat_session", _hang)
-    run = _turn(conn, clock, seat="pm", cfg={"max_wall_s": 0.05})
+    monkeypatch.setattr(run_day_script, "SEAT_MAX_WALL_S", 0.05)
+    run = _turn(conn, clock, seat="pm")
     started = time.monotonic()
     run()                                    # must NOT raise, must NOT hang
     assert time.monotonic() - started < 5    # abandoned at the bound
@@ -680,7 +683,7 @@ def test_a_seat_turn_that_never_returns_is_abandoned_at_its_wall_clock_bound(
     payload = _alert_payloads(conn)[-1]
     assert payload["code"] == "seat_turn_timeout"
     assert payload["text"].startswith("pm_turn_timeout —")
-    assert "0.05s" in payload["text"] and "max_wall_s" in payload["text"]
+    assert "0.05s" in payload["text"] and "SEAT_MAX_WALL_S" in payload["text"]
     assert "default is HOLD" in payload["text"]
 
     # ...and because it now RAISES, the stage's own default finally lands:
@@ -695,12 +698,12 @@ def test_a_seat_turn_that_never_returns_is_abandoned_at_its_wall_clock_bound(
     assert (row["action"], row["qty"]) == ("hold", 0)
 
 
-def test_a_seat_with_no_max_wall_s_still_gets_the_default_ceiling(
+def test_every_seat_turn_is_bounded_by_the_one_named_ceiling(
         wired, monkeypatch):
-    """max_wall_s is optional and resolved from ONE named constant, so a seat
-    yaml that never mentions it is still bounded. A `cfg["max_wall_s"]`
-    subscript would instead leave every one of today's six configs unbounded —
-    the exact defect #44 reports."""
+    """The ceiling is ONE module constant applied unconditionally, so a seat is
+    bounded by virtue of being a seat — no config, no opt-in. Make the bound
+    conditional on anything a yaml carries and today's six configs, none of
+    which carry it, go back to unbounded: the exact defect #44 reports."""
     conn, _, clock = wired
     seen = {}
 
@@ -716,25 +719,6 @@ def test_a_seat_with_no_max_wall_s_still_gets_the_default_ceiling(
     _turn(conn, clock, seat="analyst", cfg={})()
 
     assert seen["wall_s"] == run_day_script.SEAT_MAX_WALL_S
-
-
-@pytest.mark.parametrize("bad", [0, 0.0, -1, -0.05, "soon", None, [240]])
-def test_a_max_wall_s_that_is_not_a_positive_number_is_rejected_at_wiring(
-        wired, bad):
-    """agents/seats.py's loader is a bare yaml.safe_load with no schema, so a
-    `max_wall_s: 0` typo reaches the bound unchecked — and a non-positive
-    ceiling insta-times-out EVERY turn into its stage default: a whole trading
-    day of HOLDs whose only trace is one seat_turn_timeout per stage, with
-    nothing saying the cause was one yaml line. Invariant 4 makes HOLD the
-    answer to genuine ambiguity; a config typo is not ambiguity.
-
-    Checked when the turn is BUILT, not when it runs: make_turn is called from
-    _trading_day's wiring, before the first stage, so a bad value stops the day
-    inside guarded() — one alert, drained to Slack, exit 1 — rather than after
-    the gate has already minted tickets."""
-    conn, _, clock = wired
-    with pytest.raises(SystemExit, match="max_wall_s"):
-        _turn(conn, clock, seat="pm", cfg={"max_wall_s": bad})
 
 
 def test_the_seat_wall_clock_ceiling_fires_before_systemd_sigterms_the_unit():

--- a/tests/test_run_day.py
+++ b/tests/test_run_day.py
@@ -718,6 +718,25 @@ def test_a_seat_with_no_max_wall_s_still_gets_the_default_ceiling(
     assert seen["wall_s"] == run_day_script.SEAT_MAX_WALL_S
 
 
+@pytest.mark.parametrize("bad", [0, 0.0, -1, -0.05, "soon", None, [240]])
+def test_a_max_wall_s_that_is_not_a_positive_number_is_rejected_at_wiring(
+        wired, bad):
+    """agents/seats.py's loader is a bare yaml.safe_load with no schema, so a
+    `max_wall_s: 0` typo reaches the bound unchecked — and a non-positive
+    ceiling insta-times-out EVERY turn into its stage default: a whole trading
+    day of HOLDs whose only trace is one seat_turn_timeout per stage, with
+    nothing saying the cause was one yaml line. Invariant 4 makes HOLD the
+    answer to genuine ambiguity; a config typo is not ambiguity.
+
+    Checked when the turn is BUILT, not when it runs: make_turn is called from
+    _trading_day's wiring, before the first stage, so a bad value stops the day
+    inside guarded() — one alert, drained to Slack, exit 1 — rather than after
+    the gate has already minted tickets."""
+    conn, _, clock = wired
+    with pytest.raises(SystemExit, match="max_wall_s"):
+        _turn(conn, clock, seat="pm", cfg={"max_wall_s": bad})
+
+
 def test_the_seat_wall_clock_ceiling_fires_before_systemd_sigterms_the_unit():
     """The whole point of a per-seat bound is that it beats
     ops/fund-daily.service's TimeoutStartSec=30min — that SIGTERM can land
@@ -725,11 +744,17 @@ def test_the_seat_wall_clock_ceiling_fires_before_systemd_sigterms_the_unit():
     recorder committing the row. A day runs at most four seat turns (the two
     research seats, the PM, the trader), so the ceiling must leave real room
     for the non-turn work underneath: the broker snapshot, the market-data
-    fetch, reconcile's 90s wait, the audit and the drains."""
+    fetch, reconcile's 90s wait, the audit and the drains.
+
+    A guard-rail on the constants, not on behaviour: it would still pass
+    against a SEAT_MAX_WALL_S with no bound behind it. The behaviour is pinned
+    by the abandoned-turn test above; this one exists so a later re-tune of
+    the ceiling cannot silently cross the unit's budget."""
     turns_per_day = sum(len(seats) for seats in run_day_script.SEATS.values())
     assert turns_per_day == 4
     worst_case_s = turns_per_day * run_day_script.SEAT_MAX_WALL_S
-    assert worst_case_s <= 0.6 * 30 * 60          # >= 40% of the unit's budget
+    # at most 60% of the unit's budget, leaving 40%+ for the non-turn work
+    assert worst_case_s <= 0.6 * 30 * 60
     # ...and still far above any turn ever observed (exec's measured live turn
     # was 3 tool-calling turns), so a slow real turn is not culled as a hang.
     assert run_day_script.SEAT_MAX_WALL_S >= 120


### PR DESCRIPTION
Closes #44.

`max_turns` and `max_budget_usd` bound turns and dollars, not seconds — a stalled MCP tool call or model stream consumes neither. Before this change there was **no wall-clock bound on a seat turn anywhere in the repo**, and no `asyncio.wait_for` or `asyncio.timeout` in the codebase at all, tests included. A hung turn hung the day forever, held the flock from `scripts/run_day.py`, and the next day's timer then found the lock and exited 0 — indistinguishable from a market-closed day.

Each seat turn now runs under `SEAT_MAX_WALL_S`. A timeout raises `SeatTurnTimeout`, which is caught alongside the existing failure handler, alerts `seat_turn_timeout`, and falls into the stage default.

## Deviations from the issue's prescribed fix — both deliberate

**`asyncio.timeout`, not `asyncio.wait_for`.** On 3.11+ `asyncio.TimeoutError` *is* the builtin `TimeoutError`. Three existing tests raise `TimeoutError` from inside `_seat_session` and assert the alert reads `seat_turn_failed`; `wait_for` cannot distinguish an inner `TimeoutError` from its own expiry by type, so a blanket handler would have relabelled all three as hangs. `asyncio.timeout`'s `.expired()` is the structural discriminator. Rewriting those tests was not an option.

**No required per-seat `max_wall_s` key.** The issue prescribes one in all six `agents/config/*.yaml`. Only three seats have a measured basis (`pm` 5 turns/\$0.1161, `analyst` 7 turns/\$0.0504, `exec` 3 turns/\$0.0332); `critic` is PROVISIONAL, `news` says INHERITED-NOT-MEASURED, and `reflect` carries no marker at all. Three of six ceilings would have been invented and would have read as measured. The defect here is *unbounded*, not *mis-bounded*, so one conservative ceiling fixes it. Per-seat sizing is #131.

## Why this is safe around real orders

The obvious worry is that abandoning a turn cancels a coroutine mid-`place_stock_order`. Checked, and the change makes that **strictly less harmful**:

- `record_order` is an `async def` with no `await` in its body, so once the hook starts it cannot be cancelled. The reachable window is narrower than feared — cancellation after the broker accepted but before the hook is invoked, which leaves the ticket `status='open'`.
- `run_execution` and the reconciliation stage run **in the same process**, and `recover_lost_orders` is the existing repair pass for exactly that state. Under the old `TimeoutStartSec=30min` SIGTERM the process died and that repair never ran, leaving the order permanently unrecorded. Under this bound the process survives into reconciliation and recovers it.

## Two things a reviewer would otherwise assume the other way

- **`make sim-day` gives zero coverage of this call site.** `tests/test_sim_day.py` imports neither `scripts.run_day` nor `agents.seats` nor `agents.exec_turn`. The "injected `Clock` is what makes sim-day possible" rationale does not reach here in either direction — which is also why the bound is legitimate in `scripts/`, the composition root that `check_purity.py` deliberately excludes.
- **The timeout needed no new default logic.** `asyncio.TimeoutError` is an `Exception`, so it resolves into the existing HOLD machinery the moment the turn raises.

## Where the number came from, and what is not demonstrated

A day runs exactly 4 seat turns, fixed by the stages rather than by ticker count. 4 × 240s = 16 min against `ops/fund-daily.service`'s `TimeoutStartSec=30min`, leaving 14 min for all non-turn work. **That arithmetic is demonstrated and a test pins it.**

**"A real seat turn is well under 240s" is reasoned, not measured — there is no wall-clock measurement of a seat turn anywhere in this repo.** The measured numbers are turn counts and dollars. #131 tracks closing that gap.

## Known limit, filed rather than hidden

`_bounded` is not a hard ceiling: `asyncio.timeout` cancels once, and a teardown that blocks after the cancel is unbounded (#152). The obvious repair was built and measured — 3.06s against the original 3.05s, because `asyncio.run`'s own shutdown re-awaits the same task, so the hang moves rather than closes. Documented instead of bodged; #152 carries the negative result so nobody rediscovers it.

## Scope

The issue's other half — the lock-not-acquired path exiting 0 without alerting — is **not** in this PR. It is run entry, not seat turn lifecycle, and it is #129 (`severity:high`: exit 0 pings Healthchecks `/0`, which reads as an affirmative success, so a skipped day reports green).

Specs updated where this change made them incomplete: `specs/design.md` (bounds enumeration), `specs/acceptance.md` Phase 4 (the wall-clock sibling to the budget criterion — recording what the three tests already prove), and `evals/runner.py`'s docstring, which claimed to mirror `_seat_session` exactly and no longer does. `specs/contracts.md` §6 deliberately untouched: `seat_turn_failed` and every other run_day-level alert are absent from it, so adding one row would misrepresent §6 as complete (#112 tracks that).

Also found while reviewing, filed separately: #144 (`check_purity.py` forbids `asyncio.sleep` but not `asyncio.timeout`/`wait_for`, so nothing would have stopped this bound being placed in a pure package — demonstrated with a probe) and #145 (the reflect job inherits this ceiling through `run_day.make_turn`, but its 25-turn cap against a 30-min budget shared by three `ExecStart` lines crosses over at 7-8 due decisions).

`1469 passed, 1 skipped, 7 deselected`; purity and alert-code lints clean.