### PR TITLE
Close Phase 2's three acceptance-test gaps, then tick Phase 2

### DIFF
--- a/specs/acceptance.md
+++ b/specs/acceptance.md
@@ -27,16 +27,16 @@ Testing splits LLM **decisions** (expensive, non-deterministic) from tool **exec
 
 ## Phase 2 — The desk (PM + 2 analysts + real gate)
 
-- [ ] Gate unit tests (pure, exhaustive): vol tiers (14.9/15/49.9/50%), correlation multipliers at boundaries, cash cap, max position count, sector weight, daily-loss circuit breaker, and **any malformed/NaN/missing input → REJECT `gate_error`**.
-- [ ] Golden-day vector: fixture inputs produce the exact ticket in `fixtures/golden-day.md` (max_qty **66** — 105 is the pre-sector-cap intermediate; assert both step values).
-- [ ] Pre-gate (advisory mode): same fixture at 08:45 yields allowed actions `{buy: 66, sell: 0}` for NVDA (full computation incl. sector cap — same code path as enforcement, no ticket); a fixture ticker with no cash headroom and no held shares yields `{buy: 0, sell: 0}` and is dropped from the active set.
-- [ ] Sim full day (replayed decisions, real execution): both analysts' `submit_signal` rows present → PM `submit_decision` row → gate ticket → order → all checkpoints `done`.
-- [ ] Missing-signal default: one analyst recording omits a ticker → `neutral/0` row auto-inserted, day completes.
-- [ ] PM timeout: no decision recorded for a ticker → decision row `hold/0`, `pm_timeout` event exists.
-- [ ] HOLD-only skip: ticker where the 08:45 pre-gate computes `{buy:0, sell:0}` never reaches the LLM pipeline (assert zero agent turns for it).
-- [ ] PM inputs: the decision-stage prompt context includes the allowed-actions snapshot for every active ticker (assert on the rendered stage input, not the prompt text — no per-run values in prompts).
-- [ ] Journals: after sim day each participating seat's journal has an entry via `state/journal.py`; reflection job at `SimClock`+5 trading days writes `resolutions` with correct realized return & alpha from fixture prices.
-- [ ] Cost rows recorded per seat per session.
+- [x] Gate unit tests (pure, exhaustive): vol tiers (14.9/15/49.9/50%), correlation multipliers at boundaries, cash cap, max position count, sector weight, daily-loss circuit breaker, and **any malformed/NaN/missing input → REJECT `gate_error`**.
+- [x] Golden-day vector: fixture inputs produce the exact ticket in `fixtures/golden-day.md` (max_qty **66** — 105 is the pre-sector-cap intermediate; assert both step values).
+- [x] Pre-gate (advisory mode): same fixture at 08:45 yields allowed actions `{buy: 66, sell: 0}` for NVDA (full computation incl. sector cap — same code path as enforcement, no ticket); a fixture ticker with no cash headroom and no held shares yields `{buy: 0, sell: 0}` and is dropped from the active set.
+- [x] Sim full day (replayed decisions, real execution): both analysts' `submit_signal` rows present → PM `submit_decision` row → gate ticket → order → all checkpoints `done`.
+- [x] Missing-signal default: one analyst recording omits a ticker → `neutral/0` row auto-inserted, day completes.
+- [x] PM timeout: no decision recorded for a ticker → decision row `hold/0`, `pm_timeout` event exists.
+- [x] HOLD-only skip: ticker where the 08:45 pre-gate computes `{buy:0, sell:0}` never reaches the LLM pipeline (assert zero agent turns for it).
+- [x] PM inputs: the decision-stage prompt context includes the allowed-actions snapshot for every active ticker (assert on the rendered stage input, not the prompt text — no per-run values in prompts).
+- [x] Journals: after sim day each participating seat's journal has an entry via `state/journal.py`; reflection job at `SimClock`+5 trading days writes `resolutions` with correct realized return & alpha from fixture prices.
+- [x] Cost rows recorded per seat per session.
 
 ## Phase 3 — The firm (debates, risk persona, macro, ops, CEO gate)
 

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -182,6 +182,30 @@ def test_cash_cap_binds():
     r = size(golden_inputs(cash=1800.0, sector_value=0.0), "enforce")
     assert r.max_qty == 10                       # floor(1800/180)
 
