### PR TITLE
fix: drop an invalid \$ escape from a test docstring

### DIFF
--- a/tests/test_critic_g1_job.py
+++ b/tests/test_critic_g1_job.py
@@ -334,7 +334,7 @@ def test_a_cap_that_exactly_drains_the_queue_raises_no_alert(db):
 
 def test_the_nightly_cap_is_derived_not_inherited_from_reflect(db):
     """reflect's MAX_TURNS_PER_NIGHT=25 is sized for one turn per resolved
-    decision. Inheriting it here would ask for 100 minutes and \$18.75 of worst
+    decision. Inheriting it here would ask for 100 minutes and $18.75 of worst
     case from the LAST leg of a unit whose whole budget is 30 minutes — i.e.
     would guarantee this leg is cut by the guillotine.
 


### PR DESCRIPTION
One character. Kept off #171's branch deliberately — a reviewer scanning the deepest lane on the board shouldn't have to work out why a #169 test file is in the diff.

## What

`tests/test_critic_g1_job.py:337` had `\$18.75` inside a docstring. `$` needs no escaping in Python, so the backslash was never doing anything; Python warns that the sequence is invalid and will stop working. Dropped rather than doubled or made raw.

Residue of #169, which is mine.

## Why it's worth a PR

Test output should be pristine. A tolerated warning is where the next real one hides — and this one was loud enough to surface only because I happened to run the file directly while verifying something else.

## Instrument

Swept the whole repo by compiling every `.py` under `warnings.catch_warnings` and collecting `SyntaxWarning`, rather than grepping for `\$` — grep would only have found the sequence I already knew about, and could not have told me whether it was the only one.

- Before: **1** repo-wide, this one.
- After: **0**.

`tests/test_critic_g1_job.py` — 33 passed, output clean.