### PR TITLE
fix: dedup the accounting shortfall on the gap, not the absolute pair

### DIFF
--- a/orchestrator/protection.py
+++ b/orchestrator/protection.py
@@ -397,7 +397,22 @@ def assert_positions_accounted(conn: sqlite3.Connection, *, broker,
     audit is what masks the next new failure. That is a narrower argument than
     crying wolf: the sanctioned stopless position above is a correct state,
     while this is a fault that is still a fault on day two. Worth saying once,
-    not worth saying daily."""
+    not worth saying daily.
+
+    A distinct discrepancy is a distinct GAP (recorded - held), not a distinct
+    (recorded, held) pair. Keying on the pair re-reported an unchanged fault
+    every time the symbol traded again, because a later fill moves both
+    numbers together — 80/40 became 108/68 on 2026-08-27 with the same 40
+    shares missing, and the day audit reddened (#141).
+
+    The gap is the exact residue, and that is why it is the right key rather
+    than merely the quieter one: held moves by whatever the fund recorded plus
+    whatever it did not, so the gap is unchanged if and only if the unrecorded
+    movement is zero. A new unrecorded exit always changes the gap and always
+    alerts; nothing that leaves the gap alone is a new fault. What this does
+    NOT do is refresh the standing alert's text, so the absolutes a human
+    reconciles from stay as first reported while the position moves under
+    them."""
     nap = sleep or (lambda _s: None)
 
     def alert(text: str, accounting: dict) -> None:
@@ -465,8 +480,15 @@ def assert_positions_accounted(conn: sqlite3.Connection, *, broker,
                       {"symbol": symbol, "cleared": True})
                 appended += 1
             continue
-        if (last.get("recorded"), last.get("held")) == (want, have):
-            continue                      # same finding, already standing
+        # The finding is the GAP, not the pair. A later buy in the same symbol
+        # moves recorded and held by the same amount and leaves the shortfall
+        # untouched — 80/40 became 108/68 on 2026-08-27 with the same 40 shares
+        # missing, and the audit reddened on a day nothing new had gone wrong
+        # (#141). A cleared record carries no `recorded`, so it never matches,
+        # which is what keeps a recurrence after a clear reportable.
+        standing = last.get("recorded")
+        if standing is not None and standing - last["held"] == want - have:
+            continue                      # same gap, already standing
         alert(_shortfall_text(symbol, want, have),
               {"symbol": symbol, "recorded": want, "held": have,
                "cleared": False})

--- a/tests/test_protection.py
+++ b/tests/test_protection.py
@@ -593,6 +593,40 @@ def test_a_discrepancy_that_changes_shape_alerts_again(fund_db):
     assert len(_alerts(fund_db)) == 2
 
 
+def test_a_standing_gap_is_silent_when_the_symbol_trades_again(fund_db):
+    """The 2026-08-27 red day (#141). A 40-share hole stood unreconciled from
+    08-24. On 08-27 the fund bought 28 more NVDA, moving both numbers by the
+    same +28 — recorded 80->108, held 40->68 — while the gap stayed exactly
+    40. Nothing new went wrong, and the audit reddened anyway: dedup keyed on
+    the absolute (recorded, held) pair saw a new tuple. The discrepancy is
+    the gap, so that is what 'same finding' has to mean."""
+    _promised(fund_db, qty=80)
+    first = assert_positions_accounted(
+        fund_db, broker=Broker([_long("NVDA", "40")], []), now_iso=NOW)
+    _promised(fund_db, qty=28, tid="59d360b5-be75-4230-b2d7-24728dcf202c",
+              submitted_at="2026-08-27T13:38:52+00:00")
+    second = assert_positions_accounted(
+        fund_db, broker=Broker([_long("NVDA", "68")], []), now_iso=NOW)
+    assert (first, second) == (1, 0), "an unchanged 40-share gap re-alerted"
+    assert len(_alerts(fund_db)) == 1
+
+
+def test_a_gap_that_widens_on_a_trading_day_still_alerts(fund_db):
+    """The over-correction guard for the test above. Keying on the gap must
+    not buy its silence by swallowing a real new discrepancy that happens to
+    surface on a day the symbol also traded: 40 missing becomes 48 missing,
+    and 8 more shares left without a record. That is a new fact."""
+    _promised(fund_db, qty=80)
+    assert_positions_accounted(
+        fund_db, broker=Broker([_long("NVDA", "40")], []), now_iso=NOW)
+    _promised(fund_db, qty=28, tid="59d360b5-be75-4230-b2d7-24728dcf202c",
+              submitted_at="2026-08-27T13:38:52+00:00")
+    n = assert_positions_accounted(
+        fund_db, broker=Broker([_long("NVDA", "60")], []), now_iso=NOW)
+    assert n == 1
+    assert len(_alerts(fund_db)) == 2
+
+
 def test_unreadable_positions_fail_closed(fund_db):
     """Same rule as the rest of the module: a check that can pass while lying
     is worse than no check at all."""


### PR DESCRIPTION
Layer 2 of #141. Layer 1 — the 40-share reconciliation itself — is untouched and remains open, so this PR is deliberately not marked as closing that issue.

## The defect

`assert_positions_accounted` keyed *"same finding, already standing"* on the absolute `(recorded, held)` pair. A later fill in the same symbol moves both numbers together, so a standing hole read as new:

| | recorded | held | gap | audit |
|---|---|---|---|---|
| 08-24 | 80 | 40 | 40 | alert |
| 08-25 / 08-26 | 80 | 40 | 40 | silent |
| 08-27 (bought 28) | 108 | 68 | **40** | **alert — red day** |

`fund-daily` exited 1 on a day nothing new had gone wrong. The fund traded normally; the exit is the day-audit refusing to call the day clean.

## The change

One condition: key on the gap, `recorded - held`.

The gap is the exact residue, which is why it is the right key rather than merely the quieter one. `held` moves by whatever the fund recorded plus whatever it did not, so **the gap is unchanged if and only if the unrecorded movement is zero**. A new unrecorded exit always changes the gap and always alerts; nothing that leaves the gap alone is a new fault.

A cleared record carries no `recorded`, so it can never match — which is what keeps a recurrence after a clear reportable (pinned by the existing `test_a_discrepancy_that_clears_and_recurs_alerts_again`).

## The check the issue asked for

The issue said not to ship this without testing *"whether 'same gap' can mask two genuinely different faults."* That check ran. Two reviewers independently produced a masking counter-example and **both were false** — in each, Δrecorded = Δheld exactly, so the drop in `held` was fully explained by the recorded sell they had posited, and no new unrecorded movement existed. Verified against a control where a genuine unrecorded exit moves the gap 40→68 and still alerts.

## What this does not do

It does not refresh the standing alert's text, so the absolutes a human reconciles from stay as first reported while the position moves under them. Documented in the docstring; a separate change if it matters.

## Verification

- `make test` — 1559 passed, 1 skipped, 7 deselected (baseline was 1557; +2 new tests)
- purity lint clean (53 files), alert-code lint clean (97 files)
- full red-green cycle: reverting the production change alone fails the new test with `assert (1, 1) == (1, 0)`
- the real 08-24→08-27 sequence replayed offline now ends green