+@pytest.mark.parametrize("sector_value,max_qty", [
+    (59640.00, 2),      # headroom 360 -> two shares
+    (59820.00, 1),      # headroom 180 -> exactly one share: the last approval
+    (59820.01, None),   # headroom 179.99 -> floors to zero, nothing to buy
+    (60000.00, None),   # headroom exactly 0.0 -> sitting ON the cap
+    (61000.00, None),   # already OVER the cap -> clamped, never a negative qty
+])
+def test_sector_cap_boundaries(sector_value, max_qty):
+    """The sixth boundary the Phase-2 criterion names, and the only one that
+    had no test of its own (#100). It is the LAST reduction size() applies
+    (gate/risk.py:90-91), so an error here is the one that survives every
+    earlier clamp and reaches the ticket.
+
+    equity 100000 -> SECTOR_CAP * equity = 60000; at price 180 the cap edge in
+    SHARE terms therefore sits at sector_value 59820, where headroom is exactly
+    one share. pre_sector is 105 at every row, so what binds below is always
+    the sector cap and never cash -- the same separation the golden-day vector
+    makes at one interior point (:38), asserted here at the edge."""
+    r = size(golden_inputs(sector_value=sector_value), "enforce")
+    if max_qty is None:
+        assert r == Rejected("no_headroom")
+    else:
+        assert r == Approved(max_qty=max_qty, pre_sector_qty=105, side="buy")
+
 def test_position_count_hard_reject_new_position_only():
     assert size(golden_inputs(position_count=8), "enforce") == Rejected("position_count")
     r = size(golden_inputs(position_count=8, held_qty=5), "enforce")

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -189,7 +189,7 @@ _NO_HEADROOM = Rejected("no_headroom")
     (59820.00, Approved(max_qty=1, pre_sector_qty=105, side="buy")),
     (59820.01, _NO_HEADROOM),   # headroom 179.99 -> floors to zero
     (60000.00, _NO_HEADROOM),   # headroom exactly 0.0 -> sitting ON the cap
