### PR TITLE
fix: redact credentials from alert text before it is stored

### DIFF
--- a/slackkit/outbox.py
+++ b/slackkit/outbox.py
@@ -46,11 +46,13 @@ def append_alert(conn: sqlite3.Connection, code: str, text: str, *,
     dead trading day (invariant 4). scripts/check_alert_codes.py enforces the
     code's shape statically instead.
 
-    `text` is redacted here rather than at the call sites: the three
-    scripts/run_day.py sites interpolate a raw exception, and the stored row
-    feeds BOTH egresses — Slack via drain(), GitHub via
-    scripts/file_alert_issues.py. redact() never raises, so this cannot cost
-    an alert.
+    `text` — and only `text` — is redacted here rather than at the call sites:
+    the three scripts/run_day.py sites interpolate a raw exception, and the
+    stored row feeds BOTH egresses, Slack via drain() and GitHub via
+    scripts/file_alert_issues.py. `**payload` is stored as given;
+    orchestrator/preconditions.py:78 deliberately keeps a full uncapped
+    exception there, and no egress reads payload extras today. redact()
+    neither raises nor runs long, so this cannot cost an alert.
     """
     body: dict = {"text": redact(text), "code": code, **payload}
     if ticker is not None:

--- a/slackkit/outbox.py
+++ b/slackkit/outbox.py
@@ -11,6 +11,7 @@ import logging
 import sqlite3
 
 from .port import PermanentPostError
+from .redact import redact
 from .render import render
 
 log = logging.getLogger(__name__)
@@ -44,8 +45,14 @@ def append_alert(conn: sqlite3.Connection, code: str, text: str, *,
     an `except`, and a raise here would turn "something needs review" into a
     dead trading day (invariant 4). scripts/check_alert_codes.py enforces the
     code's shape statically instead.
+
+    `text` is redacted here rather than at the call sites: the three
+    scripts/run_day.py sites interpolate a raw exception, and the stored row
+    feeds BOTH egresses — Slack via drain(), GitHub via
+    scripts/file_alert_issues.py. redact() never raises, so this cannot cost
+    an alert.
     """
-    body: dict = {"text": text, "code": code, **payload}
+    body: dict = {"text": redact(text), "code": code, **payload}
     if ticker is not None:
         body["ticker"] = ticker
     if clears:

--- a/slackkit/redact.py
+++ b/slackkit/redact.py
@@ -54,7 +54,26 @@ log = logging.getLogger(__name__)
 # DIVERGENCE from the shell twin, deliberate: over this length the two
 # implementations no longer agree, because sed is fed a bounded journal tail
 # (-n 20) and has no equivalent exposure. Under it they agree byte for byte.
+#
+# Raising it is not free and not linear-cheap: with the cap disabled, cost runs
+# ~22 us/char on the worst shape below — 1MB takes 23s and 4MB takes 97s,
+# inside an `except` on the trading path.
 _MAX_CHARS = 8192
+
+# Truncation cuts back to the last of these, so the cap can never bisect a
+# token. It otherwise can: PK[A-Z0-9]{16,} needs 16 characters after its
+# prefix, so a PK token cut short by the cap is not a match and its first
+# 1-17 characters were emitted in the clear — the cap introducing a leak the
+# uncapped scan did not have. The `+` rules (sk-ant-, xoxb-, xapp-) never had
+# it; they match any fragment and give up only the non-secret prefix.
+#
+# The lookback is deliberately UNBOUNDED, unlike the shell-style bounded
+# window: a bound reopens exactly this class, because a non-whitespace run
+# longer than the window falls back to the hard cut and bisects a token again.
+# The cost is that a truncated alert ending in one huge unbroken blob loses
+# that blob — and a whitespace-free 8KB run carries no readable diagnosis
+# anyway. If the kept region holds no whitespace at all, all of it is dropped.
+_WHITESPACE = " \t\n\r\f\v"
 
 # Whitespace except newline. sed is line-oriented, so a shell match can never
 # span log lines; \s here would let one run off the end of a line and eat the
@@ -85,6 +104,13 @@ _SP = r"[^\S\n]"
 _NAME_HEAD = r"[A-Z0-9_]{0,63}"
 _NAME_TAIL = r"[A-Z0-9_]{0,63}+"
 
+# COST CENTRE, for whoever edits these next: it is the TAIL of the name rule,
+# `_SP*[=:]_SP*['"]?\S+`, not the name halves above. The worst input found is a
+# long capitals run, a delimiter, then thousands of spaces ended by a newline,
+# so `\S+` fails at every backtrack position of the second `_SP*`: ~0.19s at
+# and above the cap. The name halves, having been bounded, no longer dominate.
+# Anything added to this half needs the same adversarial measurement.
+#
 # Applied in order, exactly as ops/notify_failure.sh chains its -e expressions:
 # prefix rules catch known token shapes, then the name rule catches secrets
 # with no recognizable prefix (e.g. ALPACA_SECRET_KEY), written as NAME=VALUE,
@@ -115,18 +141,26 @@ def redact(text: str) -> str:
     failure passes the ORIGINAL text through untouched, and input past
     _MAX_CHARS is dropped rather than scanned.
 
-    Truncation drops the tail; it never passes it through. A cut can only
-    remove credential material, never expose it: a value split by the cut is
-    still preceded by its NAME= and still redacted, and a NAME split by the
-    cut carries no secret.
+    Truncation drops the tail; it never passes it through. The cut lands on a
+    whitespace boundary, so every token the scan sees is whole: a value cut in
+    half is dropped rather than emitted as a prefix of itself, and a value that
+    survives is still preceded by its NAME= and still redacted.
+
+    The `…[N chars truncated]` marker reaches the GitHub egress but not the
+    Slack one: slackkit/render.py:33-38 clips section text at 3000 characters,
+    so anything long enough to have been truncated here is clipped again well
+    before the marker. The operator sees render's own `…` and learns the size
+    of the drop only from the issue body.
     """
     try:
         out = text
+        dropped = 0
         if len(out) > _MAX_CHARS:
-            dropped = len(out) - _MAX_CHARS
-            out = out[:_MAX_CHARS]
-        else:
-            dropped = 0
+            head = out[:_MAX_CHARS]
+            boundary = max(head.rfind(ws) for ws in _WHITESPACE)
+            head = head[:boundary + 1]          # -1 -> drop the lot
+            dropped = len(out) - len(head)
+            out = head
         for pattern, replacement in _RULES:
             out = pattern.sub(replacement, out)
         if dropped:

--- a/slackkit/redact.py
+++ b/slackkit/redact.py
@@ -1,0 +1,69 @@
+"""Strip credential-shaped text out of anything bound for an egress.
+
+Three sites in scripts/run_day.py interpolate a raw exception into an alert
+(`seat_turn_failed`, `exec_turn_violation`, `run_day_failed`), and a traceback
+that touches os.environ carries broker keys, Slack tokens or the Anthropic key
+with it. Alert text reaches TWO egresses — Slack, via outbox.drain(), and
+GitHub, via scripts/file_alert_issues.py, which writes it into an issue title
+and body. Redacting in append_alert covers both, because both read the stored
+row.
+
+TWIN: the `redact()` shell function in ops/notify_failure.sh:25-32 applies
+these same five rules to the journal tail. That script is deliberately
+dependency-free of the fund (its header: "the alert path must not share a
+failure mode with the thing it is watching"), so the duplication is permanent
+and intentional — change the two together, and keep tests/test_ops_notify.py
+and tests/test_redact.py in step.
+
+The rules cut in both directions on purpose. Over-redaction guts an alert's
+usefulness: `KeyError: 'ALPACA_SECRET_KEY'` names the ONE fact the operator
+needs, so the name pattern is anchored to ALL_CAPS env-var shape throughout
+and leaves a mixed-case `KeyError` alone.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+log = logging.getLogger(__name__)
+
+# Whitespace except newline. sed is line-oriented, so a shell match can never
+# span log lines; \s alone would let one.
+_SP = r"[^\S\n]"
+
+# Applied in order, exactly as ops/notify_failure.sh chains its -e expressions:
+# prefix rules catch known token shapes, then the name rule catches secrets
+# with no recognizable prefix (e.g. ALPACA_SECRET_KEY), written as NAME=VALUE,
+# NAME: VALUE, or quoted python/JSON dict dumps ('NAME': 'VALUE').
+#
+# The name rule's replacement keeps the NAME and normalises `:` to `=`, so the
+# operator still learns which credential the line was about.
+_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"sk-ant-[A-Za-z0-9_-]+"), "sk-ant-REDACTED"),
+    (re.compile(r"xoxb-[A-Za-z0-9-]+"), "xoxb-REDACTED"),
+    (re.compile(r"xapp-[A-Za-z0-9-]+"), "xapp-REDACTED"),
+    (re.compile(r"PK[A-Z0-9]{16,}"), "PK-REDACTED"),
+    (re.compile(r"""['"]?([A-Z][A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD)"""
+                r"""[A-Z0-9_]*)['"]?""" + _SP + r"""*[=:]""" + _SP
+                + r"""*['"]?\S+"""), r"\1=REDACTED"),
+)
+
+
+def redact(text: str) -> str:
+    """Return `text` with credential-shaped substrings replaced.
+
+    Never raises. This runs on the alert path, inside `except` blocks, where a
+    raise would turn "something needs review" into a dead trading day
+    (invariant 4; slackkit/outbox.py:44-47). A redactor that can lose an alert
+    is worse than the leak it fixes, so any failure passes the ORIGINAL text
+    through untouched.
+    """
+    try:
+        out = text
+        for pattern, replacement in _RULES:
+            out = pattern.sub(replacement, out)
+        return out
+    except Exception:
+        log.exception("redact: failed; alert text passes through unredacted")
+        return text

