### PR TITLE
fix: dedup the accounting shortfall on the gap, and only when nothing was written off

### DIFF
--- a/orchestrator/protection.py
+++ b/orchestrator/protection.py
@@ -397,7 +397,11 @@ def assert_positions_accounted(conn: sqlite3.Connection, *, broker,
     audit is what masks the next new failure. That is a narrower argument than
     crying wolf: the sanctioned stopless position above is a correct state,
     while this is a fault that is still a fault on day two. Worth saying once,
-    not worth saying daily."""
+    not worth saying daily.
+
+    A distinct discrepancy is a distinct GAP (recorded - held) that arrived
+    without anything being written off — not a distinct (recorded, held) pair.
+    See the condition below for why it takes both halves."""
     nap = sleep or (lambda _s: None)
 
     def alert(text: str, accounting: dict) -> None:
@@ -465,8 +469,25 @@ def assert_positions_accounted(conn: sqlite3.Connection, *, broker,
                       {"symbol": symbol, "cleared": True})
                 appended += 1
             continue
-        if (last.get("recorded"), last.get("held")) == (want, have):
-            continue                      # same finding, already standing
+        # The finding is the GAP, not the pair. A later buy in the same symbol
+        # moves recorded and held together and leaves the shortfall untouched:
+        # 80/40 became 108/68 on 2026-08-27 with the same 40 shares missing,
+        # and the audit reddened on a day nothing new had gone wrong (#141).
+        #
+        # `want >= standing` is NOT redundant with the gap test, and dropping
+        # it is a regression rather than a simplification (PR #161 was closed
+        # for exactly that). `recorded` does not only move on fills — it also
+        # falls when a human writes the missing exit down, which is precisely
+        # what _shortfall_text instructs. So a write-off can cancel out a NEW
+        # unrecorded exit and hold the gap constant: 80/40 -> 40/0 is still a
+        # gap of 40, and the second 40 shares left the account unrecorded.
+        # Requiring that recorded never shrank keeps the #141 win and still
+        # alerts on that. A cleared record carries no `recorded`, so it never
+        # matches, which keeps a recurrence after a clear reportable.
+        standing = last.get("recorded")
+        if (standing is not None and want >= standing
+                and standing - last.get("held", 0) == want - have):
+            continue                      # same gap, nothing written off
         alert(_shortfall_text(symbol, want, have),
               {"symbol": symbol, "recorded": want, "held": have,
                "cleared": False})

--- a/tests/test_protection.py
+++ b/tests/test_protection.py
@@ -593,6 +593,47 @@ def test_a_discrepancy_that_changes_shape_alerts_again(fund_db):
     assert len(_alerts(fund_db)) == 2
 
 
+def test_a_standing_gap_is_silent_when_the_symbol_trades_again(fund_db):
+    """#141, from production. A 40-share hole stood since 08-24. The fund then
+    bought 28 more NVDA, moving both numbers by +28 — recorded 80->108, held
+    40->68 — while the gap stayed 40. Nothing new went wrong, so nothing new is
+    said. Under the old (recorded, held) key this alerted and reddened the day.
+
+    Discriminating: fails against the pair key with assert (1, 1) == (1, 0)."""
+    _promised(fund_db)                                    # recorded 80
+    first = assert_positions_accounted(
+        fund_db, broker=Broker([_long("NVDA", "40")], []), now_iso=NOW)
+    _promised(fund_db, qty=28, tid="a3f90000-0000-4000-8000-000000000002",
+              submitted_at="2026-08-27T19:59:00+00:00")   # recorded 80 + 28
+    second = assert_positions_accounted(
+        fund_db, broker=Broker([_long("NVDA", "68")], []), now_iso=NOW)
+    assert (first, second) == (1, 0)
+    assert len(_alerts(fund_db)) == 1
+
+
+def test_a_new_unrecorded_exit_alerts_even_when_it_leaves_the_gap_unchanged(
+        fund_db):
+    """The guard on the guard above, and the reason `want >= standing` is in
+    the condition rather than the gap test alone.
+
+    `_shortfall_text` tells the operator to record the exit. Doing so shrinks
+    `recorded` — 80 -> 40 — which is not a broker movement. If a NEW unrecorded
+    exit takes held 40 -> 0 in the same window, the gap is still 40 while a
+    second lot of shares has left the account unrecorded. That is a new fault
+    of exactly the kind this guard exists to catch and it must alert.
+
+    Discriminating: fails against a gap-only key with assert (1, 0) == (1, 1),
+    which is why PR #161 was closed."""
+    _promised(fund_db)                                    # recorded 80
+    first = assert_positions_accounted(
+        fund_db, broker=Broker([_long("NVDA", "40")], []), now_iso=NOW)
+    _recorded_sell(fund_db, qty=40)                       # recorded 80 -> 40
+    second = assert_positions_accounted(                  # held 40 -> 0
+        fund_db, broker=Broker([], []), now_iso=NOW)
+    assert (first, second) == (1, 1)
+    assert len(_alerts(fund_db)) == 2
+
+
 def test_unreadable_positions_fail_closed(fund_db):
     """Same rule as the rest of the module: a check that can pass while lying
     is worse than no check at all."""


### PR DESCRIPTION
Closes #175. Layer 2 of #141 — **Layer 1 (the 40 shares in `orders` with no row) is untouched and
stays open.**

This is the second attempt. **PR #161 was the gap-only version and was closed on 2026-08-28 for a
demonstrated regression.** This one keeps that regression fixed, and pins it with a test that fails
against #161's implementation.

## The defect

`assert_positions_accounted` keyed *"same finding, already standing"* on the absolute
`(recorded, held)` pair. A later fill in the same symbol moves both numbers together, so a standing
hole read as new:

| | recorded | held | gap | audit |
|---|---|---|---|---|
| 08-24 | 80 | 40 | 40 | alert |
| 08-25 / 08-26 | 80 | 40 | 40 | silent |
| 08-27 (bought 28) | 108 | 68 | **40** | **alert — red day** |

`fund-daily` exited 1 on a day nothing new had gone wrong.

## The change

Key on the gap, **and** require that `recorded` did not shrink.

```python
standing = last.get("recorded")
if (standing is not None and want >= standing
        and standing - last.get("held", 0) == want - have):
    continue                      # same gap, nothing written off
```

**Why the second clause is not redundant — this is what closed #161.** That PR argued *"a new
unrecorded exit always changes the gap and always alerts."* **That is false.** It holds only if
`recorded` never shrinks except via fills, and `_shortfall_text` tells the operator to *"Record the
exit or reconcile by hand"* — so the module's own remediation instruction breaks its own premise:

| step | recorded | held | gap | |
|---|---|---|---|---|
| standing finding | 80 | 40 | 40 | alerts |
| operator records the missing exit, **as instructed** | 40 | | | |
| a **new** unrecorded stop-leg exit closes the rest | 40 | **0** | **40** | must alert |

Under a gap-only key that third state is silent. Requiring `want >= standing` keeps the #141 win
(80→108 suppresses) and still alerts on the write-off case (80→40 alerts).

Credit: the counter-example is #161's review agent's. The refinement was identified there too and
left explicitly unimplemented — *"REASONED only: not implemented, not run."* It is now both.

## Both new tests discriminate

Verified by reverting **only** the production change, three ways, tests untouched:

| key | `..._standing_gap_is_silent_when_the_symbol_trades_again` | `..._new_unrecorded_exit_alerts_even_when_it_leaves_the_gap_unchanged` |
|---|---|---|
| pair (before this PR) | **FAIL** | PASS |
| gap only (PR #161) | PASS | **FAIL** |
| **this change** | **PASS** | **PASS** |

Each cell was executed, not reasoned. This matters because #161's review found that PR's own
over-correction guard passed against both implementations — *a test green against the old and the new
code is not a test of the change.*

## Also addressed from #161's review

`.get("held", 0)` rather than `last["held"]` — that was the only bracket access on decoded JSON in a
module whose docstring says it never raises on data problems.

## Verification

- `make test` — **1559 passed, 1 skipped, 7 deselected** (baseline 1557; +2 new tests)
- `scripts/check_purity.py` — clean, 53 files. `orchestrator` is in `PURE_PACKAGES`; no imports and
  no wall-clock calls added
- `scripts/check_alert_codes.py` — clean, 97 files
- No `CLAUDE.md` invariant touched. The change only ever **suppresses** an alert, so it cannot
  produce an action (invariant 4 intact). No workflow-table transition touched.

## What this does NOT do — filed separately, not fixed here

When suppression applies, the standing alert's payload keeps its original absolutes, so it says
"recorded 80, held 40" while the book is 108/68. #161 called that cosmetic; it is the number a human
reconciles from. Out of scope for this diff.

## The judgement this encodes, stated so it can be overruled

A standing gap goes quiet when the fund buys more of a symbol it cannot account for. #141's author
leaned against, on the grounds that buying more of an unaccountable symbol is when you most want
telling. Measured against the actual downstream: `scripts/file_alert_issues.py:110` returns `"skip"`
when an issue already exists, so a repeat alert files nothing and comments nothing — its only effect
was `scripts/audit_day.py:148-152` reddening the day. So re-alerting delivered a red flag carrying no
new information, against the documented cost that a permanently red audit masks the next new failure.