-    (61000.00, _NO_HEADROOM),   # already OVER -> clamped, never a negative qty
+    (61000.00, _NO_HEADROOM),   # already OVER the cap -> rejected, not sized
 ])
 def test_sector_cap_boundaries(sector_value, expected):
     """The sixth boundary the Phase-2 criterion names, and the only one that

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -182,14 +182,16 @@ def test_cash_cap_binds():
     r = size(golden_inputs(cash=1800.0, sector_value=0.0), "enforce")
     assert r.max_qty == 10                       # floor(1800/180)
 
-@pytest.mark.parametrize("sector_value,max_qty", [
-    (59640.00, 2),      # headroom 360 -> two shares
-    (59820.00, 1),      # headroom 180 -> exactly one share: the last approval
-    (59820.01, None),   # headroom 179.99 -> floors to zero, nothing to buy
-    (60000.00, None),   # headroom exactly 0.0 -> sitting ON the cap
-    (61000.00, None),   # already OVER the cap -> clamped, never a negative qty
+_NO_HEADROOM = Rejected("no_headroom")
+
+@pytest.mark.parametrize("sector_value,expected", [
+    (59640.00, Approved(max_qty=2, pre_sector_qty=105, side="buy")),
+    (59820.00, Approved(max_qty=1, pre_sector_qty=105, side="buy")),
+    (59820.01, _NO_HEADROOM),   # headroom 179.99 -> floors to zero
+    (60000.00, _NO_HEADROOM),   # headroom exactly 0.0 -> sitting ON the cap
+    (61000.00, _NO_HEADROOM),   # already OVER -> clamped, never a negative qty
 ])
-def test_sector_cap_boundaries(sector_value, max_qty):
+def test_sector_cap_boundaries(sector_value, expected):
     """The sixth boundary the Phase-2 criterion names, and the only one that
     had no test of its own (#100). It is the LAST reduction size() applies
     (gate/risk.py:90-91), so an error here is the one that survives every
@@ -199,12 +201,9 @@ def test_sector_cap_boundaries(sector_value, max_qty):
     SHARE terms therefore sits at sector_value 59820, where headroom is exactly
     one share. pre_sector is 105 at every row, so what binds below is always
     the sector cap and never cash -- the same separation the golden-day vector
-    makes at one interior point (:38), asserted here at the edge."""
-    r = size(golden_inputs(sector_value=sector_value), "enforce")
-    if max_qty is None:
-        assert r == Rejected("no_headroom")
-    else:
-        assert r == Approved(max_qty=max_qty, pre_sector_qty=105, side="buy")
+    makes at one interior point (tests/test_risk.py:38), asserted here at the
+    edge."""
+    assert size(golden_inputs(sector_value=sector_value), "enforce") == expected
 
 def test_position_count_hard_reject_new_position_only():
     assert size(golden_inputs(position_count=8), "enforce") == Rejected("position_count")

--- a/tests/test_runtime_hooks.py
+++ b/tests/test_runtime_hooks.py
@@ -407,6 +407,38 @@ def test_record_turn_result_writes_the_cost_row(fund_db):
     assert _alerts(fund_db) == []
 
 
+def test_every_seat_turn_records_its_own_agent_and_session(fund_db):
+    """acceptance.md Phase 2: "Cost rows recorded per seat per session". That
+    is a property of the SET of rows, not their count (#158) -- and the count
+    is all the day-level tests assert, which cannot tell four seats turning
+    once from one seat turning four times."""
+    for seat, session in (("analyst", "s-a"), ("news", "s-n"),
+                          ("pm", "s-p"), ("exec", "s-e")):
+        assert record_turn_result(
+            fund_db, "2026-07-06", seat,
+            _Result(total_cost_usd=0.01, session_id=session), NOW) is True
+
+    assert [(r["agent"], r["session_id"]) for r in _costs(fund_db)] == [
+        ("analyst", "s-a"), ("news", "s-n"), ("pm", "s-p"), ("exec", "s-e")]
+    assert _alerts(fund_db) == []
+
+
+def test_a_seat_that_turns_twice_owes_two_rows(fund_db):
+    """The row count equals the seat count only because each seat happens to
+    turn once -- a coincidence the count assertion then depends on. A seat
+    that turns twice (a retried research turn) owes one row per SESSION, and
+    the day's spend is their sum."""
+    for session in ("s-1", "s-2"):
+        record_turn_result(fund_db, "2026-07-06", "analyst",
+                           _Result(total_cost_usd=0.02, session_id=session),
+                           NOW)
+
+    rows = _costs(fund_db)
+    assert [(r["agent"], r["session_id"]) for r in rows] == [
+        ("analyst", "s-1"), ("analyst", "s-2")]
+    assert sum(r["usd_estimate"] for r in rows) == pytest.approx(0.04)
+
+
 def test_record_turn_result_none_cost_records_nothing_and_alerts(fund_db):
     """total_cost_usd is Optional in the SDK. A missing estimate must NOT
     become a 0.0 row — that would make real spend look free in the digest.

--- a/tests/test_runtime_hooks.py
+++ b/tests/test_runtime_hooks.py
@@ -380,7 +380,9 @@ class _Result:
 
 
 def _costs(conn):
-    return conn.execute("SELECT * FROM costs").fetchall()
+    # ORDER BY id like _alerts below: positional assertions on insertion order
+    # are only meaningful if the order is asked for.
+    return conn.execute("SELECT * FROM costs ORDER BY id").fetchall()
 
 
 def _alerts(conn):
@@ -429,14 +431,15 @@ def test_a_seat_that_turns_twice_owes_two_rows(fund_db):
     that turns twice (a retried research turn) owes one row per SESSION, and
     the day's spend is their sum."""
     for session in ("s-1", "s-2"):
-        record_turn_result(fund_db, "2026-07-06", "analyst",
-                           _Result(total_cost_usd=0.02, session_id=session),
-                           NOW)
+        assert record_turn_result(
+            fund_db, "2026-07-06", "analyst",
+            _Result(total_cost_usd=0.02, session_id=session), NOW) is True
 
     rows = _costs(fund_db)
     assert [(r["agent"], r["session_id"]) for r in rows] == [
         ("analyst", "s-1"), ("analyst", "s-2")]
     assert sum(r["usd_estimate"] for r in rows) == pytest.approx(0.04)
+    assert _alerts(fund_db) == []
 
 
 def test_record_turn_result_none_cost_records_nothing_and_alerts(fund_db):

--- a/tests/test_sim_day.py
+++ b/tests/test_sim_day.py
@@ -365,6 +365,13 @@ def test_all_hold_day(tmp_path):
     assert _event_payloads(sim, "alert") == []
     assert "#risk" not in sim.slack.posts
 
+    # No fill, so no exec journal — the negative arm of the rule test_golden_day
+    # asserts positively. Without a no-fill day here, _participating_seats'
+    # exec branch is never exercised and an unconditional add("exec") would
+    # pass every test in this file.
+    assert _participating_seats(sim) == {"analyst", "news", "pm"}
+    assert {p.stem for p in sim.journals.glob("*.md")} == _participating_seats(sim)
+
     _assert_day_completed(sim)
 
 

--- a/tests/test_sim_day.py
+++ b/tests/test_sim_day.py
@@ -204,23 +204,27 @@ def _event_payloads(sim: SimResult, kind: str) -> list[dict]:
         "SELECT payload FROM events WHERE kind = ? ORDER BY id", (kind,))]
 
 
