### PR TITLE
docs: invariant 6 says "never a trigger", not "never write to Slack"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Multi-agent paper-trading firm on the Claude Agent SDK (Python). Agents communic
 3. **`gate/`, `stratgate/`, and `calibration/` import no LLM code.** No `claude_agent_sdk`, no `anthropic`, no prompt strings. Pure Python + SQLite. Enforced in CI by `scripts/check_purity.py` (AST lint: forbidden imports + wall-clock calls; runs in `make test`). Gate thresholds (risk and strategy-validation) change only by human commit — never by an agent.
 4. **Default is HOLD.** Any error, timeout, malformed tool input, or ambiguity anywhere in the pipeline resolves to no action — never to a guess.
 5. **Orders are idempotent.** `client_order_id` = gate ticket id, always. Alpaca 422-rejects duplicates; never mint a new id on retry.
-6. **SQLite is the source of truth; Slack is a projection.** Never read workflow state from Slack; never trigger execution from a Slack event.
+6. **SQLite is the source of truth; Slack is never where a decision comes from.** Agents may post to Slack, read each other's prose there, and answer when asked (`specs/design.md` §3–§4, `VISION.md`). Never read *workflow state* from Slack — turn assignment, stage, decision or ticket status — and never let a Slack event produce a decision, an order, or a state transition; the orchestrator assigns every workflow-critical turn. Outbound delivery goes through the `events` outbox, so a crash or retry can neither lose nor duplicate a post.
 7. **Agents emit structured data only through MCP tools** (`submit_signal`, `submit_decision`, strict schemas) — never as free text that code parses.
 
 ## Commands


### PR DESCRIPTION
## What

One-line reword of invariant 6 in `CLAUDE.md`. No code, no behavior change.

**Before**
> **SQLite is the source of truth; Slack is a projection.** Never read workflow state from Slack; never trigger execution from a Slack event.

**After**
> **SQLite is the source of truth; Slack is never where a decision comes from.** Agents may post to Slack, read each other's prose there, and answer when asked (`specs/design.md` §3–§4, `VISION.md`). Never read *workflow state* from Slack — turn assignment, stage, decision or ticket status — and never let a Slack event produce a decision, an order, or a state transition; the orchestrator assigns every workflow-critical turn. Outbound delivery goes through the `events` outbox, so a crash or retry can neither lose nor duplicate a post.

## Why

"Slack is a projection" reads as a restriction on what agents may **write**. Both source docs say the opposite:

- `specs/design.md` §4 — one Slack app per agent, "genuinely @mentionable with its own identity, token, scopes"
- `specs/design.md` §3 — debate mechanics: a shared thread transcript where "each turn must counter the opponent's last specific argument"
- `VISION.md:74` — "any seat can be asked a question and will answer from its own record ... never the place decisions actually come from"

The rule was always about Slack as an **input**. `specs/design.md:127` names the line exactly:

> Slack dampens bot-to-bot delivery by design, so **workflow-critical turns are assigned by the orchestrator directly to agent processes — Slack is the record of the turn, not the trigger.**

Note *workflow-critical*. A human @mention getting an answer is explicitly in scope in both docs, so the restriction cannot be on turns in general — which is why the new wording bans a Slack event producing a *decision, order, or state transition* rather than banning triggering outright.

## What the old phrasing would have blocked

Two things the design requires, both Phase 3 (`specs/acceptance.md`, all boxes still open):

1. a seat posting in its own voice
2. a bear reading the bull's argument out of a debate thread

An invariant marked "never violate, no exceptions" should not read as forbidding what the build order schedules.

## Already visible downstream

`charters/pm.md` v6 (0658a99) deleted the PM's instruction to post its verdict, because the seat has no Slack tool. The thesis still reaches `#trading-floor` — `handle_submit_decision` appends a `decision` event and `drain` posts it — so the projection was never lost, only the seat's voice.

Restoring that voice is a **separate** change (needs a prose field on `submit_decision`, rendered verbatim by `slackkit/render.py`). This PR only stops the invariant from standing in its way.

## Substance unchanged

- no Slack read of workflow state
- no decision / order / transition from a Slack event
- outbound still through the `events` outbox

## Testing

Docs only — no code touched. `git diff` is 1 line.

## Note for reviewers

`CLAUDE.md` is auto-loaded per session from the working tree, so this lands by PR rather than an in-place edit: an uncommitted change here would become live instructions for every session started after it, and be invisible to every session started before.