### PR TITLE
docs: PROGRESS.md status carries only facts that do not rot

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -6,10 +6,11 @@ session. `README.md` explains what the system *is*; this file explains what the 
 
 Update it when a milestone lands or an open item closes — not per commit.
 
-> **⚠ STALE — a snapshot, not current state.** Despite "read this first" above, this file
-> has not been updated since 2026-08-20 (`git log -1 -- PROGRESS.md`). Nothing below is
-> current state, and this header deliberately quotes no commit, count, or phase number —
+> **⚠ A snapshot, not current state.** Despite "read this first" above, nothing below is
+> live state, and this header deliberately quotes no commit, count, or phase number —
 > a number that depends on state outside this file will eventually be wrong inside it.
+> Check the date on the Status section against `git log -1 -- PROGRESS.md`; if they disagree,
+> someone edited the file without moving the date and the section is older than it claims.
 >
 > For what is actually true right now: board issue **#49** and its children for what to work
 > on, open issues and PRs for what is in flight, `git log` on `master` for what shipped, and
@@ -17,20 +18,26 @@ Update it when a milestone lands or an open item closes — not per commit.
 
 ---
 
-## Status — 2026-08-19
+## Status — 2026-08-28
 
-The following table summarizes where the fund stands:
+**This table carries only facts that do not rot.** Anything that changes without a commit to
+this file — positions, test counts, issue counts, the deployed SHA — is a **pointer**, not a
+value, for the reason the header above gives: a number that depends on state outside this file
+will eventually be wrong inside it. The 2026-08-19 version of this table stated a test count, a
+CI count and an open position; all three were wrong within days, and the position was wrong in
+the direction that mattered.
 
 | Item | Value |
 |---|---|
 | **Mode** | Alpaca **paper** only (invariant 1) |
 | **Live since** | 2026-08-17 — first clean end-to-end day |
-| **Tests** | 955 offline green at `51bc7eb`, identical on macOS arm64, linux/amd64 and linux/arm64 |
-| **CI** | runs all 909 (was 36); **first green run in the repo's history on 2026-08-19** |
-| **Seats** | PM, exec, and **two** analysts — `analyst` (price/fundamentals) and `news` (news/sentiment, read-only, blind to the book). The `news` seat is deployed but **defective**, see #6 |
-| **Watchlist** | NVDA, MSFT, AAPL |
-| **Open position** | NVDA 80 @ 227.09, stop 215 gtc (expires 2026-11-17) — **hand-placed 2026-08-19 11:46 PDT** after two sessions unprotected (see below) |
-| **Scheduled on** | **DigitalOcean droplet `fund-vm` (NYC3, Debian 13, ET clock)** since 2026-08-18 |
+| **Phase** | **Phase 2 complete** — all ten of `specs/acceptance.md`'s Phase 2 criteria are ticked as of 2026-08-28 (PR #160 closed four real gaps first). **Phase 3 is not started**; its criteria are unticked in the same file, which is the build order |
+| **Seats** | PM, exec, and two analysts — `analyst` (price/fundamentals) and `news` (news/sentiment, read-only, blind to the book). The **Critic is built and eval-gated but still outside the daily cycle**: `orchestrator/daily.py:201` pre-inserts `no_critic_seat` |
+| **Deployed** | **DigitalOcean droplet `fund-vm`** (NYC3, Debian 13, ET clock) since 2026-08-18. `/opt/fund` is a plain checkout; a deploy is a pull. **The dev loop (`devloop/`) has never run there** — no `.baseline`, no `logs/`, no unit, no cron entry (measured 2026-08-28) |
+| **Deployed SHA** | → `make dev-status`, check `deploy_state`. Never stated here |
+| **Tests / CI** | → the CI run on `master`. Never stated here |
+| **Open position** | → the broker, via `make dev-status`. **Never stated here** — `specs/design.md` §4 forbids inferring position state from the database, and this file is further from the truth than the database is |
+| **What to work on** | → board issue **#49** and its children, in map order |
 
 ### 2026-08-19 — the stop that expired at the bell
 


### PR DESCRIPTION
Supersedes the recovery attempt in #164. **Carries no closing keyword** — this retires no issue.

## The defect

`PROGRESS.md`'s status table was dated **2026-08-19** and stated a test count, a CI count, and an open position. All three were wrong within days. The position was wrong in the direction that matters: it read **NVDA 80** while the broker holds **68** and the fund's own `orders` records **108**.

The table sat **two lines below** a banner saying *"this header deliberately quotes no commit, count, or phase number — a number that depends on state outside this file will eventually be wrong inside it."* The table contradicted its own banner.

That is also why #164 is the wrong fix: recovering the 2026-08-25 snapshot restores a table with the same property, and would additionally make the banner's own "not updated since 2026-08-20" false.

## The change

The status table now carries **only facts that do not rot** — mode, live-since, phase, seats, where it is deployed — and makes everything else a **pointer**:

| rots | now points at |
|---|---|
| deployed SHA | `make dev-status` → `deploy_state` |
| tests / CI | the CI run on `master` |
| open position | the broker, via `make dev-status` |
| what to work on | board #49 |

This follows the 2026-08-26 authority-tiers ruling directly: **nothing in the repo may claim to be live state.**

Two facts recorded because they are durable and were not written down anywhere:

- **Phase 2 is complete** — all ten `specs/acceptance.md` criteria ticked as of 2026-08-28 (PR #160 closed four real gaps first). **Phase 3 is not started.**
- **The dev loop has never run on the droplet** — no `devloop/.baseline`, no `devloop/logs/`, no systemd unit referencing it, nothing in root's crontab. Measured 2026-08-28 over ssh, and matching all 8 checkouts on the dev machine. Two open issues (#78, and #45's item 9 before it closed) were costing options against that unknown.

The banner drops its own hardcoded date for the same reason the table drops its numbers, and tells the reader to check the Status date against `git log -1 -- PROGRESS.md` instead — so a future edit that moves content without moving the date is detectable.

## Evidence tier

**Demonstrated:** the droplet measurements (ssh), the Phase 2 tick state at `origin/master`, `orchestrator/daily.py:201` still pre-inserting `no_critic_seat`, and the position discrepancy. **Not verified:** nothing in this diff rests on a reasoned claim.

## Review note

Reviewed by nobody — this repo's single GitHub identity means no agent can set a review state (every merged PR here reads `reviewDecision: ""`). Read it rather than trusting the CI badge.