-def _cost_pairs(sim: SimResult) -> list[tuple[str, str]]:
-    """(agent, session_id) per cost row. The criterion is "per seat per
-    session" (#158) — a COUNT cannot tell four seats turning once from one
-    seat turning four times."""
-    return [(r["agent"], r["session_id"]) for r in sim.conn.execute(
-        "SELECT agent, session_id FROM costs ORDER BY agent")]
-
-
 def _participating_seats(sim: SimResult) -> set[str]:
-    """The seats run_close owes a journal to, derived the way it derives them
-    (orchestrator/daily.py:460-467) rather than named literally — so a new
-    seat is covered here without editing the test."""
+    """The seats run_close owes a journal to (orchestrator/daily.py:460-467):
+    every seat that signalled today, plus the PM, plus the trader IFF the day
+    had a fill. Derived rather than named literally so a new seat is covered
+    without editing the test.
+
+    The exec arm must ask the question run_close asks, which is _fill_rows'
+    (daily.py:392-397) — scoped to THIS run_date and to the two statuses that
+    mean shares changed hands. `filled_qty > 0` alone is a different question:
+    a partially-filled order later canceled or expired carries a non-zero
+    filled_qty, and run_close writes no exec journal for a day whose fills
+    line reads `none`."""
     seats = {r["agent"] for r in sim.conn.execute(
         "SELECT DISTINCT agent FROM signals WHERE run_date = ?",
         (sim.run_date,))} | {"pm"}
-    if sim.conn.execute("SELECT COUNT(*) c FROM orders"
-                        " WHERE filled_qty > 0").fetchone()["c"]:
+    if sim.conn.execute(
+            "SELECT COUNT(*) c FROM orders o"
+            " JOIN tickets t ON t.id = o.client_order_id"
+            " JOIN decisions d ON d.id = t.decision_id"
+            " WHERE d.run_date = ? AND o.status IN ('filled', 'partially_filled')",
+            (sim.run_date,)).fetchone()["c"]:
         seats.add("exec")
     return seats
 
@@ -311,9 +315,12 @@ def test_golden_day(tmp_path):
 
     # every turn that ran recorded its cost, and the digest reports the sum
     assert sim.turns == {"research": 2, "decision": 1, "execution": 1}
-    # per SEAT per SESSION, not four-of-something (#158)
-    assert _cost_pairs(sim) == [("analyst", "sim-analyst"), ("exec", "sim-exec"),
-                                ("news", "sim-news"), ("pm", "sim-pm")]
+    # One row per turn. NOT the "per seat per session" criterion: the sim
+    # harness supplies both agent and session_id itself (`sim-{seat}`, :144),
+    # so any assertion on those values here would be checking the harness's
+    # own f-string. That criterion is pinned on the production seam instead,
+    # in tests/test_runtime_hooks.py.
+    assert _count(sim, "costs") == 4   # analyst + news + pm + exec
     digest = _event_payloads(sim, "digest")[0]["text"]
     assert "decisions: NVDA buy 80 (executed)" in digest
     assert "fills: NVDA buy 66@180.14" in digest
@@ -321,8 +328,13 @@ def test_golden_day(tmp_path):
 
     assert (sim.journals / "exec.md").read_text().count("NVDA buy 66@180.14") == 1
     # EVERY participating seat, not just the two named by hand: the news seat
