### PR TITLE
docs: the alert filer is hand-run, so an alert becomes an issue only when a human runs it

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -454,6 +454,16 @@ can only cause a false alarm, never silence. The check must be in **cron** mode
 (`35 9 * * 1-5`); the default simple period mode would make Friday's ping set
 Saturday's deadline and page every weekend.
 
+**Nothing else is scheduled, and one thing that looks scheduled is not.**
+`scripts/file_alert_issues.py` turns alert codes into GitHub issues, but no
+unit, timer, Makefile target or CI job invokes it, and `--apply` is opt-in
+(`:157-158`) so a bare run is a dry run. **An alert reaches Slack unattended and
+becomes a tracked issue only when a human runs the filer.** That also means a
+repeat of an already-filed alert changes nothing on GitHub: the filer returns
+`skip` when an open issue with the same `(code, ticker)` labels exists
+(`:110`), so a re-alert's only effect is reddening the day audit
+(`scripts/audit_day.py:148-152`).
+
 The timezone is pinned **in the `OnCalendar` expression** as well as on the
 host, so the schedule survives a host timezone change. `Persistent=false`
 reproduces the old plists' `RunAtLoad=false`: a day starts because the market


### PR DESCRIPTION
Last of the content recovered from `docs/progress-2026-08-25` (PR #164, closed by me as superseded by #168 — which only rewrote the Status section).

`PROGRESS.md`'s **What runs unattended** lists the timers and stops, which reads as a complete picture of automation. `scripts/file_alert_issues.py` looks like part of that path and is not. Verified at `origin/master`, not carried over on trust:

- **No invoker.** `git grep -l file_alert_issues -- ops/ Makefile scripts/ .github/` returns only `check_alert_codes.py` (a lint that reads the name) and the script itself. No unit, timer, target or CI job runs it.
- **Dry run by default.** `--apply` is opt-in, `:157-158`: *"actually file; without it this is a dry run"*.

So an alert reaches Slack unattended and becomes a tracked issue **only when a human runs the filer**.

Also records the fact that carried the #141/#176 dedup argument: the filer returns `skip` when an open issue with the same `(code, ticker)` labels already exists (`:110`), so a **repeat** alert files nothing and comments nothing — its only downstream effect is `scripts/audit_day.py:148-152` reddening the day. That is why suppressing a repeat costs no information, and it was previously written down nowhere.

`make test` 1559 passed, 1 skipped, 7 deselected. Docs only.

After this, `docs/progress-2026-08-25` holds nothing master lacks and can be deleted.