### PR TITLE
docs: the night-close handoff's post-push corrections

### DIFF
--- a/docs/superpowers/handoffs/2026-08-26-night-close.md
+++ b/docs/superpowers/handoffs/2026-08-26-night-close.md
@@ -60,7 +60,7 @@ Measured against each branch's own remote, not against `master`. Four locations,
 
 | Where | Branch | Ahead of remote | Dirty | What it is |
 |---|---|---|---|---|
-| `fund-wt/reflection-stage` | `feat/reflection-stage` | **4 commits** | 4 files | **#4's implementation.** The reflect seat, `submit_reflection`, the nightly job. Its author (`fund-c6`) is gone. |
+| `fund-wt/reflection-stage` | `feat/reflection-stage` | **4 commits** | 4 files | **#4's implementation.** The reflect seat, `submit_reflection`, the nightly job. **Owner is LIVE** — `fund-c6`, now named `fund-34`, sessionId `25602639-…`, mid-amend. ~~Its author is gone.~~ (Cell rewritten 10:50; see the ⛔ block above. A table cell gets read out of order, so the false claim is corrected here rather than only in prose.) |
 | `fund-wt/reflection-idempotent` | `fix/reflection-writer-idempotent` | 1 commit (`0b754ad`) | 0 | #4's idempotency fix. **Deliberately held**, not stranded — hold was the lane's own recommendation. |
 | `Developer/fund` (root) | detached `HEAD` | **21 commits** | 14 files | Standup-dispatch spec work. See §2. |
 | `fund-wt/dev-status` | `feat/dev-status` | ~~2 commits~~ **7 and growing** | 1 file | ~~Unknown provenance; predates this run.~~ **`fund-91`'s live lane**, all seven commits made today 09:54–10:03. Corrected 10:10. |
@@ -134,6 +134,28 @@ intent unknown.
 
 **Do not fix it by editing the file** — the rule being deleted is precisely the one saying you
 cannot settle a rule that way. It goes to Benjamin as-is.
+
+> ### ⚠ The `CLAUDE.md` deletion is not one file's problem. The mechanism is the checkout.
+>
+> Two things follow from the root checkout's `HEAD` being 21 commits divergent, and both were
+> demonstrated on 2026-08-26:
+>
+> **1. `git status` reports files as untracked (`??`) that are on `master`.** The status is
+> computed against the divergent `HEAD`, not against `master`. Of ten docs that looked untracked
+> there, **six were already on `master`** — three byte-identical. The real exposure was four.
+>
+> **2. The checkout's copy can be OLDER than master's, and "rescuing" it reverts work.**
+> `docs/superpowers/plans/2026-08-18-critic-seat.md` shows `??` in `git status`, is on `master`,
+> and differs by 740 lines — the local copy **lacks** master's `DELIVERED` status header, its
+> pointer to `map.md` for the current owner, and its measured finding that checkbox state is not
+> a progress signal. Committing it would have deleted all three.
+>
+> Same shape as the `CLAUDE.md` deletion above, and that is the point: **the checkout silently
+> holds older content that undoes work on `master`.** Caught by `fund-f5` mid-rescue.
+>
+> **Never use `git status` in the root checkout to decide whether a file exists upstream.**
+> `git show origin/master:<path>` is the instrument. This is the §7 rule again — the wrong
+> instrument answering confidently.
 
 **Consequences for you:** never `git checkout` in the root checkout; never read a file's state
 from it (`git show master:<path>` instead — its HEAD is a divergent line, not an ancestor);


### PR DESCRIPTION
Recovers three corrections to the night-close handoff that exist on no other ref. Tracked as §2 of #118.

## What this is

One existing commit, `9259388`, one file: `docs/superpowers/handoffs/2026-08-26-night-close.md`. **17 of 18 added lines are absent upstream.**

**Nothing was added to the branch to open this PR.** It is the commit as its author left it.

## Why it matters more than its size suggests

These are corrections to a handoff that is **wrong in a way a reader acts on**. Per #118 §2, the commit carries three:

1. A §1 table cell still reading *"its author is gone"* for an owner whose session was live — the handoff also instructed the reader to push that owner's branch first. Both wrong. #94's thread records the owner's session never ended; its **name** churned from `fund-c6` to `fund-34` while `map.md`'s sessionId stayed constant. Acting on the uncorrected text means pushing a branch that was being amended at the time.
2. A block establishing that the stale-copy problem is **the checkout**, not one file — 6 of 10 apparently-untracked docs were already on master, because `git status` in a detached checkout computes against a HEAD hundreds of commits behind.
3. A header that pinned a SHA which went stale within the hour.

The handoff's author has already retracted §1 in #94's thread. **This commit is that retraction in the file itself**, where the next reader will actually encounter it.

## Verification

- `origin/master` = `6ce5791`; branch tip `9259388`, identical to `origin/docs/night-close-corrections`.
- Landed-ness established by content, not ancestry — this repo squash-merges. DEMONSTRATED: 17 of 18 added lines absent upstream.
- 1 ahead, 12 behind. Single file, single commit. #118 §2 predicted no conflict; that holds.
- Documentation only.

## One thing a reviewer should weigh

This edits a **dated handoff**, which under the 2026-08-26 doc-authority tiers is a derived artifact — a snapshot of the moment it was written. There is a real question about whether a stale snapshot should be corrected at all, and the answer is not uniform: **correct a stale directive a reader will act on; preserve a stale claim whose staleness is itself the evidence.**

All three corrections here are the first kind — "its author is gone / push their branch first" is an instruction, and following it causes harm. Merging is right on that reading. But a reviewer who thinks the historical record is better served by leaving the file as written and letting #94's thread carry the retraction has a defensible position, and this PR should not be merged without someone actually holding that view up.

<sub>Opened by the orphan-branch sweep lane against `origin/master` = `6ce5791`. No branch was extended; disposition detail is on #118.</sub>