-    # signalled today and owes a journal exactly as the analyst does (#158)
-    assert {p.stem for p in sim.journals.glob("*.md")} == _participating_seats(sim)
+    # signalled today and owes a journal exactly as the analyst does (#158).
+    # The criterion is "has an ENTRY", so each file must carry today's entry,
+    # not merely exist -- _append_entry_once stamps the run_date as its header.
+    seats = _participating_seats(sim)
+    assert {p.stem for p in sim.journals.glob("*.md")} == seats
+    for seat in seats:
+        assert sim.run_date in (sim.journals / f"{seat}.md").read_text(), seat
     _assert_day_completed(sim)
 
 
@@ -536,6 +548,42 @@ def test_pm_brief_carries_the_signal_and_the_budget_the_gate_enforces(tmp_path):
     _assert_day_completed(sim)
 
 
+# --- 5. the stop that expired at the bell (2026-08-19) ----------------------
+
+def test_the_stop_that_expired_at_the_bell_is_caught(tmp_path):
+    """2026-08-19, reproduced end to end. A stopped NVDA entry fills, its OTO
+    stop leg then EXPIRES at the close exactly as the real one did on 08-17,
+    and the day must not end quietly.
+
+    Before this assertion existed the run was clean — holds, AUDIT CLEAN, a
+    digest posted — while the position sat naked for two sessions. A green
+    suite proved nothing then. This is what proving looks like: the real gate,
+    the real hooks, the real fill-poll, and a broker whose protection dies on
+    schedule."""
+    sim = sim_day(tmp_path, market={"NVDA": _nvda()},
+                  pm_recs=("mvf_pm_stop.jsonl",),
+                  exec_recs=("mvf_exec_stop_gtc.jsonl",),
+                  broker_mode="stop_expires_at_the_bell")
+
+    # the entry really happened, carrying the ticket's stop
+    placed = sim.broker.place_attempts[0]
+    assert (placed["order_class"], placed["time_in_force"]) == ("oto", "gtc")
+    assert placed["stop_loss_stop_price"] == "168.0"
+    assert sim.conn.execute(
+        "SELECT stop_price FROM tickets").fetchone()["stop_price"] == 168.0
+
+    # ...and the broker is now holding the position with nothing guarding it
+    assert sim.broker.open_positions() == [
+        {"symbol": "NVDA", "qty": "66", "side": "long"}]
+    assert sim.broker.open_orders() == []
+
+    texts = [p["text"] for p in _event_payloads(sim, "alert")]
+    assert any("NVDA" in t and "stop at 168" in t for t in texts), (
+        f"the naked position was not reported; alerts were {texts}")
+    assert any("NO live protective order" in p["text"]
+               for p in sim.slack.posts["#risk"])
+
+
 # --- 7. the HOLD-only ticker never reaches a seat ---------------------------
 
 def test_a_hold_only_ticker_never_reaches_the_pipeline(tmp_path):
@@ -576,39 +624,3 @@ def test_a_hold_only_ticker_never_reaches_the_pipeline(tmp_path):
     assert _decision(sim, "NVDA")["action"] == "buy"
     assert _count(sim, "tickets") == 1
     _assert_day_completed(sim)
-
-
-# --- 5. the stop that expired at the bell (2026-08-19) ----------------------
-
-def test_the_stop_that_expired_at_the_bell_is_caught(tmp_path):
-    """2026-08-19, reproduced end to end. A stopped NVDA entry fills, its OTO
-    stop leg then EXPIRES at the close exactly as the real one did on 08-17,
-    and the day must not end quietly.
-
-    Before this assertion existed the run was clean — holds, AUDIT CLEAN, a
-    digest posted — while the position sat naked for two sessions. A green
-    suite proved nothing then. This is what proving looks like: the real gate,
-    the real hooks, the real fill-poll, and a broker whose protection dies on
-    schedule."""
-    sim = sim_day(tmp_path, market={"NVDA": _nvda()},
-                  pm_recs=("mvf_pm_stop.jsonl",),
-                  exec_recs=("mvf_exec_stop_gtc.jsonl",),
-                  broker_mode="stop_expires_at_the_bell")
-
-    # the entry really happened, carrying the ticket's stop
-    placed = sim.broker.place_attempts[0]
-    assert (placed["order_class"], placed["time_in_force"]) == ("oto", "gtc")
-    assert placed["stop_loss_stop_price"] == "168.0"
-    assert sim.conn.execute(
-        "SELECT stop_price FROM tickets").fetchone()["stop_price"] == 168.0
-
-    # ...and the broker is now holding the position with nothing guarding it
-    assert sim.broker.open_positions() == [
-        {"symbol": "NVDA", "qty": "66", "side": "long"}]
-    assert sim.broker.open_orders() == []
-
-    texts = [p["text"] for p in _event_payloads(sim, "alert")]
-    assert any("NVDA" in t and "stop at 168" in t for t in texts), (
-        f"the naked position was not reported; alerts were {texts}")
-    assert any("NO live protective order" in p["text"]
-               for p in sim.slack.posts["#risk"])