--- a/slackkit/redact.py
+++ b/slackkit/redact.py
@@ -8,6 +8,16 @@ GitHub, via scripts/file_alert_issues.py, which writes it into an issue title
 and body. Redacting in append_alert covers both, because both read the stored
 row.
 
+SCOPE — this covers alert TEXT only, and nothing else claims to be clean.
+append_alert's `**payload` extras are stored unredacted, and one site relies on
+that: orchestrator/preconditions.py:77-78 caps the text at 120 chars and keeps
+the FULL uncapped exception in `payload["error"]` on purpose, so the cap never
+costs the only diagnostic there is. No renderer or filer egresses payload
+extras today. Separately, scripts/run_day.py:350 logs the RAW text before
+append_alert ever sees it, so logs/run_day.err.log keeps an unredacted copy on
+the box. Neither is in scope here; do not read this module as a promise that a
+credential cannot reach disk.
+
 TWIN: the `redact()` shell function in ops/notify_failure.sh:25-32 applies
 these same five rules to the journal tail. That script is deliberately
 dependency-free of the fund (its header: "the alert path must not share a
@@ -28,9 +38,52 @@ import re
 
 log = logging.getLogger(__name__)
 
+# Longest input the rules run over; the rest is dropped, not passed through
+# unredacted. The three run_day.py sites interpolate `{exc}` with no length
+# cap of their own (unlike orchestrator/protection.py:203 and
+# preconditions.py:77, which use str(e)[:120]), and an attacker-influenced
+# exception message is the ordinary shape here — the analyst seat reads
+# attacker-authorable news (issue #42).
+#
+# The bound is what keeps redaction from becoming the outage. This module's
+# whole thesis is that it must never cost an alert, and a regex that runs for
+# minutes is strictly worse than one that raises: a raise is caught and logged
+# at run_day.py:471, while a hang inside guarded() is a dead trading day with
+# no signal at all (invariant 4, violated in effect rather than in form).
+#
+# DIVERGENCE from the shell twin, deliberate: over this length the two
+# implementations no longer agree, because sed is fed a bounded journal tail
+# (-n 20) and has no equivalent exposure. Under it they agree byte for byte.
+_MAX_CHARS = 8192
+
 # Whitespace except newline. sed is line-oriented, so a shell match can never
-# span log lines; \s alone would let one.
+# span log lines; \s here would let one run off the end of a line and eat the
+# next one, destroying the diagnosis that follows. Pinned by
+# test_a_match_cannot_run_across_a_newline.
 _SP = r"[^\S\n]"
+
+# The two halves of a NAME, either side of its keyword. The unbounded `*` these
+# replace was the cubic term: two of them straddling the alternation made 8KB
+# of `("A"*40 + "KEY" + "A"*40)` take ~20 seconds and 40KB roughly 40 minutes.
+#
+# HEAD must still backtrack — the keyword follows it, so it has to give back to
+# let KEY|TOKEN|... match. Its bound costs no fidelity: on a name with more
+# than 64 characters before its keyword the match simply starts further right,
+# the skipped characters are copied through verbatim, and the rendered line is
+# byte-identical.
+#
+# TAIL is possessive, which is both exact and 11x faster (215ms -> 19ms on the
+# worst input found). Giving back cannot rescue a failed match: everything that
+# may follow the name is `['"]?`, horizontal space or `[=:]`, and none of those
+# match a [A-Z0-9_] character.
+#
+# TAIL's bound is the one real divergence from the shell twin. sed redacts
+# `AKEY` + 70 more capitals + `=v`; this does not. Real credential names run
+# under 30 characters, and an unbounded-but-possessive tail measured 3.5x
+# SLOWER than the plain bound, so the bound stays and the gap is documented
+# rather than closed.
+_NAME_HEAD = r"[A-Z0-9_]{0,63}"
+_NAME_TAIL = r"[A-Z0-9_]{0,63}+"
 
 # Applied in order, exactly as ops/notify_failure.sh chains its -e expressions:
 # prefix rules catch known token shapes, then the name rule catches secrets
@@ -44,8 +97,9 @@ _RULES: tuple[tuple[re.Pattern[str], str], ...] = (
     (re.compile(r"xoxb-[A-Za-z0-9-]+"), "xoxb-REDACTED"),
     (re.compile(r"xapp-[A-Za-z0-9-]+"), "xapp-REDACTED"),
     (re.compile(r"PK[A-Z0-9]{16,}"), "PK-REDACTED"),
-    (re.compile(r"""['"]?([A-Z][A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD)"""
-                r"""[A-Z0-9_]*)['"]?""" + _SP + r"""*[=:]""" + _SP
+    (re.compile(r"""['"]?([A-Z]""" + _NAME_HEAD
+                + r"""(?:KEY|TOKEN|SECRET|PASSWORD)""" + _NAME_TAIL
+                + r""")['"]?""" + _SP + r"""*[=:]""" + _SP
                 + r"""*['"]?\S+"""), r"\1=REDACTED"),
 )
 
@@ -53,16 +107,30 @@ _RULES: tuple[tuple[re.Pattern[str], str], ...] = (
 def redact(text: str) -> str:
     """Return `text` with credential-shaped substrings replaced.
 
-    Never raises. This runs on the alert path, inside `except` blocks, where a
-    raise would turn "something needs review" into a dead trading day
-    (invariant 4; slackkit/outbox.py:44-47). A redactor that can lose an alert
-    is worse than the leak it fixes, so any failure passes the ORIGINAL text
-    through untouched.
+    Never raises, and never runs long. This is on the alert path, inside
+    `except` blocks, where a raise would turn "something needs review" into a
+    dead trading day (invariant 4; slackkit/outbox.py:44-47) — and where a
+    regex that grinds for minutes would do the same thing, silently. A
+    redactor that can lose an alert is worse than the leak it fixes, so any
+    failure passes the ORIGINAL text through untouched, and input past
+    _MAX_CHARS is dropped rather than scanned.
+
+    Truncation drops the tail; it never passes it through. A cut can only
+    remove credential material, never expose it: a value split by the cut is
+    still preceded by its NAME= and still redacted, and a NAME split by the
+    cut carries no secret.
     """
     try:
         out = text
+        if len(out) > _MAX_CHARS:
+            dropped = len(out) - _MAX_CHARS
+            out = out[:_MAX_CHARS]
+        else:
+            dropped = 0
         for pattern, replacement in _RULES:
             out = pattern.sub(replacement, out)
+        if dropped:
+            out += f"…[{dropped} chars truncated before redaction]"
         return out
     except Exception:
         log.exception("redact: failed; alert text passes through unredacted")

--- a/tests/test_redact.py
+++ b/tests/test_redact.py
@@ -1,0 +1,227 @@
+"""slackkit/redact.py — the in-band alert path must not leak secrets, must not
+gut the alert to do it, and must never cost an alert.
+
+Mirrors tests/test_ops_notify.py, which pins the same five rules on the
+out-of-band shell path (ops/notify_failure.sh:25-32). The two implementations
+are duplicated on purpose — that script is dependency-free of the fund — so
+these two test modules move together.
+"""
+import json
+import re
+
+import pytest
+
+from slackkit import redact as redact_mod
+from slackkit.outbox import append_alert
+from slackkit.redact import redact
+
+SECRET = "aB3dEfGhIjKlMnOpQrSt9zZ"
+
+
+# --- leaks (mirrors test_ops_notify.py's redaction cases) --------------------
+
+def test_redacts_every_known_secret_prefix():
+    """Mirrors test_ops_notify.py::test_redacts_every_known_secret_prefix."""
+    leaky = (
+        "Traceback: ANTHROPIC_API_KEY=sk-ant-api03-DEADBEEFdeadbeef\n"
+        "SLACK_BOT_TOKEN=xoxb-9999-8888-abcdefgh\n"
+        "SLACK_APP_TOKEN_EXEC=xapp-1-A099-77-cafebabe\n"
+        "ALPACA_API_KEY=PKABCDEFGHIJKLMNOP01\n"
+    )
+    text = redact(leaky)
+    for secret in ("sk-ant-api03-DEADBEEFdeadbeef", "xoxb-9999-8888-abcdefgh",
+                   "xapp-1-A099-77-cafebabe", "PKABCDEFGHIJKLMNOP01"):
+        assert secret not in text, f"leaked {secret}"
+    assert "REDACTED" in text
+
+
+def test_redacts_a_bare_prefixed_token_with_no_name_beside_it():
+    """A token can reach an alert with no NAME= in front of it — a broker
+    error that quotes the key it rejected, say. The prefix rules stand alone."""
+    for token, keep in (("sk-ant-api03-DEADBEEFdeadbeef", "sk-ant-"),
+                        ("xoxb-9999-8888-abcdefgh", "xoxb-"),
+                        ("xapp-1-A099-77-cafebabe", "xapp-"),
+                        ("PKABCDEFGHIJKLMNOP01", "PK-")):
+        text = redact(f"broker rejected {token}")
+        assert token not in text, f"leaked {token}"
+        assert keep + "REDACTED" in text
+
+
+def test_redacts_secret_key_with_no_recognized_value_prefix():
+    """ALPACA_SECRET_KEY's value has none of the four known prefixes, so only
+    name-based redaction catches it."""
+    text = redact(f"ALPACA_SECRET_KEY={SECRET}")
+    assert SECRET not in text, f"leaked secret: {text}"
+    assert "REDACTED" in text
+
+
+def test_redacts_every_real_env_var_in_this_project():
+    """The name rule is anchored to ALL_CAPS env-var shape. Every credential
+    this fund actually carries is that shape — see .env."""
+    for name in ("ANTHROPIC_API_KEY", "ALPACA_API_KEY", "ALPACA_SECRET_KEY",
+                 "SLACK_BOT_TOKEN", "SLACK_BOT_TOKEN_EXEC", "SLACK_APP_TOKEN_EXEC"):
+        assert SECRET not in redact(f"{name}={SECRET}"), f"{name} leaked"
+
+
+def test_redacts_python_os_environ_repr_form():
+    """A dumped os.environ prints as a python dict repr — NAME': 'VALUE'."""
+    text = redact("{'ALPACA_SECRET_KEY': '%s'}" % SECRET)
+    assert SECRET not in text, f"leaked secret: {text}"
+    assert "REDACTED" in text
+
+
+def test_redacts_json_form():
+    """A JSON-formatted log line pairs NAME and VALUE with a colon and double
+    quotes rather than =."""
+    text = redact('{"ALPACA_SECRET_KEY": "%s"}' % SECRET)
+    assert SECRET not in text, f"leaked secret: {text}"
+    assert "REDACTED" in text
+
+
+def test_redacts_plain_colon_form():
+    """NAME: VALUE with no quotes at all."""
+    text = redact(f"ALPACA_SECRET_KEY: {SECRET}")
+    assert SECRET not in text, f"leaked secret: {text}"
+    assert "REDACTED" in text
+
+
+def test_keeps_the_name_and_normalises_colon_to_equals():
+    """The shell's replacement is `\\1=REDACTED`: the operator still learns
+    WHICH credential the line was about, and both delimiters render the same."""
+    assert redact(f"ALPACA_SECRET_KEY: {SECRET}") == "ALPACA_SECRET_KEY=REDACTED"
+    assert redact(f"ALPACA_SECRET_KEY={SECRET}") == "ALPACA_SECRET_KEY=REDACTED"
+
+
+# --- over-redaction (the alert must still say what broke) -------------------
+
+def test_diagnostic_text_naming_a_credential_survives_readable():
+    """market/source_alpaca.py uses os.environ["ALPACA_SECRET_KEY"], so a
+    missing credential on a fresh host raises KeyError naming the variable —
+    the ONE fact the operator needs. An earlier unanchored rule on the shell
+    side turned it into `KeyError=REDACTED`; a Python port written as
+    \\w*(KEY|TOKEN|...)\\w* would re-break it."""
+    text = redact("KeyError: 'ALPACA_SECRET_KEY'")
+    assert "KeyError" in text
+    assert "ALPACA_SECRET_KEY" in text, f"variable name destroyed: {text}"
+
+
+def test_does_not_redact_ordinary_assignment_that_is_not_a_credential():
+    """A plain NAME=VALUE log line whose NAME isn't credential-shaped must
+    survive verbatim: NAME=VALUE alone is not a trigger."""
+    assert redact("run_day: universe=NVDA,MSFT,AAPL") == \
+        "run_day: universe=NVDA,MSFT,AAPL"
+
+
+def test_does_not_redact_ordinary_lines_with_colons_or_equals():
+    """Redaction extended to colons must not start eating ordinary log lines
+    that happen to contain a colon or an equals sign but no credential."""
+    text = redact("run_day: market is closed\nqty=80 stop=215")
+    assert "run_day: market is closed" in text
+    assert "qty=80 stop=215" in text
+
+
+def test_the_exec_turn_violation_alert_shape_survives_intact():
+    """`exec_turn_violation — {exc}` is one of the three leaky sites. Its
+    ordinary output is an exception type followed by a colon, which is exactly
+    the shape a careless name rule eats."""
+    text = redact("exec_turn_violation — ExecTurnViolation: alpaca failed")
+    assert text == "exec_turn_violation — ExecTurnViolation: alpaca failed"
+
+
+def test_the_seat_turn_failed_alert_keeps_its_diagnosis():
+    """The whole point of that alert is naming the exception and the fallback."""
+    original = ("pm_turn_failed — TimeoutError: seat exceeded 300s;"
+                " stage default applies (default is HOLD)")
+    assert redact(original) == original
+
+
+# --- must never cost an alert ----------------------------------------------
+
+class _Boom:
+    """Stands in for a compiled pattern whose .sub() blows up."""
+
+    def sub(self, replacement, text):
+        raise RuntimeError("regex engine exploded")
+
+
+def test_a_failing_rule_passes_the_original_text_through(monkeypatch, caplog):
+    """append_alert deliberately validates nothing, because a raise on the
+    alert path turns "something needs review" into a dead trading day
+    (invariant 4). A redactor that can raise would reintroduce exactly that.
+    A leaked alert is bad; a lost alert is worse."""
+    monkeypatch.setattr(redact_mod, "_RULES", ((_Boom(), "x"),))
+    original = f"ALPACA_SECRET_KEY={SECRET}"
+    assert redact(original) == original
+    assert "redact" in caplog.text.lower()
+
+
+def test_a_failure_midway_through_the_rules_discards_partial_work(monkeypatch):
+    """Not just "does not raise": the fallback must be the ORIGINAL text, not
+    whatever half-redacted string the loop had reached."""
+    monkeypatch.setattr(
+        redact_mod, "_RULES",
+        ((re.compile("closed"), "OPEN"), (_Boom(), "x")))
+    assert redact("run_day: market is closed") == "run_day: market is closed"
+
+
+def test_non_string_input_is_returned_unchanged(monkeypatch):
+    """Fails open on a caller that hands over something unexpected rather than
+    raising inside an `except` block."""
+    assert redact(None) is None
+
+
+def test_append_alert_still_records_the_alert_when_redaction_breaks(
+        fund_db, monkeypatch):
+    """The end-to-end version of the guarantee: the row lands, with the
+    original text, even with redaction broken."""
+    monkeypatch.setattr(redact_mod, "_RULES", ((_Boom(), "x"),))
+    original = f"run_day_failed — RuntimeError: ALPACA_SECRET_KEY={SECRET}"
+    rowid = append_alert(fund_db, "run_day_failed", original,
+                         now_iso="2026-08-27T13:00:00+00:00")
+    payload = json.loads(fund_db.execute(
+        "SELECT payload FROM events WHERE id=?", (rowid,)).fetchone()["payload"])
+    assert payload["text"] == original
+    assert payload["code"] == "run_day_failed"
+
+
+# --- wiring: the stored row is what BOTH egresses read ----------------------
+
+def test_append_alert_stores_redacted_text(fund_db):
+    """Slack reads the stored row via drain(); GitHub reads it via
+    scripts/file_alert_issues.py, which writes it into an issue title and
+    body. Redacting at the store covers both."""
+    rowid = append_alert(
+        fund_db, "run_day_failed",
+        f"run_day_failed — RuntimeError: ALPACA_SECRET_KEY={SECRET}",
+        now_iso="2026-08-27T13:00:00+00:00")
+    payload = json.loads(fund_db.execute(
+        "SELECT payload FROM events WHERE id=?", (rowid,)).fetchone()["payload"])
+    assert SECRET not in payload["text"], payload["text"]
+    assert "ALPACA_SECRET_KEY=REDACTED" in payload["text"]
+    assert payload["text"].startswith("run_day_failed — RuntimeError:")
+
+
+def test_append_alert_leaves_an_ordinary_alert_untouched(fund_db):
+    """The overwhelming majority of alerts carry no credential. Redaction must
+    be invisible to them — these are the exact texts other tests pin."""
+    for code, text in (("unprotected_position", "NVDA 40 exposed"),
+                       ("pm_timeout", "pm_timeout AAPL — defaulted to hold"),
+                       ("accounting_shortfall", "NVDA agrees again at 40")):
+        rowid = append_alert(fund_db, code, text,
+                             now_iso="2026-08-27T13:00:00+00:00")
+        payload = json.loads(fund_db.execute(
+            "SELECT payload FROM events WHERE id=?", (rowid,)).fetchone()["payload"])
+        assert payload["text"] == text
+
+
+@pytest.mark.parametrize("name", ["ANTHROPIC_API_KEY", "ALPACA_SECRET_KEY"])
+def test_the_github_egress_title_cannot_carry_a_credential(fund_db, name):
+    """scripts/file_alert_issues.py:43-46 slices the stored text into a public
+    issue TITLE. Truncation is not redaction — the secret must already be gone
+    by the time it is stored."""
+    rowid = append_alert(fund_db, "seat_turn_failed",
+                         f"seat_turn_failed — RuntimeError: {name}={SECRET}",
+                         now_iso="2026-08-27T13:00:00+00:00")
+    payload = json.loads(fund_db.execute(
+        "SELECT payload FROM events WHERE id=?", (rowid,)).fetchone()["payload"])
+    assert SECRET not in payload["text"]

--- a/tests/test_redact.py
+++ b/tests/test_redact.py
@@ -8,13 +8,17 @@ these two test modules move together.
 """
 import json
 import re
+import subprocess
+import sys
+from pathlib import Path
 
 import pytest
 
 from slackkit import redact as redact_mod
 from slackkit.outbox import append_alert
-from slackkit.redact import redact
+from slackkit.redact import _MAX_CHARS, redact
 
+ROOT = Path(__file__).resolve().parents[1]
 SECRET = "aB3dEfGhIjKlMnOpQrSt9zZ"
 
 
@@ -55,9 +59,14 @@ def test_redacts_secret_key_with_no_recognized_value_prefix():
     assert "REDACTED" in text
 
 
-def test_redacts_every_real_env_var_in_this_project():
-    """The name rule is anchored to ALL_CAPS env-var shape. Every credential
-    this fund actually carries is that shape — see .env."""
+def test_redacts_the_prefixed_credential_env_vars():
+    """The name rule is anchored to ALL_CAPS env-var shape AND to a KEY /
+    TOKEN / SECRET / PASSWORD substring, so it covers exactly the variables
+    named here and claims nothing beyond them. It does NOT cover every secret
+    the fund carries: HC_PING_URL (ops/README.md:150, injected at
+    ops/fund-daily.service:57) is bearer-equivalent and matches no rule on
+    either side. That gap is shared with the shell twin and is filed
+    separately — closing it here alone would desync the two."""
     for name in ("ANTHROPIC_API_KEY", "ALPACA_API_KEY", "ALPACA_SECRET_KEY",
                  "SLACK_BOT_TOKEN", "SLACK_BOT_TOKEN_EXEC", "SLACK_APP_TOKEN_EXEC"):
         assert SECRET not in redact(f"{name}={SECRET}"), f"{name} leaked"
@@ -120,6 +129,21 @@ def test_does_not_redact_ordinary_lines_with_colons_or_equals():
     assert "qty=80 stop=215" in text
 
 
+def test_a_match_cannot_run_across_a_newline():
+    """Pins the one design decision in the port: _SP is `[^\\S\\n]`, not `\\s`.
+
+    sed is line-oriented, so no shell match can span lines. Python's `\\s`
+    matches a newline, so `\\s*[=:]` would let a name at the end of one line
+    pair with a delimiter at the start of the next and swallow it — here, the
+    runbook step that is the whole point of the message. Every other case in
+    this module is complete on a single line and would pass either way."""
+    text = redact("run_day_failed — KeyError: ALPACA_SECRET_KEY\n"
+                  ": not in /etc/fund/env — load it, then restart fund-daily")
+    assert ": not in /etc/fund/env — load it, then restart fund-daily" in text
+    assert "ALPACA_SECRET_KEY" in text
+    assert "REDACTED" not in text, f"a match ran across the newline: {text}"
+
+
 def test_the_exec_turn_violation_alert_shape_survives_intact():
     """`exec_turn_violation — {exc}` is one of the three leaky sites. Its
     ordinary output is an exception type followed by a colon, which is exactly
@@ -135,7 +159,82 @@ def test_the_seat_turn_failed_alert_keeps_its_diagnosis():
     assert redact(original) == original
 
 
-# --- must never cost an alert ----------------------------------------------
+# --- must never cost an alert: bounded runtime ------------------------------
+
+# The cubic shape. Two unbounded [A-Z0-9_]* straddling the keyword alternation
+# made this input take ~2.4s at 4KB and ~20s at 8KB — 2x length for 8x time,
+# extrapolating to ~40 minutes at 40KB. Flat "A"*n is only quadratic and hides
+# the worst of it, so it is not the shape to test with.
+_CUBIC = "('A'*40 + 'KEY' + 'A'*40) * 1205"          # ~100KB, no '=' or ':'
+_HANG_BUDGET_S = 30.0        # subprocess kill: bounds an unbounded regression
+_SLOW_BUDGET_S = 5.0         # assertion: bounds a finite-but-slow one
+
+
+def test_adversarial_input_cannot_hang_the_alert_path():
+    """redact() cannot raise — which makes running LONG its remaining way to
+    kill a day, and a worse one. A raise is caught and logged at
+    run_day.py:471; a regex grinding inside guarded() is a dead trading day
+    with no signal at all.
+
+    Reachable from exactly the three sites this module exists for:
+    run_day.py:291-293, :306-307 and :464-466 interpolate `{exc}` with no
+    length cap (contrast orchestrator/protection.py:203, which caps at 120),
+    and the analyst seat reads attacker-authorable news (issue #42).
+
+    Runs in a subprocess so an unbounded regression fails in bounded time
+    instead of hanging the suite — the pre-fix code needs ~10 hours on this
+    input. Both budgets are 400x+ over the measured ~12ms: this must catch
+    minutes-versus-milliseconds, never scheduler noise."""
+    src = (f"import sys, time\n"
+           f"sys.path.insert(0, {str(ROOT)!r})\n"
+           f"from slackkit.redact import redact\n"
+           f"s = {_CUBIC}\n"
+           f"t = time.perf_counter()\n"
+           f"redact(s)\n"
+           f"print(time.perf_counter() - t)\n")
+    try:
+        proc = subprocess.run([sys.executable, "-c", src], capture_output=True,
+                              text=True, timeout=_HANG_BUDGET_S)
+    except subprocess.TimeoutExpired:
+        pytest.fail(f"redact() did not finish on {len(('A'*40+'KEY'+'A'*40)*1205)}"
+                    f" adversarial chars within {_HANG_BUDGET_S}s — catastrophic"
+                    " backtracking is back")
+    assert proc.returncode == 0, proc.stderr
+    elapsed = float(proc.stdout.strip())
+    assert elapsed < _SLOW_BUDGET_S, f"redact() took {elapsed:.2f}s"
+
+
+def test_input_past_the_cap_is_truncated_not_scanned():
+    """The cap is half the fix; the bounded repeats are the other half.
+
+    The repeats alone are enough for every shape found so far — with them,
+    100KB runs in ~6ms and this assertion cannot tell a 64KB cap from a 10MB
+    one. The cap earns its place against the shape nobody found: it makes
+    total work O(cap x 64 x 64), a ceiling that holds no matter what a later
+    rule does. So the ceiling itself is asserted, not just the truncation."""
+    assert _MAX_CHARS <= 65536, "the cap must stay a real ceiling"
+    out = redact("A" * (_MAX_CHARS + 500))
+    assert len(out) < _MAX_CHARS + 100
+    assert "500 chars truncated" in out
+
+
+def test_truncation_drops_the_tail_rather_than_passing_it_through():
+    """Redaction stops at the cap, so text past it must not survive: passing
+    an unscanned tail through would leak precisely what the cap skipped."""
+    out = redact("x" * _MAX_CHARS + f" ALPACA_SECRET_KEY={SECRET}")
+    assert SECRET not in out, "unscanned tail passed through"
+
+
+def test_a_credential_just_inside_the_cap_is_still_redacted():
+    """The cap must not become a way to push a secret out of reach by padding
+    in front of it — everything up to it is still scanned."""
+    lead = "x" * (_MAX_CHARS - 60)
+    out = redact(lead + f" ALPACA_SECRET_KEY={SECRET}" + "y" * 400)
+    assert SECRET not in out, out[-120:]
+    assert "ALPACA_SECRET_KEY=REDACTED" in out
+
+
+# --- must never cost an alert: no raise -------------------------------------
 
 class _Boom:
     """Stands in for a compiled pattern whose .sub() blows up."""
@@ -218,7 +317,9 @@ def test_append_alert_leaves_an_ordinary_alert_untouched(fund_db):
 def test_the_github_egress_title_cannot_carry_a_credential(fund_db, name):
     """scripts/file_alert_issues.py:43-46 slices the stored text into a public
     issue TITLE. Truncation is not redaction — the secret must already be gone
-    by the time it is stored."""
+    from the TEXT by the time it is stored. Says nothing about `payload`
+    extras, which are stored unredacted and which no egress reads today (see
+    slackkit/redact.py's SCOPE note)."""
     rowid = append_alert(fund_db, "seat_turn_failed",
                          f"seat_turn_failed — RuntimeError: {name}={SECRET}",
                          now_iso="2026-08-27T13:00:00+00:00")

--- a/tests/test_redact.py
+++ b/tests/test_redact.py
@@ -165,12 +165,27 @@ def test_the_seat_turn_failed_alert_keeps_its_diagnosis():
 # made this input take ~2.4s at 4KB and ~20s at 8KB — 2x length for 8x time,
 # extrapolating to ~40 minutes at 40KB. Flat "A"*n is only quadratic and hides
 # the worst of it, so it is not the shape to test with.
-_CUBIC = "('A'*40 + 'KEY' + 'A'*40) * 1205"          # ~100KB, no '=' or ':'
+# Two shapes, because they stress opposite halves of the name rule.
+#
+# CUBIC is what the pre-fix code died on: the two unbounded name repeats
+# straddling the keyword alternation. Sized to 7968 chars — just UNDER the
+# cap, and deliberately so. It holds no whitespace, so at any length past the
+# cap the cut-back now drops the whole thing and the rules never see it; a
+# 100KB version of this input measures 0.04ms and would guard nothing. Under
+# the cap it is scanned in full, and is the exact 19.85s pre-fix case.
+#
+# SPACES is the current worst, and it is NOT the half that was fixed — a long
+# capitals run, a delimiter, then thousands of spaces ended by a newline, so
+# `\S+` fails at every backtrack position of the trailing `_SP*`. ~0.18s, flat
+# at 64KB, 1MB and 10MB. Keep both: a future edit to either half has a guard.
+_CUBIC = "('A'*40 + 'KEY' + 'A'*40) * 96"                         # 7968 ch
+_SPACES = "((('KEY'*44)[:129] + ' ' + '=' + ' '*4096 + '\\n') * 250)"  # ~1MB
 _HANG_BUDGET_S = 30.0        # subprocess kill: bounds an unbounded regression
 _SLOW_BUDGET_S = 5.0         # assertion: bounds a finite-but-slow one
 
 
-def test_adversarial_input_cannot_hang_the_alert_path():
+@pytest.mark.parametrize("shape", [_CUBIC, _SPACES], ids=["cubic", "spaces"])
+def test_adversarial_input_cannot_hang_the_alert_path(shape):
     """redact() cannot raise — which makes running LONG its remaining way to
     kill a day, and a worse one. A raise is caught and logged at
     run_day.py:471; a regex grinding inside guarded() is a dead trading day
@@ -182,13 +197,13 @@ def test_adversarial_input_cannot_hang_the_alert_path():
     and the analyst seat reads attacker-authorable news (issue #42).
 
     Runs in a subprocess so an unbounded regression fails in bounded time
-    instead of hanging the suite — the pre-fix code needs ~10 hours on this
-    input. Both budgets are 400x+ over the measured ~12ms: this must catch
-    minutes-versus-milliseconds, never scheduler noise."""
+    instead of hanging the suite. Both budgets are 25x+ over the measured
+    worst (~0.18s): this must catch minutes-versus-milliseconds, never
+    scheduler noise."""
     src = (f"import sys, time\n"
            f"sys.path.insert(0, {str(ROOT)!r})\n"
            f"from slackkit.redact import redact\n"
-           f"s = {_CUBIC}\n"
+           f"s = {shape}\n"
            f"t = time.perf_counter()\n"
            f"redact(s)\n"
            f"print(time.perf_counter() - t)\n")
@@ -196,26 +211,34 @@ def test_adversarial_input_cannot_hang_the_alert_path():
         proc = subprocess.run([sys.executable, "-c", src], capture_output=True,
                               text=True, timeout=_HANG_BUDGET_S)
     except subprocess.TimeoutExpired:
-        pytest.fail(f"redact() did not finish on {len(('A'*40+'KEY'+'A'*40)*1205)}"
-                    f" adversarial chars within {_HANG_BUDGET_S}s — catastrophic"
-                    " backtracking is back")
+        pytest.fail(f"redact() did not finish on {shape} within"
+                    f" {_HANG_BUDGET_S}s — catastrophic backtracking is back")
     assert proc.returncode == 0, proc.stderr
     elapsed = float(proc.stdout.strip())
-    assert elapsed < _SLOW_BUDGET_S, f"redact() took {elapsed:.2f}s"
+    assert elapsed < _SLOW_BUDGET_S, f"redact() took {elapsed:.2f}s on {shape}"
 
 
 def test_input_past_the_cap_is_truncated_not_scanned():
-    """The cap is half the fix; the bounded repeats are the other half.
+    """Two mutations, and the measured matrix for each (verified, not
+    assumed — an earlier version of this note had it wrong):
 
-    The repeats alone are enough for every shape found so far — with them,
-    100KB runs in ~6ms and this assertion cannot tell a 64KB cap from a 10MB
-    one. The cap earns its place against the shape nobody found: it makes
-    total work O(cap x 64 x 64), a ceiling that holds no matter what a later
-    rule does. So the ceiling itself is asserted, not just the truncation."""
-    assert _MAX_CHARS <= 65536, "the cap must stay a real ceiling"
+    * REMOVING the truncation fails 6 tests: the length assertion below, the
+      [spaces] timing case, and the four bisect cases.
+    * RAISING the cap to 1_000_000 fails 2: the ceiling assertion below and
+      the [spaces] timing case, which stops being flat once a 1MB input is
+      scanned whole. The length assertion does NOT catch it — truncation
+      still happens, just later, so it scales with the cap and passes.
+
+    The ceiling is asserted directly anyway. It is what makes total work
+    O(cap x 64 x 64) whatever a later rule does, and it says so at a size a
+    reader can act on rather than leaving it to a timing case to notice."""
+    assert _MAX_CHARS <= 65536, (
+        "the cap must stay a real ceiling: with it disabled the name rule runs"
+        " ~22us/char on its worst shape — 1MB takes 23s and 4MB takes 97s,"
+        " inside an except on the trading path")
     out = redact("A" * (_MAX_CHARS + 500))
     assert len(out) < _MAX_CHARS + 100
-    assert "500 chars truncated" in out
+    assert "chars truncated" in out
 
 
 def test_truncation_drops_the_tail_rather_than_passing_it_through():
@@ -225,13 +248,60 @@ def test_truncation_drops_the_tail_rather_than_passing_it_through():
     assert SECRET not in out, "unscanned tail passed through"
 
 
+@pytest.mark.parametrize("kept", [1, 2, 5, 8, 15, 16, 17, 18, 25])
+def test_the_cap_cannot_bisect_a_credential_token(kept):
+    """The cap introduced a leak the uncapped scan did not have.
+
+    PK[A-Z0-9]{16,} needs 16 characters after its prefix, so a PK token cut
+    short by the cap simply was not a match, and its first 1-17 characters
+    went out verbatim — into an alert TITLE, on a public GitHub issue. The
+    `+` rules (sk-ant-, xoxb-, xapp-) never had this: they match any fragment
+    and give up only their non-secret prefix.
+
+    `kept` is how much of the token falls before the cut. Every value must be
+    clean, which is what cutting back to a whitespace boundary buys and a hard
+    cut does not: the straddling token is dropped whole."""
+    token = "PKABCDEFGHIJKLMNOP01"
+    out = redact("x " * ((_MAX_CHARS - kept) // 2) + token + "y" * 50)
+    assert token[:kept] not in out, f"emitted {kept} chars of the token"
+    assert "PKABC" not in out
+
+
+def test_the_cap_cannot_bisect_a_token_with_no_whitespace_to_fall_back_on():
+    """The cut-back is unbounded on purpose. A bounded lookback would fall
+    back to a hard cut on an unbroken run longer than the window and bisect
+    the token again — the exact class this closes, and reachable by anyone
+    who can influence the exception text. The price is that the whole run is
+    dropped, which is why the marker reports the size."""
+    out = redact("x" * (_MAX_CHARS - 10) + "PKABCDEFGHIJKLMNOP01")
+    assert "PKABC" not in out, out[-60:]
+    assert "chars truncated" in out
+
+
 def test_a_credential_just_inside_the_cap_is_still_redacted():
     """The cap must not become a way to push a secret out of reach by padding
-    in front of it — everything up to it is still scanned."""
+    in front of it — everything up to the cut is still scanned, and a
+    credential that ends before it is redacted in place, not dropped."""
+    lead = "x" * (_MAX_CHARS - 60)
+    out = redact(lead + f" ALPACA_SECRET_KEY={SECRET} " + "y" * 400)
+    assert SECRET not in out, out[-120:]
+    assert "ALPACA_SECRET_KEY=REDACTED" in out
+
+
+def test_a_credential_straddling_the_cap_is_dropped_rather_than_redacted():
+    """The other side of the same boundary, and the reason the test above
+    needs that trailing space. With no whitespace between the credential and
+    what follows, the two are ONE token spanning the cut, so it is dropped
+    whole — no `NAME=REDACTED` survives to show it was there.
+
+    That is a deliberate trade: dropping a straddling token is what stops the
+    cap emitting a prefix of it, and losing the marker is cheaper than
+    leaking 17 characters of a key."""
     lead = "x" * (_MAX_CHARS - 60)
     out = redact(lead + f" ALPACA_SECRET_KEY={SECRET}" + "y" * 400)
     assert SECRET not in out, out[-120:]
-    assert "ALPACA_SECRET_KEY=REDACTED" in out
+    assert "ALPACA_SECRET_KEY" not in out
+    assert "chars truncated" in out
 
 
 # --- must never cost an alert: no raise -------------------------------------


### PR DESCRIPTION
Credentials can reach Slack and a public GitHub issue in plain text today. This adds
`slackkit/redact.py` and calls it where `append_alert` builds the row it stores.

## The leak

Three sites interpolate a raw exception into alert text — `scripts/run_day.py:291-293`
(`seat_turn_failed`), `:306-307` (`exec_turn_violation`), `:464-466` (`run_day_failed`). A traceback
that touches `os.environ` carries broker keys, Slack tokens or the Anthropic key into that string.

The fund already defends the **out-of-band** path: `ops/notify_failure.sh:25-32` redacts five credential
shapes, with the comment *"A traceback that dumps os.environ must not publish broker keys to Slack."*
**There is no redaction anywhere in Python**, so the in-band path has none of it.

## Why the fix goes at the store, not at the Slack boundary

The stored row has **two** egresses:

- **Slack** — `append_alert` → stored → `drain` posts it.
- **GitHub** — `scripts/file_alert_issues.py:69` selects the stored payload and writes the alert text
  into an issue **body** (`:61-62`) and an issue **title** (`:43-46`).

Redacting at the Slack boundary was the first plan and it is a trap: it would have scrubbed the Slack
copy while the filer published the same traceback to the issue tracker — **and it would have looked
fixed.** Redacting where the body dict is built covers both, plus every future consumer.

A third option — redacting at the three call sites — is the same edit three times, against a caller
surface that is already growing (`orchestrator/daily.py:27` imports `append_alert` too).

## What this does NOT do — the claim, stated accurately

An earlier draft of this change claimed the credential "never reaches durable storage." **That is
false**, and it is worth being precise instead:

| path | redacted by this PR? |
|---|---|
| alert `text` → SQLite → Slack / GitHub issue | **yes** |
| alert `text` → `log()` → `logs/run_day.err.log` | no — `run_day.py:350` logs the raw text first (#150) |
| `**payload` → SQLite | no — `preconditions.py:78` deliberately stores the uncapped raw exception |

**This PR redacts alert `text` at the store, closing the Slack and GitHub egresses.** The other two
paths are filed, not fixed here.

Also filed rather than fixed: **#146**, `HC_PING_URL` — a bearer-equivalent secret (it is the fund's
liveness heartbeat, so holding it lets someone suppress the "run never started" alarm) whose name
contains no `KEY`/`TOKEN`/`SECRET`/`PASSWORD` and whose value carries none of the four prefixes, so
**no rule in either implementation matches it.** And **#147**: `tests/test_ops_notify.py` executes the
real shell script, so it validates BSD sed on developer machines while production runs GNU sed.

## Two ways this could have killed a trading day, both closed

`slackkit/outbox.py:44-47` states that `append_alert` validates nothing on purpose, because it runs
inside `except` blocks and *"a raise here would turn 'something needs review' into a dead trading day
(invariant 4)."* That constraint has **two** failure modes, and the first draft only guarded one.

**1. It must not raise.** `redact()` fails open: on any error the original text passes through and the
alert is still recorded. Leaking on redactor failure beats losing the alert. Pinned by tests, not by a
comment — including that a failure *midway* through the rules returns the ORIGINAL rather than
half-rewritten text, and that `append_alert` still records the row end-to-end when redaction is broken.

**2. It must not hang — and the first version did.** The name rule had two unbounded `[A-Z0-9_]*`
straddling the keyword alternation: cubic, measured at **19.85 s on 8 KB**, extrapolating to ~42 minutes
at 40 KB. A hang is strictly worse than a raise here: a raise is caught at `run_day.py:471` and logged,
whereas a regex grinding inside `guarded()` is a dead trading day with **no signal at all**. And it was
reachable from exactly the three sites this change exists for, where `{exc}` is uncapped — while
`protection.py:203` and `preconditions.py:77` already cap at 120 chars.

Closed by bounded repeats (`{0,63}`, with a possessive tail), plus an 8192-char cap. Worst case now
**~0.18 s**, flat at 64 KB, 1 MB and 10 MB. Both shapes are guarded by a test that runs in a subprocess,
so an unbounded regression fails in bounded time instead of hanging the suite.

**The cost centre moved, and the tests say so.** The worst input is no longer the name repeats — it is
`_SP*[=:]_SP*['"]?\S+`: a long capitals run, a delimiter, then thousands of spaces ended by a newline,
so `\S+` fails at every backtrack position. Both shapes are pinned, and the module names that half as
the one needing adversarial measurement next.

## The cap introduced a leak of its own, and that is closed too

`PK[A-Z0-9]{16,}` needs 16 characters after its prefix, so a `PK…` token **cut short by the cap was not
a match**, and its first 1-17 characters went out verbatim — into an alert title, on a public issue. The
uncapped scan did not have this; the fix introduced it. (`sk-ant-`/`xoxb-`/`xapp-` never did: they are
`+` rules and give up only their non-secret prefix.)

Truncation now cuts back to the last **whitespace**, so every token the scan sees is whole. The lookback
is deliberately **unbounded** rather than a bounded window: a bound reopens the same class, because a
non-whitespace run longer than the window falls back to a hard cut and bisects the token again — and the
threat model is text an attacker can shape, so that fallback is reachable by construction. The price is
that a truncated alert ending in one unbroken blob loses the blob, which is stated at the definition.

## Over-redaction is the failure this repo has already had

`tests/test_ops_notify.py:105` records that *"an earlier unanchored rule turned it into
`KeyError=REDACTED`."* The new tests mirror that suite in both directions: `KeyError: 'ALPACA_SECRET_KEY'`
keeps **both** halves readable; `universe=NVDA,MSFT,AAPL`, `market is closed`, `qty=80 stop=215` and
`ExecTurnViolation: alpaca failed` all survive verbatim.

Fidelity to the shell twin was established by a differential harness running the real `sed` pipeline and
`redact()` over the same inputs — byte-identical, including multi-line cases, with one documented
divergence: a name with 64+ capitals after the keyword. Unreachable in practice — the longest credential
name in the repo is `SLACK_BOT_TOKEN_EXEC` at 20 characters, with 5 after the keyword, and a real
credential's name comes from `os.environ` where an attacker cannot lengthen it.

The harness is **not committed**, deliberately: this machine has BSD sed and production has GNU sed, so
committing it here would certify the wrong implementation. That is #147.

## Verification

`make test` — **1504 passed**, 1 skipped, 7 deselected. Purity lint clean over 53 files (`slackkit` is in
`PURE_PACKAGES`; `re` is not forbidden). Alert-code lint clean. Run independently by the reviewer and
again before opening this PR, not taken from the author.

Every guard was mutation-tested — each reverted in turn, confirming which test catches it. That is how
the cap was shown to be load-bearing rather than decorative: with the bounds kept but the cap **raised**,
cost is linear at ~22 µs/char, so 1 MB takes 23 s and 4 MB takes 97 s inside an `except` on the trading
path. `assert _MAX_CHARS <= 65536` is what stands between a future maintainer and that, and its message
now names the cost.

No pre-existing test was modified, weakened or deleted.

## Why this says "Part of" and not "closes"

`closes #45` would be false. #45 is a bundle of 13 items; ten are split out (#123, #124, #125, #126,
#127, #128, #130, #132, #134, and #135, #146, #147, #150 found on the way; #133 was filed and retracted).
The thirteenth — *delete `evals/_work/audit-src.tar.gz`* — is untracked and gitignored, so deleting it is
an empty diff and **no merge can close it**; it needs a human to run `rm` and confirm.

Part of #45
