### PR TITLE
docs: Status clause and issue ref on the deterministic-order-params design

### DIFF
--- a/docs/superpowers/specs/2026-08-28-deterministic-order-params-design.md
+++ b/docs/superpowers/specs/2026-08-28-deterministic-order-params-design.md
@@ -1,7 +1,8 @@
 # The exec seat stops constructing order parameters
 
-**Date** 2026-08-28 · **Branch** TBD (off `master`) · **Issue** none yet — filed from a
-question, not from the board
+**Date:** 2026-08-28 · **Status:** derived design, not canonical. Defers to `specs/design.md`,
+`specs/contracts.md`, `charters/exec.md`, and `CLAUDE.md`; where this document appears to extend
+them, the canonical file must be edited first (by human commit). **Issue:** #174.
 
 ## The problem
 


### PR DESCRIPTION
One header, on a design doc already living on `master`.

`docs/superpowers/specs/2026-08-28-deterministic-order-params-design.md` carried no `Status:` clause, so it read as canonical when it is not. And its `**Issue** none yet — filed from a question, not from the board` is false: **#174** is open and is exactly this document's subject. Left alone, the next reader files a duplicate — and #174's own body says it was filed *because* the doc carried "none yet", so this closes a loop the issue already flagged.

```
-**Date** 2026-08-28 · **Branch** TBD (off `master`) · **Issue** none yet — filed from a
-question, not from the board
+**Date:** 2026-08-28 · **Status:** derived design, not canonical. Defers to `specs/design.md`,
+`specs/contracts.md`, `charters/exec.md`, and `CLAUDE.md`; where this document appears to extend
+them, the canonical file must be edited first (by human commit). **Issue:** #174.
```

The deferral list was derived from what the body actually cites, not copied from the sibling: `specs/design.md` and `charters/exec.md` throughout, `specs/contracts.md` once (the §4 `list_open_tickets` row), `CLAUDE.md` in Non-goals. `specs/acceptance.md` and the regression-ratchet doc are cited too but only for test procedure, not as canon this design extends, so they are out.

The `**Branch** TBD` field is dropped rather than updated: neither sibling document carries one, no implementation branch exists, and the doc's own Open section already says the branch is named after the issue when work starts. A stale placeholder would decay exactly the way `Issue: none yet` just did.

Body untouched — no argument, no `file:line` citation changed. Several of those citations are 41 commits old and may have drifted; auditing them is not this change.

## Incidental finding: `ratify-resident-seats` is redundant

This started as an attempt to land two commits parked on `ratify-resident-seats`. They do not need landing: **both spec files are already on `master`, byte-identical.** The branch's commits are content-duplicates that reached master by another route, so `git log origin/master..ratify-resident-seats` reports two commits while `git rebase` drops both as *"patch contents already upstream"* — SHA-difference, not content-difference.

That branch can be deleted. It is fully pushed, 41 commits behind, and carries nothing master lacks.

## Verification

`make test` → **1764 passed, 1 skipped, 7 deselected**, run in the branch worktree after rebasing onto `5d5c1d6`. Documentation-only change; the suite is reported because it was run, not because it is evidence about a header.

---

## Landed by the 2026-09-12 orphan-sweep lane

**Reviewer:** the orphan-sweep lane's review subagent (session `lane orphan sweep overseer`), Spec axis against `origin/master` = `e8d4ce4`. Verdict: **APPROVE WITH NOTES**, none blocking.

- Demonstrated: all four deferred-to files exist on master; the clause matches `specs/INDEX.md`'s derived-tier rule and the sibling `2026-08-28-resident-seats.md` header; #174's body links this file by path; the doc genuinely proposes canonical edits (`:80-82` contracts §4 row rewritten, `:89-91` `charters/exec.md` v5), so "must be edited first" is literal, not defensive.
- Correction to the original body (description defect, not a diff defect): this was **not** "the only file in that directory without a `Status:` clause" — 9 of 22 lack one, including `2026-08-19-missing-stop-design.md` with the same `Date · Branch` template. The claim is struck above.
- Follow-ups, not in this PR (a land lane does not extend a branch): the doc's Open section at `:198` still says "no issue exists yet" beneath a header that says #174; `specs/INDEX.md`'s derived-designs table lists neither 2026-08-28 document.
- The `ratify-resident-seats` redundancy claim was independently re-verified by the sweep (blob `cf26d6de` for this file and `71e5397d` for `resident-seats.md`, identical on `0036b9b` and `origin/master`); the obituary goes on #170/#174. The ref stays until Benjamin moves the root checkout off it.

Re-verified: `make test` on a local merge of this branch onto `e8d4ce4` → 1824 passed, 1 skipped, 10 deselected.

https://claude.ai/code/session_016Y5fp1VYGbMYatypWXCr59