--- a/tests/test_sim_day.py
+++ b/tests/test_sim_day.py
@@ -204,6 +204,27 @@ def _event_payloads(sim: SimResult, kind: str) -> list[dict]:
         "SELECT payload FROM events WHERE kind = ? ORDER BY id", (kind,))]
 
 
+def _cost_pairs(sim: SimResult) -> list[tuple[str, str]]:
+    """(agent, session_id) per cost row. The criterion is "per seat per
+    session" (#158) — a COUNT cannot tell four seats turning once from one
+    seat turning four times."""
+    return [(r["agent"], r["session_id"]) for r in sim.conn.execute(
+        "SELECT agent, session_id FROM costs ORDER BY agent")]
+
+
+def _participating_seats(sim: SimResult) -> set[str]:
+    """The seats run_close owes a journal to, derived the way it derives them
+    (orchestrator/daily.py:460-467) rather than named literally — so a new
+    seat is covered here without editing the test."""
+    seats = {r["agent"] for r in sim.conn.execute(
+        "SELECT DISTINCT agent FROM signals WHERE run_date = ?",
+        (sim.run_date,))} | {"pm"}
+    if sim.conn.execute("SELECT COUNT(*) c FROM orders"
+                        " WHERE filled_qty > 0").fetchone()["c"]:
+        seats.add("exec")
+    return seats
+
+
 def _brief(sim: SimResult, stage: str) -> dict:
     """The stage brief the seat actually received that turn, straight off the
     replayed tool result — not re-derived, or the assertion would be circular."""
@@ -290,13 +311,18 @@ def test_golden_day(tmp_path):
 
     # every turn that ran recorded its cost, and the digest reports the sum
     assert sim.turns == {"research": 2, "decision": 1, "execution": 1}
-    assert _count(sim, "costs") == 4   # analyst + news + pm + exec
+    # per SEAT per SESSION, not four-of-something (#158)
+    assert _cost_pairs(sim) == [("analyst", "sim-analyst"), ("exec", "sim-exec"),
+                                ("news", "sim-news"), ("pm", "sim-pm")]
     digest = _event_payloads(sim, "digest")[0]["text"]
     assert "decisions: NVDA buy 80 (executed)" in digest
     assert "fills: NVDA buy 66@180.14" in digest
     assert "est. inference cost $0.04" in digest   # 4 turns: +news seat
 
     assert (sim.journals / "exec.md").read_text().count("NVDA buy 66@180.14") == 1
+    # EVERY participating seat, not just the two named by hand: the news seat
+    # signalled today and owes a journal exactly as the analyst does (#158)
+    assert {p.stem for p in sim.journals.glob("*.md")} == _participating_seats(sim)
     _assert_day_completed(sim)
 
 

--- a/tests/test_sim_day.py
+++ b/tests/test_sim_day.py
@@ -510,6 +510,48 @@ def test_pm_brief_carries_the_signal_and_the_budget_the_gate_enforces(tmp_path):
     _assert_day_completed(sim)
 
 
