### PR TITLE
docs: PROGRESS.md said a watchdog ping means success; it has meant "ended" since 08-24

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -437,18 +437,22 @@ hosts means genuine duplicate orders that `client_order_id` cannot dedupe.
 | unit | fires | does |
 |---|---|---|
 | `fund-daily.timer` | 09:35 ET Mon–Fri | full trading day, self-audits |
-| `fund-pnl.timer` | 16:35 ET Mon–Fri | posts P&L $ / % vs SPY |
-| `fund-backup.timer` | 17:30 ET daily | atomic, integrity-checked snapshot |
+| `fund-pnl.timer` | 16:35 ET Mon–Fri | posts P&L $ / % vs SPY, **then writes the nightly `resolutions`, then reflects** — three `ExecStart=` lines, in that order (`ops/fund-pnl.service:19,26,32`) |
+| `fund-backup.timer` | 17:30 ET daily | atomic, integrity-checked snapshot — DB, journals and traces |
 | `fund-alert@.service` | on any of the preceding three timers failing | posts the failure to `#risk`, mentioning the operator |
-| healthchecks.io `fund-daily` | **when a 09:35 ping does not arrive** | alerts `#risk` + email at 10:20 ET |
+| healthchecks.io `fund-daily` | **when a 09:35 ping does not arrive, or arrives non-zero** | alerts `#risk` + email at 10:20 ET |
 
 The watchdog is off-box on purpose: a dead droplet cannot run its own. It is fed
-by `ExecStartPost` on `fund-daily.service`, so a ping means the day *completed*;
-the `-` prefix is fail-safe in the right direction — a failed ping cannot fail
-the trading day it reports on, and a ping that never lands makes the watchdog
-alert. Errors there can only cause a false alarm, never silence. The check must
-be in **cron** mode (`35 9 * * 1-5`); the default simple period mode would make
-Friday's ping set Saturday's deadline and page every weekend.
+by **`ExecStopPost=`** on `fund-daily.service` (`:57`) — **not `ExecStartPost=`**,
+which runs only on success and therefore made a failed run and a powered-off
+droplet look identical, both silent. `${EXIT_STATUS}` travels with the ping, so
+the watchdog can tell them apart (`d955a68`, 2026-08-24). A ping therefore means
+the day *ended*, not that it succeeded; the status says which. The `-` prefix is
+fail-safe in the right direction — a failed ping cannot fail the trading day it
+reports on, and a ping that never lands makes the watchdog alert. Errors there
+can only cause a false alarm, never silence. The check must be in **cron** mode
+(`35 9 * * 1-5`); the default simple period mode would make Friday's ping set
+Saturday's deadline and page every weekend.
 
 The timezone is pinned **in the `OnCalendar` expression** as well as on the
 host, so the schedule survives a host timezone change. `Persistent=false`
@@ -515,6 +519,16 @@ either.
 | 2026-08-19 | clean run; **found the NVDA stop had expired at the 08-17 bell** — two sessions unprotected, never breached; stop re-placed by hand at 11:46 PDT |
 | 2026-08-19 | the `news` seat's first live signals asserted "No news published" on a day with 30 articles — zero-width query, and a charter that licensed it (#6) |
 | 2026-08-20 | missing-stop class closed: the gate requires `gtc`, and the day asserts every position is protected (`51bc7eb`) — leg inheritance and leg visibility both measured live |
+| 2026-08-20 | **first decision the fund could not execute** — NVDA sell 40 approved, ticket `c0a9ae97` expired: a full-size stop reserves the position |
+| 2026-08-20 | improvement loops live in production — traces per seat turn, `charter_version` + `model_id` on every row, a daily scorecard (PR #7) |
+| 2026-08-20 | one `requirements.lock` for local, CI and the droplet; 20 packages had differed, `mcp` among them (`78e2174`) |
+| 2026-08-20 | the Critic seat merged — advisory on trades, blocking at G1, eval-gated; **not wired into the daily cycle** (PRs #21, #22) |
+| 2026-08-21 | the hand-placed NVDA stop, resized to 40, **filled at 214.85** — position 80 → 40. This is the origin of the shortfall #141 is still reconciling |
+| 2026-08-21 | the gate's account preconditions get a pinned baseline; an unreadable baseline stops the day (PR #31) |
+| 2026-08-24 | `assert_positions_accounted` fires for the first time: records say 80, broker holds 40 — still unreconciled (#141 Layer 1) |
+| 2026-08-24 | alerts carry stable codes and can be filed as issues; the watchdog can tell a dead box from a failed run (PRs #47, #48) |
+| 2026-08-25 | an external audit files **#38–#46**, two critical; open work moves onto the board (**#49**) |
+| 2026-08-28 | the accounting alert stops re-firing when a symbol with a standing gap trades again — dedup keys on the gap, and only when nothing was written off (PR #176, #141 Layer 2) |
 
 ### The stop-leg shape the broker never accepted
 


### PR DESCRIPTION
Two factual corrections to `PROGRESS.md`, plus the milestone history that #164 took with it when I
closed it. Docs only.

## 1. The watchdog line was wrong, and wrong in the direction that matters

`PROGRESS.md` said:

> It is fed by `ExecStartPost` on `fund-daily.service`, so a ping means the day *completed*

`d955a68` (2026-08-24, *"the watchdog could not tell a dead box from a failed run"*) changed that to
`ExecStopPost=`, for exactly the reason the old form was unsafe. Verified at `origin/master`:

| | |
|---|---|
| `ops/fund-daily.service:57` | `ExecStopPost=-/usr/bin/curl … ${HC_PING_URL}/${EXIT_STATUS}` |
| `ops/fund-daily.service:36` | `# NOT ExecStartPost, which runs only on success. Under that form a failed run…` |

The unit file's own comment contradicts the doc. **A reader of the old text believes a ping means the
day succeeded** — it means the day *ended*, and `${EXIT_STATUS}` says which. That is the difference
between a silent failure and a reported one, on the alert path that covers the whole trading day.

## 2. Two table rows had drifted

- `fund-pnl.timer` — described as "posts P&L $ / % vs SPY". It runs **three** `ExecStart=` lines
  (`ops/fund-pnl.service:19,26,32` — `close_pnl.py`, `resolve_day.py`, `reflect_day.py`).
- healthchecks — described as firing when a ping does not arrive. It also fires when one **arrives
  non-zero**, which is the whole point of `d955a68`.

## 3. Milestones stopped at 2026-08-20

Rows for 08-20 → 08-25 were written on `docs/progress-2026-08-25`. **I closed its PR (#164) earlier
today as superseded by #168** — but #168 only rewrote the *Status* section, so this history was retired
with the PR instead of landed. That is the failure mode where "superseded" settles the change and
quietly drops the content.

Among the restored rows:

> `| 2026-08-21 | the hand-placed NVDA stop, resized to 40, **filled at 214.85** — position 80 → 40 |`

**That is the origin of the shortfall #141 is still reconciling**, and `master` had lost it. I have
added the pointer to #141 on that row and on the 08-24 row, and a new 08-28 row for PR #176.

## Provenance

The 08-20 → 08-25 rows are carried from `docs/progress-2026-08-25` as its author wrote them; I did not
re-verify each claim against git history. The two corrections in §1 and §2 **are** verified, at the ops
files cited. Flagged so the two are not read as equally checked.

## Verification

`make test` 1559 passed, 1 skipped, 7 deselected · `check_purity.py` clean (53 files). Docs-only diff:
23 insertions, 9 deletions in one file.

Once this lands, `docs/progress-2026-08-25` holds nothing master lacks and can be deleted.
