### PR TITLE
docs: F12 is caught by EXPECT too, and that firing is equally spurious

### DIFF
--- a/docs/evals/saturation-open-coding.md
+++ b/docs/evals/saturation-open-coding.md
@@ -473,7 +473,11 @@ Caught by: **I4** (`invented-subject`). Correct verdict; the cause is
 case rewritten after it was recorded. Count: **6** — `critic-v2-r1/a04/{1,2,3}`,
 `critic-v2-r1/h01/{1,2,3}`, where `trace.brief_subjects != case.subjects`.
 Caught by: **I4**, but **mislabelled** — the tag says `schema-reject`
-("the handler refused the submission"); nothing was refused.
+("the handler refused the submission"); nothing was refused. Also by `EXPECT`
+(`missing-row`) on all 6, and **equally spurious**: `case.subjects` names a spec
+the trace never critiqued, so the lookup misses at `evals/expectations.py:47-50`
+before a verdict is compared. The seat submitted correctly for the spec it was
+shown — this is added false-positive surface, not added coverage.
 `grade_traces` checks that trace and case agree on *seat*
 (`evals/grade.py:119-124`) but not that they agree on *subject*.
 


### PR DESCRIPTION
**This PR carries no closing reference, deliberately.** It touches one documentation entry and retires
no tracked work. See "Why no closing reference" at the bottom — the omission is intentional, not the
silent kind.

One file, docs only. Five added lines, no pre-existing line modified.

## What was wrong

`docs/evals/saturation-open-coding.md`'s **F12** entry credited only **I4** as catching the mode.
`EXPECT` also FAILs on all six of those trials, tagged `missing-row`.

The mechanism: both case files carry `RE-AUTHORED 2026-08-19`, so `case.subjects` names a spec the
trace never critiqued. The row lookup misses and `evals/expectations.py:47-50` returns before a
verdict is ever compared.

## Why it is written as false-positive surface, not as coverage

This is the part worth reviewing, and the first draft got it wrong.

On all six trials `brief_subjects == rows[strategy_critiques].spec_id != case.subjects` — **the seat
submitted correctly for the spec it was actually shown.** Only the case moved. So `EXPECT`'s
`missing-row` is a false FAIL against the seat, from the identical cause as I4's `schema-reject`
mislabel that the entry already documents.

That direction matters. The document's argumentative spine is that *no blocking invariant has ever
fired on a real model trace because of what a model decided* — which holds only by reading these
firings as rig defects. A version of this change that read as "one more detector catches F12" would
have quietly undercut the document's own conclusion, in a document about detection being overstated.

## Verification

Both the writing and the review executed the grader over the committed corpus offline — no network, no
model calls — with independent instruments.

- All six trials (`critic-v2-r1/a04/{1,2,3}`, `critic-v2-r1/h01/{1,2,3}`) produce **two** FAILs each:
  `I4 schema-reject` and `EXPECT missing-row`.
- `missing-row` over the whole 167-trial corpus is **exactly 6** — these six. Not an undercount of a
  larger set.
- Cross-check: `EXPECT`'s 19 FAILs decompose with no remainder — F7 `wrong-action` 3 + **F12
  `missing-row` 6** + F13 `wrong-verdict` 7 + F14 `wrong-verdict` 3 = 19. The document already encoded
  this fact in its own totals; it just was not written down.

**No number moves.** Every roll-up, bucket list and count in the 734-line document was re-derived by
execution and reproduces byte-identically. The six were already inside the `EXPECT 19 FAIL` figure and
already non-PASS via I4, so `143/167` is unchanged. F12 stays in "caught by a blocking invariant" and
correctly stays out of "caught **only** by a case expectation."

Gates:

- `python3 devloop/tamper_guard.py origin/master` → exit **0**
- `make test` → **1557 passed, 1 skipped, 7 deselected**
- Nothing under `evals/`, `tests/`, `evals/seats/`, `evals/cases/`, `evals/traces/` or `devloop/` is
  touched. No expected value, golden fixture or assertion altered.

## Why no closing reference

#41's fix (c) — "write the next invariants and cases from the top three modes" — is **8 of 14 open-coded
failure modes from done**, including the two largest in the corpus (F1 unstable sizing, 46 rows; F6
permission mistaken for judgment, 39 of 81 holds). This PR corrects one sentence in the table that (c)
will be written *from*. A closing reference here would retire an open programme and schedule a
thread of findings for deletion.

Nothing else on the board is retired by this change either. The reference is omitted on purpose, and
this section exists so that a reader can tell the difference between a deliberate omission and the
accidental kind.