+# --- 7. the HOLD-only ticker never reaches a seat ---------------------------
+
+def test_a_hold_only_ticker_never_reaches_the_pipeline(tmp_path):
+    """acceptance.md Phase 2, criterion 7: a ticker the pre-gate resolves to
+    {buy:0, sell:0} "never reaches the LLM pipeline (assert zero agent turns
+    for it)" (#157). The chain was pinned link by link in test_daily_stages.py
+    and joined nowhere -- and the joins are what a refactor breaks, since
+    run_research and run_decision take `active` as a parameter.
+
+    Turn counts are per STAGE, not per ticker (`turns` above), so the
+    per-ticker form of "zero agent turns" is: the ticker is absent from the
+    snapshot the PM decides on, and NEITHER stage default fired for it. The
+    defaults are what make the negative observable -- an ACTIVE ticker nobody
+    covers still gets a row (run_research writes neutral/0 and run_decision
+    writes hold/0, exactly as test_mixed_day's MSFT does), so no row at all is
+    reachable only by never having been active.
+
+    AAPL carries no cash and no shares: nothing to buy, nothing to sell. NVDA
+    trades its normal golden day beside it, so this is a drop and not an empty
+    day."""
+    sim = sim_day(tmp_path,
+                  market={"NVDA": _nvda(),
+                          "AAPL": _nvda(ticker="AAPL", price=232.0,
+                                        cash=0.0, held_qty=0)},
+                  analyst_recs=("mvf_analyst_brief.jsonl",),
+                  pm_recs=("mvf_pm_brief.jsonl",))
+
+    # the snapshot the PM was actually shown, off the replayed tool result
+    assert list(_brief(sim, "decision")["allowed_actions"]) == ["NVDA"]
+
+    # neither stage default fired for it: no row, not a zero row
+    assert [r["ticker"] for r in sim.conn.execute(
+        "SELECT DISTINCT ticker FROM signals ORDER BY ticker")] == ["NVDA"]
+    assert [r["ticker"] for r in sim.conn.execute(
+        "SELECT DISTINCT ticker FROM decisions ORDER BY ticker")] == ["NVDA"]
+
+    # a drop, not an empty day -- NVDA still ran the whole golden pipeline
+    assert _decision(sim, "NVDA")["action"] == "buy"
+    assert _count(sim, "tickets") == 1
+    _assert_day_completed(sim)
+
+
 # --- 5. the stop that expired at the bell (2026-08-19) ----------------------
 
 def test_the_stop_that_expired_at_the_bell_is_caught(tmp_path):


### PR DESCRIPTION
Phase 2's ten criteria in `specs/acceptance.md` were all unticked. A criterion-by-criterion audit found six already covered by passing tests, three covered only partially, and one genuinely missing. This branch closes the four gaps, then ticks all ten with the mapping recorded in the commit.

## What was actually missing

| Criterion | Gap | Now |
|---|---|---|
| 1 — gate boundaries | sector weight was the one of six boundaries with no dedicated case | `test_sector_cap_boundaries` |
| 7 — HOLD-only skip | the **partial** drop was uncovered; `test_run_day.py`'s zero-ticker days already covered the all-dropped case | `test_a_hold_only_ticker_never_reaches_the_pipeline` |
| 9 — journals | asserted two files `.exists()`; the `news` seat's journal was written and unasserted | every participating seat, each carrying today's entry |
| 10 — cost rows | asserted a `COUNT`, which four rows from one seat satisfy | `(agent, session_id)` on the production seam |

## Every test was proven to detect something

Production already passed, so a test written here could not get a natural red. Each one instead got a **manufactured** red: break the behaviour, confirm the new test — and only it — fails, revert. All four cycles are re-runnable and were re-confirmed after review:

| Mutation | Failures across the whole suite |
|---|---|
| sector cap `math.floor` → `round` | `test_sector_cap_boundaries` only |
| leak the watchlist into research *only when a ticker survived* | `test_a_hold_only_ticker_never_reaches_the_pipeline` only |
| collapse cost rows to one per `run_date` | the two new `test_runtime_hooks` tests only |
| journal for only the first signalling seat | `test_golden_day` only |

## Review found two things worth knowing

A two-axis review ran in fresh contexts, briefed with the raw criteria and **not** with this branch's own conclusions. It caught:

- **A circular assertion I wrote.** The sim-day cost assertion checked `sim-{seat}` — a string the test harness itself writes — so it survived a mutation making `session_id` constant. Removed. Criterion 10 rests only on `record_turn_result`, which is the sole production caller of `record_cost`.
- **A false docstring over a latent wrong assertion.** A helper claimed to derive participating seats "the way `run_close` derives them" and instead asked `filled_qty > 0`, unscoped by run_date or status. Demonstrated wrong on a constructed partially-filled-then-canceled order, and fixed to ask production's question.

## Scope

Test and docs only — `gate/`, `orchestrator/`, `agents/`, `state/` and `scripts/` are untouched (`git diff origin/master...HEAD` over those paths is empty). No fixture, expected value, or golden number was changed.

Rebased onto `612cc66`; `make test` green there — **1557 passed, 1 skipped, 7 deselected**.

Closes #100
Closes #157
Closes #158

Part of #99 — this settles Phase 2 only. Phases 1 and 3–5 remain unaudited and their boxes are untouched, so #99 stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)