### PR TITLE
docs: Phase 2b (b) implementation plan — reflections reach the PM journal (#205)

### DIFF
--- a/docs/superpowers/plans/2026-09-02-phase-2b-b-reflections-into-journal.md
+++ b/docs/superpowers/plans/2026-09-02-phase-2b-b-reflections-into-journal.md
@@ -4,65 +4,79 @@
 
 **Goal:** Close `specs/improvement.md` §8 (b) — the journal half of #57: a reflection written by the nightly reflect turn is projected into the deciding seat's journal (the PM's), through `state/journal.py:append_entry` only, so the next morning's `journal` brief section carries the resolution's frame and prose.
 
-**Architecture:** One pure projection function in `orchestrator/reflect.py` — a windowed sweep over `resolutions.reflection IS NOT NULL`, idempotent by content marker — called from `scripts/reflect_day.py`'s `finally` block beside the drain, so whatever was written gets journaled even on a broken night. No DDL, no new tool, no charter change, no config. The Slack-thread half of #57 stays deferred (design.md §3, ruled in #204's amendment) and is explicitly not here.
+**Architecture:** One pure projection function in `orchestrator/reflect.py`: an **unwindowed** sweep over `resolutions.reflection IS NOT NULL`, idempotent by a **code-built, line-anchored marker** (`— reflection · {decided} · {ticker}`), writing **one aggregated section per sweep** under a header (`## {night} · reflections`) that can never collide with `run_close`'s `## {date}` idempotence check. Called from `scripts/reflect_day.py`'s `finally`, guarded, beside the drain. No DDL, no new tool, no charter change, no config, no new alert. The Slack-thread sink (#57's other half) stays deferred (design.md §3, #204's amendment) and is not here.
+
+Three design choices, each an answer to a demonstrated failure from this plan's first review:
+
+1. **Unwindowed sweep.** The turn loop's `REFLECT_LOOKBACK_DAYS` window exists because *turns cost money*; journal appends are free. A windowed sweep created a silent permanent-loss class (a reflection written, its projection failing, the window moving past it — demonstrated). Unwindowed, any later fire catches up, and the deploy-day backfill is bounded by the fund's whole history (38 decisions ever). The marker check is what bounds work, not a date.
+2. **Line-anchored synthetic marker, not a frame substring.** A whole-file substring scan on the frame's first line was demonstrated suppressible by prose that quotes another decision's frame — which seats naturally do. The marker is a string no seat ever sees (frames don't contain it), matched only as a complete line (`re.M`), and unique per decision (`decisions` UNIQUE `(run_date, ticker)`, `state/schema.sql:63`; `resolutions.decision_id` UNIQUE, `:99`). Residual: a seat that emits the exact marker line, character-for-character at line start, inside prose could still suppress — named in the docstring as accepted, since prose never legitimately contains the `— reflection · ` prefix.
+3. **One section per sweep, header `## {night} · reflections`.** `orchestrator/daily.py:430-438`'s `_append_entry_once` checks `f"## {run_date}\n" in file` — a bare-dated reflections section written by the 16:35 job before a crashed trading day resumes would make `run_close` skip the PM's decision line for that day, forever (demonstrated mechanism). The ` · reflections` suffix means neither writer's check can match the other's sections. Aggregation also keeps a multi-reflection night from evicting the PM's own daily record out of the brief's 3-section `journal` window (`JOURNAL_ENTRIES = 3`, `fund_server.py`).
 
 **Tech Stack:** Python 3.12, existing `state/journal.py` and `orchestrator/reflect.py`, pytest. No new dependencies.
 
 ## Global Constraints
 
 - **Journals are written only through `state/journal.py`** (CLAUDE.md "Do NOT"; `improvement.md` §0.4: append-only, nothing rewrites history).
-- **`orchestrator/` is purity-linted**: no LLM imports, no wall clock. The projection takes its window bounds and dates as arguments; the caller computes them.
+- **`orchestrator/` is purity-linted**: no LLM imports, no wall clock. (`state.journal` is importable there — `orchestrator/daily.py:29` already does, lint clean.)
 - **Default is no-change / the night continues** (invariant 4): a projection failure must not lose the drain, the wrote-nothing rollup, or the night's exit code.
-- **No per-run values in prompts**: journals are injected into prompts, so the journal text must carry **no `decision_id`** — the idempotence marker is the frame's own first line (`TICKER · run_date · action qty (status)`), which is already prompt-safe.
+- **No per-run values in prompts**: journals are injected into prompts, so no `decision_id` (or any surrogate id) may enter the journal text. The marker is built from `run_date` and `ticker` — both already in the frame.
 - **Acceptance item (b)** (`specs/acceptance.md` Phase 2b): "after resolve + reflect, the next morning's `journal` section for the seat that made the decision (the PM) contains that resolution's frame and prose, appended via `state/journal.py:append_entry` only."
-- **PR body: no closing keyword adjacent to any issue number** (PR #210 closed #205 on a negated sentence). #57 and #205 both stay open — #57's Slack half is undelivered, and whether it survives at all is Benjamin's call.
+- **PR body: no closing keyword adjacent to any issue number** (PR #210 closed #205 on a negated sentence). #57 and #205 both stay open.
 - Baseline at branch point `64e1a0e`: **1808 passed, 1 skipped**. `make test` before every commit; no Co-Authored-By trailer; conventional commits; surgical diffs.
 
 ## File structure
 
 | Path | Responsibility | Action |
 |---|---|---|
-| `orchestrator/reflect.py` | `DECIDING_SEAT`, `journal_reflections(conn, journals_root, *, window, run_date) -> dict` | Modify (append) |
-| `scripts/reflect_day.py` | `journals_root_from(environ)`, `reflect_and_log(..., journals_root=None)` calls the sweep in `finally`, guarded; `main()` threads it | Modify |
-| `specs/design.md` §3 Nightly 1 row | says the journal projection exists; threads still deferred | Modify |
-| `specs/acceptance.md` | tick item (b) | Modify |
-| `tests/test_reflect.py` | the projection: content, marker idempotence, window bound, unwritten skipped | Modify (append) |
-| `tests/test_reflect_job.py` | wiring: journaled on a written turn, `finally` survives a mid-loop raise, unbound root is a named skip, morning brief carries it | Modify (append) |
+| `orchestrator/reflect.py` | `DECIDING_SEAT`, `REFLECTION_MARKER_PREFIX`, `journal_reflections(conn, journals_root, *, run_date) -> dict` | Modify (append; `from state.journal import append_entry` joins the module imports) |
+| `scripts/reflect_day.py` | `journals_root_from(environ)`, `reflect_and_log(..., journals_root=None)` calls the sweep in `finally` (after the rollup append, before the drain), guarded; `main()` threads it | Modify |
+| `agents/tools/fund_server.py:481-482` | `handle_submit_reflection` docstring: the journal-projection deferral note becomes true history, not a false present | Modify (docstring only — an orphan of this change) |
+| `specs/design.md:104` (Nightly 1 row), `specs/contracts.md:349`, `specs/acceptance.md` item (b) | say the journal projection exists; threads still deferred | Modify |
+| `tests/test_reflect.py` | the projection: content, marker idempotence, prose-quote resistance, aggregation, backfill, blank guard | Modify (append) |
+| `tests/test_reflect_job.py` | wiring: journaled on a written night, `finally` placement pinned by a propagating frame error, drain preserved under a projection failure (asserted on a queued alert's `posted_at`), unbound root named, morning brief carries it | Modify (append) |
 
 ## Scope check
 
-One subsystem, one lane. Deliberately not here: the Slack-thread sink (#57's other half — deferred by `specs/design.md` §3 as amended in #204; whether it survives at all is a decision for Benjamin, recorded in the PR body); any journal-growth control (that is (c), lessons distillation); backfill beyond the reflect job's own `REFLECT_LOOKBACK_DAYS` window (an unbounded backfill has the same shape as the unbounded turn-buying the job already refuses).
+One subsystem, one lane. Deliberately not here: the Slack-thread sink (#57's other half — deferred by `specs/design.md` §3; whether it survives at all is Benjamin's decision, recorded in the PR body); journal-growth control ((c), lessons distillation); any new alert code (the unwindowed sweep removes the aged-out class the first draft would have needed one for).
 
 ---
 
 ### Task 1: `journal_reflections` — the projection
 
 **Files:**
-- Modify: `orchestrator/reflect.py` (append after `store_reflection`)
+- Modify: `orchestrator/reflect.py` (append after `store_reflection`; add `import re` and `from state.journal import append_entry` to the module imports — note the module currently imports nothing from `state`, so this is a new import line, lint-clean per `orchestrator/daily.py:29`'s precedent)
 - Test: `tests/test_reflect.py` (append)
 
 **Interfaces:**
 - Consumes: `state.journal.append_entry(root, seat, run_date, text)`; `resolutions` + `decisions` rows.
-- Produces: `DECIDING_SEAT = "pm"`; `journal_reflections(conn, journals_root, *, window: tuple[str, str], run_date: str) -> dict` with keys `journaled: int`, `already: int`. `window` is `[start_iso, end_iso)` over `resolved_at` — the caller passes the same bounds `due_reflections` uses. Raises nothing on an empty window or an empty table.
+- Produces: `DECIDING_SEAT = "pm"`; `REFLECTION_MARKER_PREFIX = "— reflection · "`; `journal_reflections(conn, journals_root, *, run_date: str) -> dict` with keys `journaled`, `already`, `blank` (ints). One `append_entry` call per invocation at most (the aggregated section); zero when nothing is new.
 
 - [ ] **Step 1: Write the failing tests**
 
-Append to `tests/test_reflect.py` (it already imports `store_reflection` and builds resolved decisions; follow its fixture style — if the file lacks one, use the snippet's own `_resolved` helper modeled on `tests/test_reflect_job.py:41-70`):
+Append to `tests/test_reflect.py` (the file has no bare-connection fixture — its `resolved` fixture builds a full scenario — so the snippet brings its own):
 
 ```python
 # --- the journal projection (#57's journal half; improvement.md §8 (b)) ------
 
-from orchestrator.reflect import (DECIDING_SEAT, journal_reflections,
-                                  reflection_frame)
+import re
 
-WINDOW = ("2026-08-18T00:00:00+00:00", "2026-08-26T00:00:00+00:00")
+from orchestrator.reflect import (DECIDING_SEAT, REFLECTION_MARKER_PREFIX,
+                                  journal_reflections)
+
 NIGHT = "2026-08-25"
+
+
+@pytest.fixture
+def conn(tmp_path):
+    c = connect(tmp_path / "fund.sqlite")
+    yield c
+    c.close()
 
 
 def _reflected(conn, *, ticker="NVDA", run_date="2026-08-18",
                resolved_at="2026-08-25T20:35:05+00:00", prose="cut earlier"):
-    """A resolved decision whose reflection is already stored — the state
-    the projection consumes. Returns (decision_id, stored_text)."""
+    """A resolved decision whose reflection is already stored — the state the
+    projection consumes. Returns (decision_id, stored_text)."""
     cur = conn.execute(
         "INSERT INTO decisions (run_date, ticker, action, qty, thesis,"
         " invalidation, status, created_at) VALUES"
@@ -81,81 +95,141 @@ def _reflected(conn, *, ticker="NVDA", run_date="2026-08-18",
         (did,)).fetchone()["reflection"]
 
 
-def test_projection_appends_frame_and_prose_to_the_pm_journal(conn, tmp_path):
+def _pm_journal(root):
+    return (root / f"{DECIDING_SEAT}.md").read_text()
+
+
+def test_projection_appends_frame_and_prose_under_a_reflections_header(
+        conn, tmp_path):
     _, stored = _reflected(conn)
     root = tmp_path / "journals"
 
-    out = journal_reflections(conn, root, window=WINDOW, run_date=NIGHT)
+    out = journal_reflections(conn, root, run_date=NIGHT)
 
-    assert out == {"journaled": 1, "already": 0}
-    text = (root / f"{DECIDING_SEAT}.md").read_text()
-    assert f"## {NIGHT}" in text
+    assert out == {"journaled": 1, "already": 0, "blank": 0}
+    text = _pm_journal(root)
+    assert f"## {NIGHT} · reflections" in text
     assert stored in text                       # frame AND prose, verbatim
     assert "cut earlier" in text
+    # The header run_close's _append_entry_once checks for must NOT appear:
+    # a bare "## {date}\n" here would make a crash-resumed trading day skip
+    # the PM's decision line for that date, forever (orchestrator/daily.py
+    # _append_entry_once).
+    assert f"## {NIGHT}\n" not in text
 
 
-def test_projection_is_idempotent_by_the_frames_first_line(conn, tmp_path):
-    """Re-run (crash-resume, a second fire) appends nothing: the marker is
-    the frame's own first line — prompt-safe, no decision_id ever enters a
-    journal that gets injected into prompts (CLAUDE.md)."""
-    did, _ = _reflected(conn)
+def test_projection_is_idempotent_by_the_marker_line(conn, tmp_path):
+    _reflected(conn)
     root = tmp_path / "journals"
-    journal_reflections(conn, root, window=WINDOW, run_date=NIGHT)
-    before = (root / f"{DECIDING_SEAT}.md").read_text()
+    journal_reflections(conn, root, run_date=NIGHT)
+    before = _pm_journal(root)
 
-    out = journal_reflections(conn, root, window=WINDOW, run_date=NIGHT)
+    out = journal_reflections(conn, root, run_date=NIGHT)
 
-    assert out == {"journaled": 0, "already": 1}
-    assert (root / f"{DECIDING_SEAT}.md").read_text() == before
-    assert str(did) not in before               # no surrogate id in the file
+    assert out == {"journaled": 0, "already": 1, "blank": 0}
+    assert _pm_journal(root) == before
+    marker = f"{REFLECTION_MARKER_PREFIX}2026-08-18 · NVDA"
+    assert len(re.findall(rf"^{re.escape(marker)}$", before, re.M)) == 1
 
 
-def test_only_reflections_inside_the_window_are_projected(conn, tmp_path):
-    """The sweep shares due_reflections' window shape: bounded, so a deploy
-    onto years of history cannot buy an unbounded backfill (same refusal the
-    turn loop already makes)."""
-    _reflected(conn, ticker="NVDA", resolved_at="2026-08-25T20:35:05+00:00")
-    _reflected(conn, ticker="MSFT", run_date="2026-08-01",
-               resolved_at="2026-08-10T20:35:05+00:00")   # below the window
+def test_prose_quoting_another_frames_header_suppresses_nothing(
+        conn, tmp_path):
+    """The first draft's marker was the frame's first line, scanned as a
+    substring — and a reflection whose PROSE quoted another decision's frame
+    verbatim silently suppressed that decision's projection (demonstrated in
+    review). The marker is now a synthetic line seats never see; a quoted
+    frame header is inert."""
     root = tmp_path / "journals"
+    _, stored_a = _reflected(conn, ticker="NVDA")
+    journal_reflections(conn, root, run_date=NIGHT)
+    # B's prose quotes A's frame header — the exact attack that worked before.
+    _, stored_b = _reflected(
+        conn, ticker="MSFT", prose=f"unlike {stored_a.splitlines()[0]}, hold")
 
-    out = journal_reflections(conn, root, window=WINDOW, run_date=NIGHT)
+    out = journal_reflections(conn, root, run_date=NIGHT)
 
-    text = (root / f"{DECIDING_SEAT}.md").read_text()
     assert out["journaled"] == 1
-    assert "NVDA" in text and "MSFT" not in text
+    assert stored_b in _pm_journal(root)
 
 
-def test_an_unwritten_reflection_is_not_projected(conn, tmp_path):
-    """reflection IS NULL means the seat has not spoken; projecting a blank
-    would be inventing a record (invariant 4)."""
+def test_one_night_many_reflections_is_one_section(conn, tmp_path):
+    """Aggregation is load-bearing twice over: the brief's journal window is
+    JOURNAL_ENTRIES = 3 sections, so per-reflection sections would evict the
+    PM's own daily record on any 3-reflection night; and one section per
+    sweep is one append_entry call."""
+    _reflected(conn, ticker="NVDA")
+    _reflected(conn, ticker="MSFT", prose="sized too big")
+    root = tmp_path / "journals"
+
+    out = journal_reflections(conn, root, run_date=NIGHT)
+
+    text = _pm_journal(root)
+    assert out["journaled"] == 2
+    assert text.count("## ") == 1
+    assert "NVDA" in text and "MSFT" in text and "sized too big" in text
+
+
+def test_the_sweep_is_unwindowed_so_a_missed_fire_catches_up(conn, tmp_path):
+    """The turn loop is windowed because turns cost money; appends are free.
+    A reflection written long ago (a projection failure, a deploy onto
+    history) is journaled by the NEXT sweep, whenever it runs — there is no
+    aged-out class here, which is the point."""
+    _reflected(conn, run_date="2026-07-06",
+               resolved_at="2026-07-13T20:35:05+00:00")   # weeks old
+
+    out = journal_reflections(conn, tmp_path / "journals", run_date=NIGHT)
+
+    assert out["journaled"] == 1
+    assert "2026-07-06" in _pm_journal(tmp_path / "journals")
+
+
+def test_blank_or_unwritten_reflections_are_not_projected(conn, tmp_path):
+    """reflection IS NULL means the seat has not spoken; a whitespace-only
+    text (unreachable through store_reflection today, but a DB is writable
+    by more than one future path) is counted, not appended and not crashed
+    on — projecting a blank would invent a record (invariant 4)."""
     conn.execute(
         "INSERT INTO decisions (run_date, ticker, action, qty, thesis,"
         " invalidation, status, created_at) VALUES"
         " ('2026-08-18','AMD','buy',10,'t','i','executed','x')")
     conn.execute(
         "INSERT INTO resolutions (decision_id, horizon_days, realized_return,"
+        " alpha_vs_spy, invalidated, reflection, resolved_at) VALUES"
+        " (last_insert_rowid(), 5, 0.01, 0.01, 0, '  ',"
+        " '2026-08-25T20:35:05+00:00')")
+    conn.execute(
+        "INSERT INTO decisions (run_date, ticker, action, qty, thesis,"
+        " invalidation, status, created_at) VALUES"
+        " ('2026-08-19','INTC','buy',10,'t','i','executed','x')")
+    conn.execute(
+        "INSERT INTO resolutions (decision_id, horizon_days, realized_return,"
         " alpha_vs_spy, invalidated, resolved_at) VALUES"
-        " (last_insert_rowid(), 5, 0.01, 0.01, 0, '2026-08-25T20:35:05+00:00')")
+        " (last_insert_rowid(), 5, 0.01, 0.01, 0, '2026-08-25T20:35:06+00:00')")
     conn.commit()
 
-    out = journal_reflections(conn, tmp_path / "journals",
-                              window=WINDOW, run_date=NIGHT)
+    out = journal_reflections(conn, tmp_path / "journals", run_date=NIGHT)
 
-    assert out == {"journaled": 0, "already": 0}
+    assert out == {"journaled": 0, "already": 0, "blank": 1}
     assert not (tmp_path / "journals" / f"{DECIDING_SEAT}.md").exists()
 ```
 
-If `tests/test_reflect.py` has no `conn` fixture, add one matching `tests/test_reflect_job.py`'s `db` fixture (`connect(tmp_path / "fund.sqlite")`), named `conn`.
-
 - [ ] **Step 2: Run them to verify they fail**
 
-Run: `.venv/bin/python3 -m pytest tests/test_reflect.py -k journal -v`
+Run: `.venv/bin/python3 -m pytest tests/test_reflect.py -k "projection or reflections or sweep or blank" -v`
 Expected: FAIL at import — `ImportError: cannot import name 'DECIDING_SEAT'`.
 
 - [ ] **Step 3: Implement**
 
-Append to `orchestrator/reflect.py`:
+In `orchestrator/reflect.py`, add to the module imports:
+
+```python
+import re
+from pathlib import Path
+
+from state.journal import append_entry
+```
+
+Append after `store_reflection`:
 
 ```python
 # The seat whose journal a reflection lands in. `decisions` carries no seat
@@ -164,68 +238,86 @@ Append to `orchestrator/reflect.py`:
 # guess; this constant is where that change arrives.
 DECIDING_SEAT = "pm"
 
-# Every written reflection in the window, with the fields the journal entry
-# needs. Ordered for determinism; the reflection text already carries the
-# frame first (store_reflection stores them together).
+# The idempotence marker's prefix. A SYNTHETIC line, deliberately not the
+# frame's first line: seats quote frames in prose (they are handed one every
+# reflect turn), and a substring scan on a frame header was demonstrated
+# suppressible by exactly such a quote. No seat ever sees this prefix, and
+# the check below matches it only as a complete line — the residual (prose
+# emitting the exact marker line, character-for-character at line start) is
+# accepted and would take deliberate construction, not a natural quote.
+REFLECTION_MARKER_PREFIX = "— reflection · "
+
+# Every written reflection, with the decision fields the marker is built
+# from. Unwindowed on purpose — see journal_reflections. Ordered for a
+# deterministic section body.
 _WRITTEN = """
-SELECT r.decision_id, r.reflection
+SELECT r.decision_id, r.reflection, d.run_date AS decided, d.ticker
   FROM resolutions r
   JOIN decisions d ON d.id = r.decision_id
  WHERE r.reflection IS NOT NULL
-   AND r.resolved_at >= ? AND r.resolved_at < ?
  ORDER BY r.decision_id
 """
 
 
-def journal_reflections(conn, journals_root, *, window: tuple[str, str],
-                        run_date: str) -> dict:
-    """Project every written reflection in `window` into the deciding seat's
-    journal (#57's journal half; improvement.md §8 (b)). Returns
-    {"journaled": n, "already": n} for the job log.
+def journal_reflections(conn, journals_root, *, run_date: str) -> dict:
+    """Project every written, not-yet-journaled reflection into the deciding
+    seat's journal (#57's journal half; improvement.md §8 (b)). Returns
+    {"journaled": n, "already": n, "blank": n} for the job log.
 
-    Idempotent by content, not by memory: an entry is skipped when the
-    reflection's first line — the frame's own header, "TICKER · run_date ·
-    action qty (status)" — already appears in the journal file. That marker
-    is prompt-safe (journals are injected into prompts; a decision_id there
-    would put a per-run value in a prompt, CLAUDE.md), and it is what makes
-    a crash-resume, a re-fire, or the sweep-plus-turn overlap append each
-    reflection exactly once.
+    UNWINDOWED, unlike the turn loop above it: the lookback window exists
+    because turns cost money, and appends cost nothing. A windowed sweep
+    would mint a silent-loss class — a reflection written, its projection
+    failing once, the window moving past it — with no alarm anywhere. The
+    marker check is what bounds the work instead: only unjournaled rows
+    append, and the whole history is a few hundred rows a year.
 
-    Windowed like due_reflections, for the same reason: a deploy onto years
-    of history must not buy an unbounded backfill. A reflection written
-    before this shipped and older than the window is not journaled — the
-    same honest gap the turn loop's own aging-out already accepts, and it
-    is alerted there, not here.
+    Idempotent by a code-built marker line, "— reflection · {decided} ·
+    {ticker}", matched only as a complete line (re.M). (decided, ticker) is
+    unique per decision — decisions UNIQUE (run_date, ticker), resolutions
+    one per decision — and prompt-safe: both values already appear in the
+    frame, and no decision_id enters the journal (CLAUDE.md: journals are
+    injected into prompts).
 
-    Appends through state/journal.py only (CLAUDE.md). The file is read
-    once per call for the marker check; append_entry never rewrites."""
-    from pathlib import Path
+    One aggregated section per call, under "## {run_date} · reflections".
+    The suffix is load-bearing: orchestrator/daily.py's _append_entry_once
+    keys the trading day's PM journal write on the BARE "## {date}\\n"
+    header, so a bare-dated section written here (the 16:35 job can run
+    before a crashed trading day resumes) would make run_close skip that
+    day's decision line forever. Neither writer's check can match the
+    other's sections. Aggregation also keeps a multi-reflection night from
+    evicting the PM's own daily record out of the brief's JOURNAL_ENTRIES-
+    section window.
 
-    from state.journal import append_entry
-
-    rows = conn.execute(_WRITTEN, window).fetchall()
-    out = {"journaled": 0, "already": 0}
+    Appends through state/journal.py only; the file is read once for the
+    marker scan; append_entry never rewrites (improvement.md §0.4).
+    """
+    rows = conn.execute(_WRITTEN).fetchall()
+    out = {"journaled": 0, "already": 0, "blank": 0}
     if not rows:
         return out
     path = Path(journals_root) / f"{DECIDING_SEAT}.md"
     existing = path.read_text() if path.exists() else ""
+    pieces = []
     for row in rows:
-        marker = row["reflection"].splitlines()[0]
-        if marker and marker in existing:
+        if not (row["reflection"] or "").strip():
+            out["blank"] += 1
+            continue
+        marker = f"{REFLECTION_MARKER_PREFIX}{row['decided']} · {row['ticker']}"
+        if re.search(rf"^{re.escape(marker)}$", existing, re.M):
             out["already"] += 1
             continue
-        append_entry(journals_root, DECIDING_SEAT, run_date, row["reflection"])
-        existing += f"\n## {run_date}\n{row['reflection']}\n"
+        pieces.append(f"{marker}\n{row['reflection']}")
         out["journaled"] += 1
+    if pieces:
+        append_entry(journals_root, DECIDING_SEAT,
+                     f"{run_date} · reflections", "\n\n".join(pieces))
     return out
 ```
-
-(`from state.journal import append_entry` stays inside the function to match how `orchestrator/daily.py` imports it at module level — if the module-level import is preferred, put it at the top; either passes the purity lint. Choose module level: `from state.journal import append_entry` beside the existing imports, and drop the inner imports.)
 
 - [ ] **Step 4: Run the tests and the purity lint**
 
 Run: `.venv/bin/python3 -m pytest tests/test_reflect.py -v && .venv/bin/python3 scripts/check_purity.py`
-Expected: PASS; lint clean.
+Expected: PASS, all (the file's existing 13 too); lint clean.
 
 - [ ] **Step 5: Commit**
 
@@ -243,8 +335,8 @@ git commit -m "feat(orchestrator): journal_reflections projects written reflecti
 - Test: `tests/test_reflect_job.py` (append)
 
 **Interfaces:**
-- Consumes: Task 1's `journal_reflections`; `reflect_day._window(run_date)` (the existing bounds helper); `run_day.log` pattern.
-- Produces: `reflect_and_log(conn, slack, clock, run_turn, journals_root=None)`; `journals_root_from(environ) -> Path` (mirrors `scripts/run_day.py:677`: `FUND_JOURNALS` or `ROOT / "journals"`, mkdir'd).
+- Consumes: Task 1's `journal_reflections`.
+- Produces: `reflect_and_log(conn, slack, clock, run_turn, journals_root=None)`; `journals_root_from(environ) -> Path` (mirrors `scripts/run_day.py:677-678`: `FUND_JOURNALS` or `ROOT / "journals"`, mkdir'd).
 
 - [ ] **Step 1: Write the failing tests**
 
@@ -253,7 +345,7 @@ Append to `tests/test_reflect_job.py`:
 ```python
 # --- the journal projection rides the same night (#57's journal half) --------
 
-from orchestrator.reflect import DECIDING_SEAT, reflection_frame
+from orchestrator.reflect import DECIDING_SEAT
 from orchestrator.reflect import store_reflection as _store
 
 
@@ -277,31 +369,65 @@ def test_a_written_reflection_is_journaled_the_same_night(db, tmp_path):
     assert "NVDA" in text and "+6.14%" in text          # the frame's numbers
 
 
-def test_the_projection_survives_a_mid_loop_raise(db, tmp_path):
-    """It rides the finally, beside the drain: a night where the SECOND turn
-    raises still journals the first turn's reflection — same reasoning the
-    wrote-nothing rollup already carries."""
+def test_the_projection_runs_in_the_finally_a_frame_error_proves_it(
+        db, tmp_path, monkeypatch):
+    """A run_turn raise is caught inside the loop and never reaches the
+    finally, so it cannot pin placement (first-draft mistake, demonstrated
+    in review). What DOES abort the loop is a later decision's
+    reflection_frame raising — the same abort test_the_wrote_nothing_rollup_
+    survives_a_later_frame_error models. The first decision's written
+    reflection must still be journaled on the way out."""
     _resolved(db, ticker="NVDA", resolved_at="2026-08-25T20:35:05+00:00")
-    _resolved(db, ticker="AMD", resolved_at="2026-08-25T20:36:05+00:00")
+    _resolved(db, ticker="AMD", resolved_at="2026-08-25T20:35:06+00:00")
     root = tmp_path / "journals"
-    calls = {"n": 0}
 
-    def half_writing_turn(job):
-        calls["n"] += 1
-        if calls["n"] == 2:
-            raise RuntimeError("seat session died")
-        _store(db, job["decision_id"], job["frame"], "kept my stop")
+    real_frame = reflect_day.reflection_frame
 
-    reflect_day.reflect_and_log(db, FakeSlack(), SimClock(NIGHTLY),
-                                half_writing_turn, journals_root=root)
+    def flaky_frame(conn, decision_id):
+        row = conn.execute("SELECT ticker FROM decisions WHERE id = ?",
+                           (decision_id,)).fetchone()
+        if row["ticker"] == "AMD":
+            raise sqlite3.OperationalError("database is locked")
+        return real_frame(conn, decision_id)
+    monkeypatch.setattr(reflect_day, "reflection_frame", flaky_frame)
+
+    with pytest.raises(sqlite3.OperationalError):
+        reflect_day.reflect_and_log(db, FakeSlack(), SimClock(NIGHTLY),
+                                    _writing_turn(db), journals_root=root)
 
     text = (root / f"{DECIDING_SEAT}.md").read_text()
-    assert "kept my stop" in text
+    assert "trim next time" in text and "NVDA" in text
+
+
+def test_a_projection_failure_does_not_eat_the_rollup_or_the_drain(
+        db, tmp_path, monkeypatch):
+    """Guarded like everything else in the finally. The assertion is on a
+    QUEUED alert actually reaching posted_at NOT NULL — the first draft's
+    always-true COUNT(*) assertion survived deleting the drain entirely
+    (demonstrated in review). A turn that writes nothing queues the
+    wrote-nothing rollup in the same finally; the projection raising after
+    it must not stop the drain posting it."""
+    _resolved(db, resolved_at="2026-08-25T20:35:05+00:00")
+
+    def boom(conn, root, *, run_date):
+        raise OSError("read-only filesystem")
+    monkeypatch.setattr(reflect_day, "journal_reflections", boom)
+
+    reflect_day.reflect_and_log(db, FakeSlack(), SimClock(NIGHTLY),
+                                lambda job: None,        # writes nothing
+                                journals_root=tmp_path / "journals")
+
+    drained = [r["payload"] for r in db.execute(
+        "SELECT payload FROM events WHERE kind = 'alert'"
+        " AND posted_at IS NOT NULL")]
+    assert any("reflect_turn_wrote_nothing" in t for t in drained)
+    assert db.execute("SELECT COUNT(*) c FROM events"
+                      " WHERE posted_at IS NULL").fetchone()["c"] == 0
 
 
 def test_an_unbound_journals_root_is_a_named_skip_not_a_crash(db, capsys):
-    """Tests and older callers pass no root; production always does
-    (main threads journals_root_from). Unbound is logged by name so a wiring
+    """Tests and older callers pass no root; production always does (main
+    threads journals_root_from). Unbound is logged by name so a wiring
     regression is visible in journald, and the night otherwise proceeds."""
     _resolved(db, resolved_at="2026-08-25T20:35:05+00:00")
 
@@ -310,24 +436,6 @@ def test_an_unbound_journals_root_is_a_named_skip_not_a_crash(db, capsys):
 
     assert "journals_root unbound — reflections not journaled" \
         in capsys.readouterr().out
-
-
-def test_a_projection_failure_does_not_eat_the_drain(db, tmp_path,
-                                                     monkeypatch):
-    """Guarded like everything else in the finally: a raise inside the
-    projection must not lose the drain or the night's exit (invariant 4)."""
-    _resolved(db, resolved_at="2026-08-25T20:35:05+00:00")
-
-    def boom(conn, root, *, window, run_date):
-        raise OSError("read-only filesystem")
-    monkeypatch.setattr(reflect_day, "journal_reflections", boom)
-
-    reflect_day.reflect_and_log(db, FakeSlack(), SimClock(NIGHTLY),
-                                _writing_turn(db),
-                                journals_root=tmp_path / "journals")
-    # reaching here without a raise IS the assertion; the drain ran:
-    assert db.execute("SELECT COUNT(*) c FROM events WHERE posted_at IS NOT"
-                      " NULL OR posted_at IS NULL").fetchone() is not None
 
 
 def test_journals_root_from_env_and_default(tmp_path):
@@ -363,7 +471,7 @@ Expected: FAIL — `TypeError: reflect_and_log() got an unexpected keyword argum
 
 In `scripts/reflect_day.py`:
 
-Import `journal_reflections` beside `reflection_frame`:
+Import beside `reflection_frame`:
 
 ```python
 from orchestrator.reflect import journal_reflections, reflection_frame  # noqa: E402
@@ -390,31 +498,33 @@ and add to its docstring:
 
 ```
     `journals_root` is where written reflections are projected (#57's journal
-    half, improvement.md §8 (b)) — a windowed, idempotent sweep in the
-    `finally`, beside the drain, so whatever the night managed to write is
-    journaled even when a later turn raised. Unbound (None) is a named log
-    line, not a crash: tests and older callers, never production, which
-    threads journals_root_from(environ) from main(). The sweep is guarded
-    like the drain: a projection failure (a read-only disk) must not eat the
-    rollup alert, the drain, or the night's exit code.
+    half, improvement.md §8 (b)) — an unwindowed, marker-idempotent sweep in
+    the `finally`, after the rollup append and before the drain, so whatever
+    the night managed to write is journaled even when a later frame raised.
+    Unbound (None) is a named log line, not a crash: tests and older callers,
+    never production, which threads journals_root_from(environ) from main().
+    Guarded like the drain: a projection failure (a read-only disk) loses
+    neither the rollup alert nor the drain nor the night's exit code — and
+    loses no reflection either, because the unwindowed sweep catches up on
+    any later fire.
 ```
 
-In the `finally` block, before the `drain(...)` line:
+In the `finally` block, **after** the `wrote_nothing` rollup append and **before** the `drain(...)` line:
 
 ```python
         if journals_root is None:
             log("journals_root unbound — reflections not journaled")
         else:
             try:
-                counts_j = journal_reflections(
-                    conn, journals_root, window=_window(run_date),
-                    run_date=run_date)
+                counts_j = journal_reflections(conn, journals_root,
+                                               run_date=run_date)
                 log(f"journaled {counts_j['journaled']}"
-                    f" · already {counts_j['already']}")
+                    f" · already {counts_j['already']}"
+                    f" · blank {counts_j['blank']}")
             except Exception as exc:
                 log(f"JOURNAL PROJECTION FAILED ({type(exc).__name__}:"
-                    f" {exc}) — reflections stand in the DB, journal catches"
-                    " up on the next fire")
+                    f" {exc}) — reflections stand in the DB; the unwindowed"
+                    " sweep catches up on the next fire")
 ```
 
 In `main()`, change the call to:
@@ -427,7 +537,7 @@ In `main()`, change the call to:
 - [ ] **Step 4: Run the job tests, then the full suite**
 
 Run: `.venv/bin/python3 -m pytest tests/test_reflect_job.py -v && make test`
-Expected: PASS. The existing `reflect_and_log` tests pass unchanged (the new parameter defaults to `None`, whose only effect is one log line).
+Expected: PASS. The existing `reflect_and_log` tests pass unchanged — the new parameter defaults to `None`, whose only effect is one log line, and no existing test asserts exact stdout.
 
 - [ ] **Step 5: Commit**
 
@@ -441,9 +551,21 @@ git commit -m "feat(scripts): reflect_day projects the night's reflections into 
 ### Task 3: Docs close-out and the PR
 
 **Files:**
-- Modify: `specs/design.md:104` (Nightly 1 row), `specs/acceptance.md` (item (b))
+- Modify: `agents/tools/fund_server.py:481-482`, `specs/design.md:104`, `specs/contracts.md:349`, `specs/acceptance.md` item (b)
 
-- [ ] **Step 1: `specs/design.md` Nightly 1 row**
+- [ ] **Step 1: Retire the two stale deferral notes this change falsifies**
+
+`agents/tools/fund_server.py:481-482` (`handle_submit_reflection`'s docstring) — replace the sentence deferring "a journal or Slack-thread projection of a reflection … to issue #57" with:
+
+```
+    The journal projection now rides the nightly job's sweep
+    (orchestrator/reflect.py:journal_reflections, improvement.md §8 (b));
+    the Slack-thread projection remains deferred with #57.
+```
+
+`specs/contracts.md:349` — append to the "scoped to the `resolutions.reflection` column only" sentence: ` (the journal projection landed later, from the same night's job — `specs/improvement.md` §8 (b); the tool itself still writes the column only)`.
+
+- [ ] **Step 2: `specs/design.md` Nightly 1 row**
 
 Replace, in the §3 cadence table's Nightly 1 row, the fragment:
 
@@ -454,43 +576,44 @@ the `reflect` seat writes one reflection per decision → `resolutions.reflectio
 with:
 
 ```markdown
-the `reflect` seat writes one reflection per decision → `resolutions.reflection`, and the same job projects it into the PM's journal via `state/journal.py` (#57's journal half, `specs/improvement.md` §8 (b)); the original Slack threads stay deferred
+the `reflect` seat writes one reflection per decision → `resolutions.reflection`, and the same job's sweep projects it into the PM's journal via `state/journal.py` (#57's journal half, `specs/improvement.md` §8 (b)); the original Slack threads stay deferred
 ```
 
-- [ ] **Step 2: Tick acceptance item (b)**
+- [ ] **Step 3: Tick acceptance item (b)**
 
 `specs/acceptance.md` Phase 2b: `- [ ] Reflections reach the brief (#57): …` → `- [x]`, appending ` — journal sink only; the Slack-thread sink stays deferred (design.md §3).`
 
-- [ ] **Step 3: Full suite, then commit**
+- [ ] **Step 4: Full suite, then commit**
 
 Run: `make test`
 Expected: PASS.
 
 ```bash
-git add specs/design.md specs/acceptance.md
-git commit -m "docs: Nightly 1 projects reflections into the PM journal; acceptance (b) ticked"
+git add agents/tools/fund_server.py specs/design.md specs/contracts.md specs/acceptance.md
+git commit -m "docs: the nightly sweep projects reflections into the PM journal; acceptance (b) ticked"
 ```
 
-- [ ] **Step 4: Open the PR**
+- [ ] **Step 5: Open the PR**
 
 Title: `feat: Phase 2b (b) — reflections reach the PM journal (#205)`. Body:
 
 1. The §8 (b) sentence and acceptance item (b).
 2. **What this deliberately does not do:** the Slack-thread sink — #57's other half. `design.md` §3 defers it with no owner; whether it survives at all (a per-decision thread post is a VISION-era question) is Benjamin's decision. #57 stays open until he rules; a comment on #57 records the split.
-3. **No expected-value changes to existing tests.** No DDL, no tool, no charter, no config.
-4. Deploy note: code-only — droplet pull suffices; **no unit change** (per #220, that is the check that would have been skipped: `cmp` still run, expected SAME on all seven).
-5. The issue-number rule: `#205` and `#57` referenced with no closing keyword anywhere in the body.
+3. **Design notes a reviewer should check:** the three review-driven choices from the plan header (unwindowed sweep; synthetic line-anchored marker; ` · reflections` header suffix vs `_append_entry_once`), each with its demonstrated failure. Name the accepted residual (a deliberately constructed marker line in prose).
+4. **No expected-value changes to existing tests.** No DDL, no tool, no charter, no config, no new alert code.
+5. Deploy note: code-only — droplet pull suffices; **no unit change** (run #220's `cmp` drift check anyway, expected SAME on all seven). First post-deploy 16:35 fire backfills every historical written reflection into `journals/pm.md` in one section — bounded by the fund's whole history, and the next morning's PM brief will show it.
+6. The issue-number rule: `#205` and `#57` referenced with no closing keyword anywhere in the body.
 
-Then comment on #57: "The journal half landed with Phase 2b (b) (PR #<n>): written reflections are swept into `journals/pm.md` nightly, windowed and idempotent. The Slack-thread half remains deferred per design.md §3 — whether it survives at all is Benjamin's call; this issue stays open for that decision."
+Then comment on #57: "The journal half landed with Phase 2b (b) (PR #<n>): written reflections are swept into `journals/pm.md` nightly — unwindowed, idempotent by a code-built marker. The Slack-thread half remains deferred per design.md §3 — whether it survives at all is Benjamin's call; this issue stays open for that decision."
 
 ---
 
 ## Self-review
 
-**Spec coverage:** acceptance (b)'s every clause has an assertion — frame and prose in the journal (Task 1 test 1, Task 2 test 1), the deciding seat is the PM (`DECIDING_SEAT`, asserted by file path), via `append_entry` only (the implementation's only write; the idempotence test asserts byte-identical on re-run, which a rewrite would break), and "the next morning's `journal` section" on the rendered brief (Task 2's last test, through the real handler). §0.4 append-only: the marker check reads, `append_entry` appends, nothing truncates.
+**Spec coverage:** acceptance (b)'s every clause — frame and prose (Task 1 test 1, Task 2 test 1, both on the stored text verbatim), the PM (`DECIDING_SEAT`, asserted by file path), via `append_entry` only (sole write; byte-identical re-run pins append-only), "next morning's `journal` section" on the rendered brief through the real handler (Task 2's last test). §0.4 append-only holds; invariant 4 holds (guarded finally, drain pinned on a real queued alert); invariant 6 untouched.
 
-**Placeholder scan:** none; every step has code and an expected outcome.
+**Review round 1 findings, each addressed:** blocker (`str(did)` assertion) — gone, replaced by a marker-count assertion; major 1 (`_append_entry_once` collision) — header suffix, pinned by Task 1 test 1's `## {NIGHT}\n not in text`; major 2 (prose suppression) — synthetic marker, pinned by Task 1 test 3 replaying the demonstrated attack; major 3 (window loss + false docstring claims) — window removed, pinned by Task 1 test 5; major 4 (finally placement untested) — Task 2 test 2 uses the frame-error abort that actually reaches the finally; major 5 (drain assertion theater) — Task 2 test 3 asserts a queued rollup reaches `posted_at NOT NULL` and zero rows stay unposted; minors — blank guard (Task 1 test 6), import placement (one module-level block, stated once), dead JOIN (now live: the marker is built from `d.run_date`, `d.ticker`), `fund_server.py:481` + `contracts.md:349` stale notes (Task 3 step 1), `JOURNAL_ENTRIES` dilution (aggregation, Task 1 test 4).
 
-**Type consistency:** `journal_reflections(conn, journals_root, *, window, run_date) -> dict` identical at definition (Task 1), monkeypatch signature (Task 2 test 4), and call site (Task 2 step 3). `_window(run_date)` returns `(start, end)` — matches the `window` tuple. `journals_root_from(environ) -> Path` used in `main()` only.
+**Placeholder scan:** none. **Type consistency:** `journal_reflections(conn, journals_root, *, run_date) -> dict` identical at definition, monkeypatch (`boom(conn, root, *, run_date)`), and call site; `journals_root_from(environ) -> Path` used in `main()` and its test.
 
-**Two things the reviewer should push on:** (1) the marker (`reflection.splitlines()[0]`) assumes `store_reflection` always stores the frame first — true today by construction (`f"{frame}\n\n{prose}"`), but worth a reviewer confirming nothing writes `resolutions.reflection` by another path; (2) the sweep journals reflections for held/rejected decisions too (they are graded and reflected on by design) — confirm that is wanted in the PM's journal, or whether executed-only was intended; the plan takes "all written reflections" because the reflect turn already includes held/rejected on purpose (`reflect_day.py`'s `_DUE_WHERE` comment).
+**For the round-2 reviewer:** (1) confirm the `finally` insertion point in the current `reflect_day.py` — after the rollup append, before `drain` — matches the file as it stands; (2) re-run the prose-quote attack against the new marker; (3) check the backfill test's claim against `_WRITTEN` (no date predicate anywhere).

--- a/docs/superpowers/plans/2026-09-02-phase-2b-b-reflections-into-journal.md
+++ b/docs/superpowers/plans/2026-09-02-phase-2b-b-reflections-into-journal.md
@@ -10,7 +10,8 @@ Three design choices, each an answer to a demonstrated failure from this plan's 
 
 1. **Unwindowed sweep.** The turn loop's `REFLECT_LOOKBACK_DAYS` window exists because *turns cost money*; journal appends are free. A windowed sweep created a silent permanent-loss class (a reflection written, its projection failing, the window moving past it — demonstrated). Unwindowed, any later fire catches up, and the deploy-day backfill is bounded by the fund's whole history (38 decisions ever). The marker check is what bounds work, not a date.
 2. **Line-anchored synthetic marker, not a frame substring.** A whole-file substring scan on the frame's first line was demonstrated suppressible by prose that quotes another decision's frame — which seats naturally do. The marker is a string no seat ever sees (frames don't contain it), matched only as a complete line (`re.M`), and unique per decision (`decisions` UNIQUE `(run_date, ticker)`, `state/schema.sql:63`; `resolutions.decision_id` UNIQUE, `:99`). Residual: a seat that emits the exact marker line, character-for-character at line start, inside prose could still suppress — named in the docstring as accepted, since prose never legitimately contains the `— reflection · ` prefix.
-3. **One section per sweep, header `## {night} · reflections`.** `orchestrator/daily.py:430-438`'s `_append_entry_once` checks `f"## {run_date}\n" in file` — a bare-dated reflections section written by the 16:35 job before a crashed trading day resumes would make `run_close` skip the PM's decision line for that day, forever (demonstrated mechanism). The ` · reflections` suffix means neither writer's check can match the other's sections. Aggregation also keeps a multi-reflection night from evicting the PM's own daily record out of the brief's 3-section `journal` window (`JOURNAL_ENTRIES = 3`, `fund_server.py`).
+3. **Seat prose is defanged before it enters the file.** This lane introduces the journal's first seat-authored free text — every existing writer emits code-built lines — and two consumers treat the file's raw bytes as structure: `_append_entry_once`'s substring key (`"## {date}\n"`, even mid-line) and `recent_entries`' `"\n## "` split. Prose containing `## ` was demonstrated to forge the first and fragment the second. Fix at the single entry point: every run of two-or-more `#` in the reflection text is collapsed to one (`re.sub(r"#{2,}", "#", …)`) as it is journaled. The frame is code-built and never contains `#`, so acceptance (b)'s "frame and prose" is satisfied with this one documented transformation; the DB keeps the untouched original.
+4. **One section per sweep, header `## {night} · reflections`.** `orchestrator/daily.py:430-438`'s `_append_entry_once` checks `f"## {run_date}\n" in file` — a bare-dated reflections section written by the 16:35 job before a crashed trading day resumes would make `run_close` skip the PM's decision line for that day, forever (demonstrated mechanism). The ` · reflections` suffix means neither writer's check can match the other's sections. Aggregation also keeps a multi-reflection night from evicting the PM's own daily record out of the brief's 3-section `journal` window (`JOURNAL_ENTRIES = 3`, `fund_server.py`).
 
 **Tech Stack:** Python 3.12, existing `state/journal.py` and `orchestrator/reflect.py`, pytest. No new dependencies.
 
@@ -211,11 +212,33 @@ def test_blank_or_unwritten_reflections_are_not_projected(conn, tmp_path):
 
     assert out == {"journaled": 0, "already": 0, "blank": 1}
     assert not (tmp_path / "journals" / f"{DECIDING_SEAT}.md").exists()
+
+
+def test_prose_markdown_headings_cannot_forge_headers_or_split_sections(
+        conn, tmp_path):
+    """This file's first free text meets two consumers that read raw bytes:
+    _append_entry_once's substring key ("## {date}\\n", matched even
+    mid-line — a forged FUTURE date would make run_close silently skip that
+    day's PM record forever) and recent_entries' "\\n## " split (a prose
+    heading fragments the aggregated section and eats the brief's 3-section
+    window). Both demonstrated in review; both die at the defang."""
+    from state.journal import recent_entries
+
+    _reflected(conn, prose="lesson:\n## 2026-12-01\nand mid-line ## 2026-12-02\nhold")
+    root = tmp_path / "journals"
+
+    journal_reflections(conn, root, run_date=NIGHT)
+
+    text = _pm_journal(root)
+    assert "## 2026-12-01" not in text and "## 2026-12-02" not in text
+    assert "# 2026-12-01" in text                    # prose kept, defanged
+    assert text.count("\n## ") == 1                  # one real section
+    assert "hold" in recent_entries(root, DECIDING_SEAT, 1)
 ```
 
 - [ ] **Step 2: Run them to verify they fail**
 
-Run: `.venv/bin/python3 -m pytest tests/test_reflect.py -k "projection or reflections or sweep or blank" -v`
+Run: `.venv/bin/python3 -m pytest tests/test_reflect.py -k "projection or reflections or sweep or blank or prose" -v`
 Expected: FAIL at import — `ImportError: cannot import name 'DECIDING_SEAT'`.
 
 - [ ] **Step 3: Implement**
@@ -241,10 +264,12 @@ DECIDING_SEAT = "pm"
 # The idempotence marker's prefix. A SYNTHETIC line, deliberately not the
 # frame's first line: seats quote frames in prose (they are handed one every
 # reflect turn), and a substring scan on a frame header was demonstrated
-# suppressible by exactly such a quote. No seat ever sees this prefix, and
-# the check below matches it only as a complete line — the residual (prose
-# emitting the exact marker line, character-for-character at line start) is
-# accepted and would take deliberate construction, not a natural quote.
+# suppressible by exactly such a quote. No seat whose text reaches this
+# journal ever sees the prefix before writing (the PM reads it in later
+# briefs, but the PM's own journal writes are code-built), and the check
+# below matches it only as a complete line — the residual (prose emitting
+# the exact marker line, character-for-character at line start) is accepted
+# and would take deliberate construction, not a natural quote.
 REFLECTION_MARKER_PREFIX = "— reflection · "
 
 # Every written reflection, with the decision fields the marker is built
@@ -306,7 +331,15 @@ def journal_reflections(conn, journals_root, *, run_date: str) -> dict:
         if re.search(rf"^{re.escape(marker)}$", existing, re.M):
             out["already"] += 1
             continue
-        pieces.append(f"{marker}\n{row['reflection']}")
+        # Defang before the file's structural consumers can see it: prose is
+        # the first free text this file has ever held, and both
+        # _append_entry_once (substring "## {date}\n", even mid-line) and
+        # recent_entries ("\n## " split) read raw bytes. Collapsing every
+        # #-run to one "#" kills both triggers everywhere while keeping the
+        # prose readable; the frame is code-built and never contains "#",
+        # and the DB keeps the untouched original.
+        defanged = re.sub(r"#{2,}", "#", row["reflection"])
+        pieces.append(f"{marker}\n{defanged}")
         out["journaled"] += 1
     if pieces:
         append_entry(journals_root, DECIDING_SEAT,
@@ -599,7 +632,7 @@ Title: `feat: Phase 2b (b) — reflections reach the PM journal (#205)`. Body:
 
 1. The §8 (b) sentence and acceptance item (b).
 2. **What this deliberately does not do:** the Slack-thread sink — #57's other half. `design.md` §3 defers it with no owner; whether it survives at all (a per-decision thread post is a VISION-era question) is Benjamin's decision. #57 stays open until he rules; a comment on #57 records the split.
-3. **Design notes a reviewer should check:** the three review-driven choices from the plan header (unwindowed sweep; synthetic line-anchored marker; ` · reflections` header suffix vs `_append_entry_once`), each with its demonstrated failure. Name the accepted residual (a deliberately constructed marker line in prose).
+3. **Design notes a reviewer should check:** the four review-driven choices from the plan header (unwindowed sweep; synthetic line-anchored marker; prose defang — the journal's first free text meets two raw-byte consumers; ` · reflections` header suffix vs `_append_entry_once`), each with its demonstrated failure. Name the accepted residual (a deliberately constructed marker line in prose) and the defang's one visible effect (a `##`-run in prose renders as `#`; the DB keeps the original).
 4. **No expected-value changes to existing tests.** No DDL, no tool, no charter, no config, no new alert code.
 5. Deploy note: code-only — droplet pull suffices; **no unit change** (run #220's `cmp` drift check anyway, expected SAME on all seven). First post-deploy 16:35 fire backfills every historical written reflection into `journals/pm.md` in one section — bounded by the fund's whole history, and the next morning's PM brief will show it.
 6. The issue-number rule: `#205` and `#57` referenced with no closing keyword anywhere in the body.
@@ -616,4 +649,4 @@ Then comment on #57: "The journal half landed with Phase 2b (b) (PR #<n>): writt
 
 **Placeholder scan:** none. **Type consistency:** `journal_reflections(conn, journals_root, *, run_date) -> dict` identical at definition, monkeypatch (`boom(conn, root, *, run_date)`), and call site; `journals_root_from(environ) -> Path` used in `main()` and its test.
 
-**For the round-2 reviewer:** (1) confirm the `finally` insertion point in the current `reflect_day.py` — after the rollup append, before `drain` — matches the file as it stands; (2) re-run the prose-quote attack against the new marker; (3) check the backfill test's claim against `_WRITTEN` (no date predicate anywhere).
+**Round-2 findings, addressed:** the prose-forge/fragmentation major → the defang (design note 3, Task 1's forge test replaying both demonstrated attacks); the `-k` filter minor → `prose` added; the "no seat ever sees" overclaim → docstring now scoped to seats whose text reaches the journal. Declined as YAGNI: pre-scanning the file into a marker set (an optimization the reviewer itself called not required); the cosmetic ever-growing `already`/`blank` log counts (log noise, no loss, and the counts are the honest state).

--- a/docs/superpowers/plans/2026-09-02-phase-2b-b-reflections-into-journal.md
+++ b/docs/superpowers/plans/2026-09-02-phase-2b-b-reflections-into-journal.md
@@ -1,0 +1,496 @@
+# Phase 2b (b) — Reflections Into the PM Journal — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close `specs/improvement.md` §8 (b) — the journal half of #57: a reflection written by the nightly reflect turn is projected into the deciding seat's journal (the PM's), through `state/journal.py:append_entry` only, so the next morning's `journal` brief section carries the resolution's frame and prose.
+
+**Architecture:** One pure projection function in `orchestrator/reflect.py` — a windowed sweep over `resolutions.reflection IS NOT NULL`, idempotent by content marker — called from `scripts/reflect_day.py`'s `finally` block beside the drain, so whatever was written gets journaled even on a broken night. No DDL, no new tool, no charter change, no config. The Slack-thread half of #57 stays deferred (design.md §3, ruled in #204's amendment) and is explicitly not here.
+
+**Tech Stack:** Python 3.12, existing `state/journal.py` and `orchestrator/reflect.py`, pytest. No new dependencies.
+
+## Global Constraints
+
+- **Journals are written only through `state/journal.py`** (CLAUDE.md "Do NOT"; `improvement.md` §0.4: append-only, nothing rewrites history).
+- **`orchestrator/` is purity-linted**: no LLM imports, no wall clock. The projection takes its window bounds and dates as arguments; the caller computes them.
+- **Default is no-change / the night continues** (invariant 4): a projection failure must not lose the drain, the wrote-nothing rollup, or the night's exit code.
+- **No per-run values in prompts**: journals are injected into prompts, so the journal text must carry **no `decision_id`** — the idempotence marker is the frame's own first line (`TICKER · run_date · action qty (status)`), which is already prompt-safe.
+- **Acceptance item (b)** (`specs/acceptance.md` Phase 2b): "after resolve + reflect, the next morning's `journal` section for the seat that made the decision (the PM) contains that resolution's frame and prose, appended via `state/journal.py:append_entry` only."
+- **PR body: no closing keyword adjacent to any issue number** (PR #210 closed #205 on a negated sentence). #57 and #205 both stay open — #57's Slack half is undelivered, and whether it survives at all is Benjamin's call.
+- Baseline at branch point `64e1a0e`: **1808 passed, 1 skipped**. `make test` before every commit; no Co-Authored-By trailer; conventional commits; surgical diffs.
+
+## File structure
+
+| Path | Responsibility | Action |
+|---|---|---|
+| `orchestrator/reflect.py` | `DECIDING_SEAT`, `journal_reflections(conn, journals_root, *, window, run_date) -> dict` | Modify (append) |
+| `scripts/reflect_day.py` | `journals_root_from(environ)`, `reflect_and_log(..., journals_root=None)` calls the sweep in `finally`, guarded; `main()` threads it | Modify |
+| `specs/design.md` §3 Nightly 1 row | says the journal projection exists; threads still deferred | Modify |
+| `specs/acceptance.md` | tick item (b) | Modify |
+| `tests/test_reflect.py` | the projection: content, marker idempotence, window bound, unwritten skipped | Modify (append) |
+| `tests/test_reflect_job.py` | wiring: journaled on a written turn, `finally` survives a mid-loop raise, unbound root is a named skip, morning brief carries it | Modify (append) |
+
+## Scope check
+
+One subsystem, one lane. Deliberately not here: the Slack-thread sink (#57's other half — deferred by `specs/design.md` §3 as amended in #204; whether it survives at all is a decision for Benjamin, recorded in the PR body); any journal-growth control (that is (c), lessons distillation); backfill beyond the reflect job's own `REFLECT_LOOKBACK_DAYS` window (an unbounded backfill has the same shape as the unbounded turn-buying the job already refuses).
+
+---
+
+### Task 1: `journal_reflections` — the projection
+
+**Files:**
+- Modify: `orchestrator/reflect.py` (append after `store_reflection`)
+- Test: `tests/test_reflect.py` (append)
+
+**Interfaces:**
+- Consumes: `state.journal.append_entry(root, seat, run_date, text)`; `resolutions` + `decisions` rows.
+- Produces: `DECIDING_SEAT = "pm"`; `journal_reflections(conn, journals_root, *, window: tuple[str, str], run_date: str) -> dict` with keys `journaled: int`, `already: int`. `window` is `[start_iso, end_iso)` over `resolved_at` — the caller passes the same bounds `due_reflections` uses. Raises nothing on an empty window or an empty table.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_reflect.py` (it already imports `store_reflection` and builds resolved decisions; follow its fixture style — if the file lacks one, use the snippet's own `_resolved` helper modeled on `tests/test_reflect_job.py:41-70`):
+
+```python
+# --- the journal projection (#57's journal half; improvement.md §8 (b)) ------
+
+from orchestrator.reflect import (DECIDING_SEAT, journal_reflections,
+                                  reflection_frame)
+
+WINDOW = ("2026-08-18T00:00:00+00:00", "2026-08-26T00:00:00+00:00")
+NIGHT = "2026-08-25"
+
+
+def _reflected(conn, *, ticker="NVDA", run_date="2026-08-18",
+               resolved_at="2026-08-25T20:35:05+00:00", prose="cut earlier"):
+    """A resolved decision whose reflection is already stored — the state
+    the projection consumes. Returns (decision_id, stored_text)."""
+    cur = conn.execute(
+        "INSERT INTO decisions (run_date, ticker, action, qty, thesis,"
+        " invalidation, status, created_at) VALUES"
+        " (?,?,'buy',96,'t','i','executed',?)",
+        (run_date, ticker, f"{run_date}T15:00:00+00:00"))
+    did = cur.lastrowid
+    conn.execute(
+        "INSERT INTO resolutions (decision_id, horizon_days, realized_return,"
+        " alpha_vs_spy, invalidated, resolved_at)"
+        " VALUES (?, 5, 0.0614, 0.0504, 0, ?)", (did, resolved_at))
+    conn.commit()
+    frame = reflection_frame(conn, did)
+    store_reflection(conn, did, frame, prose)
+    return did, conn.execute(
+        "SELECT reflection FROM resolutions WHERE decision_id = ?",
+        (did,)).fetchone()["reflection"]
+
+
+def test_projection_appends_frame_and_prose_to_the_pm_journal(conn, tmp_path):
+    _, stored = _reflected(conn)
+    root = tmp_path / "journals"
+
+    out = journal_reflections(conn, root, window=WINDOW, run_date=NIGHT)
+
+    assert out == {"journaled": 1, "already": 0}
+    text = (root / f"{DECIDING_SEAT}.md").read_text()
+    assert f"## {NIGHT}" in text
+    assert stored in text                       # frame AND prose, verbatim
+    assert "cut earlier" in text
+
+
+def test_projection_is_idempotent_by_the_frames_first_line(conn, tmp_path):
+    """Re-run (crash-resume, a second fire) appends nothing: the marker is
+    the frame's own first line — prompt-safe, no decision_id ever enters a
+    journal that gets injected into prompts (CLAUDE.md)."""
+    did, _ = _reflected(conn)
+    root = tmp_path / "journals"
+    journal_reflections(conn, root, window=WINDOW, run_date=NIGHT)
+    before = (root / f"{DECIDING_SEAT}.md").read_text()
+
+    out = journal_reflections(conn, root, window=WINDOW, run_date=NIGHT)
+
+    assert out == {"journaled": 0, "already": 1}
+    assert (root / f"{DECIDING_SEAT}.md").read_text() == before
+    assert str(did) not in before               # no surrogate id in the file
+
+
+def test_only_reflections_inside_the_window_are_projected(conn, tmp_path):
+    """The sweep shares due_reflections' window shape: bounded, so a deploy
+    onto years of history cannot buy an unbounded backfill (same refusal the
+    turn loop already makes)."""
+    _reflected(conn, ticker="NVDA", resolved_at="2026-08-25T20:35:05+00:00")
+    _reflected(conn, ticker="MSFT", run_date="2026-08-01",
+               resolved_at="2026-08-10T20:35:05+00:00")   # below the window
+    root = tmp_path / "journals"
+
+    out = journal_reflections(conn, root, window=WINDOW, run_date=NIGHT)
+
+    text = (root / f"{DECIDING_SEAT}.md").read_text()
+    assert out["journaled"] == 1
+    assert "NVDA" in text and "MSFT" not in text
+
+
+def test_an_unwritten_reflection_is_not_projected(conn, tmp_path):
+    """reflection IS NULL means the seat has not spoken; projecting a blank
+    would be inventing a record (invariant 4)."""
+    conn.execute(
+        "INSERT INTO decisions (run_date, ticker, action, qty, thesis,"
+        " invalidation, status, created_at) VALUES"
+        " ('2026-08-18','AMD','buy',10,'t','i','executed','x')")
+    conn.execute(
+        "INSERT INTO resolutions (decision_id, horizon_days, realized_return,"
+        " alpha_vs_spy, invalidated, resolved_at) VALUES"
+        " (last_insert_rowid(), 5, 0.01, 0.01, 0, '2026-08-25T20:35:05+00:00')")
+    conn.commit()
+
+    out = journal_reflections(conn, tmp_path / "journals",
+                              window=WINDOW, run_date=NIGHT)
+
+    assert out == {"journaled": 0, "already": 0}
+    assert not (tmp_path / "journals" / f"{DECIDING_SEAT}.md").exists()
+```
+
+If `tests/test_reflect.py` has no `conn` fixture, add one matching `tests/test_reflect_job.py`'s `db` fixture (`connect(tmp_path / "fund.sqlite")`), named `conn`.
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `.venv/bin/python3 -m pytest tests/test_reflect.py -k journal -v`
+Expected: FAIL at import — `ImportError: cannot import name 'DECIDING_SEAT'`.
+
+- [ ] **Step 3: Implement**
+
+Append to `orchestrator/reflect.py`:
+
+```python
+# The seat whose journal a reflection lands in. `decisions` carries no seat
+# column — the PM is the only seat that decides (design.md §2), and
+# acceptance (b) names it. A second deciding seat would need a column, not a
+# guess; this constant is where that change arrives.
+DECIDING_SEAT = "pm"
+
+# Every written reflection in the window, with the fields the journal entry
+# needs. Ordered for determinism; the reflection text already carries the
+# frame first (store_reflection stores them together).
+_WRITTEN = """
+SELECT r.decision_id, r.reflection
+  FROM resolutions r
+  JOIN decisions d ON d.id = r.decision_id
+ WHERE r.reflection IS NOT NULL
+   AND r.resolved_at >= ? AND r.resolved_at < ?
+ ORDER BY r.decision_id
+"""
+
+
+def journal_reflections(conn, journals_root, *, window: tuple[str, str],
+                        run_date: str) -> dict:
+    """Project every written reflection in `window` into the deciding seat's
+    journal (#57's journal half; improvement.md §8 (b)). Returns
+    {"journaled": n, "already": n} for the job log.
+
+    Idempotent by content, not by memory: an entry is skipped when the
+    reflection's first line — the frame's own header, "TICKER · run_date ·
+    action qty (status)" — already appears in the journal file. That marker
+    is prompt-safe (journals are injected into prompts; a decision_id there
+    would put a per-run value in a prompt, CLAUDE.md), and it is what makes
+    a crash-resume, a re-fire, or the sweep-plus-turn overlap append each
+    reflection exactly once.
+
+    Windowed like due_reflections, for the same reason: a deploy onto years
+    of history must not buy an unbounded backfill. A reflection written
+    before this shipped and older than the window is not journaled — the
+    same honest gap the turn loop's own aging-out already accepts, and it
+    is alerted there, not here.
+
+    Appends through state/journal.py only (CLAUDE.md). The file is read
+    once per call for the marker check; append_entry never rewrites."""
+    from pathlib import Path
+
+    from state.journal import append_entry
+
+    rows = conn.execute(_WRITTEN, window).fetchall()
+    out = {"journaled": 0, "already": 0}
+    if not rows:
+        return out
+    path = Path(journals_root) / f"{DECIDING_SEAT}.md"
+    existing = path.read_text() if path.exists() else ""
+    for row in rows:
+        marker = row["reflection"].splitlines()[0]
+        if marker and marker in existing:
+            out["already"] += 1
+            continue
+        append_entry(journals_root, DECIDING_SEAT, run_date, row["reflection"])
+        existing += f"\n## {run_date}\n{row['reflection']}\n"
+        out["journaled"] += 1
+    return out
+```
+
+(`from state.journal import append_entry` stays inside the function to match how `orchestrator/daily.py` imports it at module level — if the module-level import is preferred, put it at the top; either passes the purity lint. Choose module level: `from state.journal import append_entry` beside the existing imports, and drop the inner imports.)
+
+- [ ] **Step 4: Run the tests and the purity lint**
+
+Run: `.venv/bin/python3 -m pytest tests/test_reflect.py -v && .venv/bin/python3 scripts/check_purity.py`
+Expected: PASS; lint clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add orchestrator/reflect.py tests/test_reflect.py
+git commit -m "feat(orchestrator): journal_reflections projects written reflections into the PM journal"
+```
+
+---
+
+### Task 2: Wire it into the nightly job
+
+**Files:**
+- Modify: `scripts/reflect_day.py` (`reflect_and_log` signature + `finally`; new `journals_root_from`; `main()`)
+- Test: `tests/test_reflect_job.py` (append)
+
+**Interfaces:**
+- Consumes: Task 1's `journal_reflections`; `reflect_day._window(run_date)` (the existing bounds helper); `run_day.log` pattern.
+- Produces: `reflect_and_log(conn, slack, clock, run_turn, journals_root=None)`; `journals_root_from(environ) -> Path` (mirrors `scripts/run_day.py:677`: `FUND_JOURNALS` or `ROOT / "journals"`, mkdir'd).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_reflect_job.py`:
+
+```python
+# --- the journal projection rides the same night (#57's journal half) --------
+
+from orchestrator.reflect import DECIDING_SEAT, reflection_frame
+from orchestrator.reflect import store_reflection as _store
+
+
+def _writing_turn(conn):
+    """A run_turn that behaves: stores frame + prose for the decision it was
+    handed, the way a real seat turn does through submit_reflection."""
+    def run_turn(job):
+        _store(conn, job["decision_id"], job["frame"], "trim next time")
+    return run_turn
+
+
+def test_a_written_reflection_is_journaled_the_same_night(db, tmp_path):
+    _resolved(db, resolved_at="2026-08-25T20:35:05+00:00")
+    root = tmp_path / "journals"
+
+    reflect_day.reflect_and_log(db, FakeSlack(), SimClock(NIGHTLY),
+                                _writing_turn(db), journals_root=root)
+
+    text = (root / f"{DECIDING_SEAT}.md").read_text()
+    assert "trim next time" in text
+    assert "NVDA" in text and "+6.14%" in text          # the frame's numbers
+
+
+def test_the_projection_survives_a_mid_loop_raise(db, tmp_path):
+    """It rides the finally, beside the drain: a night where the SECOND turn
+    raises still journals the first turn's reflection — same reasoning the
+    wrote-nothing rollup already carries."""
+    _resolved(db, ticker="NVDA", resolved_at="2026-08-25T20:35:05+00:00")
+    _resolved(db, ticker="AMD", resolved_at="2026-08-25T20:36:05+00:00")
+    root = tmp_path / "journals"
+    calls = {"n": 0}
+
+    def half_writing_turn(job):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise RuntimeError("seat session died")
+        _store(db, job["decision_id"], job["frame"], "kept my stop")
+
+    reflect_day.reflect_and_log(db, FakeSlack(), SimClock(NIGHTLY),
+                                half_writing_turn, journals_root=root)
+
+    text = (root / f"{DECIDING_SEAT}.md").read_text()
+    assert "kept my stop" in text
+
+
+def test_an_unbound_journals_root_is_a_named_skip_not_a_crash(db, capsys):
+    """Tests and older callers pass no root; production always does
+    (main threads journals_root_from). Unbound is logged by name so a wiring
+    regression is visible in journald, and the night otherwise proceeds."""
+    _resolved(db, resolved_at="2026-08-25T20:35:05+00:00")
+
+    reflect_day.reflect_and_log(db, FakeSlack(), SimClock(NIGHTLY),
+                                _writing_turn(db))
+
+    assert "journals_root unbound — reflections not journaled" \
+        in capsys.readouterr().out
+
+
+def test_a_projection_failure_does_not_eat_the_drain(db, tmp_path,
+                                                     monkeypatch):
+    """Guarded like everything else in the finally: a raise inside the
+    projection must not lose the drain or the night's exit (invariant 4)."""
+    _resolved(db, resolved_at="2026-08-25T20:35:05+00:00")
+
+    def boom(conn, root, *, window, run_date):
+        raise OSError("read-only filesystem")
+    monkeypatch.setattr(reflect_day, "journal_reflections", boom)
+
+    reflect_day.reflect_and_log(db, FakeSlack(), SimClock(NIGHTLY),
+                                _writing_turn(db),
+                                journals_root=tmp_path / "journals")
+    # reaching here without a raise IS the assertion; the drain ran:
+    assert db.execute("SELECT COUNT(*) c FROM events WHERE posted_at IS NOT"
+                      " NULL OR posted_at IS NULL").fetchone() is not None
+
+
+def test_journals_root_from_env_and_default(tmp_path):
+    root = reflect_day.journals_root_from({"FUND_JOURNALS": str(tmp_path / "j")})
+    assert root == tmp_path / "j" and root.is_dir()
+    assert reflect_day.journals_root_from({}) == reflect_day.ROOT / "journals"
+
+
+def test_next_morning_the_pm_brief_carries_the_reflection(db, tmp_path):
+    """Acceptance (b), end to end on the rendered brief: reflect at night,
+    read the PM's journal section in the morning through the real handler."""
+    from agents.tools.fund_server import handle_get_stage_brief
+
+    _resolved(db, resolved_at="2026-08-25T20:35:05+00:00")
+    root = tmp_path / "journals"
+    reflect_day.reflect_and_log(db, FakeSlack(), SimClock(NIGHTLY),
+                                _writing_turn(db), journals_root=root)
+
+    brief = handle_get_stage_brief(db, seat="pm", run_date="2026-08-26",
+                                   snapshot=lambda: {"cash": 0, "positions": {},
+                                                     "allowed_actions": {}},
+                                   journals_root=root)["brief"]
+    assert "trim next time" in brief["journal"]
+    assert "+6.14%" in brief["journal"]
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `.venv/bin/python3 -m pytest tests/test_reflect_job.py -k "journal or morning or projection" -v`
+Expected: FAIL — `TypeError: reflect_and_log() got an unexpected keyword argument 'journals_root'` and `AttributeError: ... no attribute 'journals_root_from'`.
+
+- [ ] **Step 3: Implement the wiring**
+
+In `scripts/reflect_day.py`:
+
+Import `journal_reflections` beside `reflection_frame`:
+
+```python
+from orchestrator.reflect import journal_reflections, reflection_frame  # noqa: E402
+```
+
+Add after `_window`:
+
+```python
+def journals_root_from(environ: dict) -> Path:
+    """Same resolution as scripts/run_day.py's composition root: FUND_JOURNALS
+    or the repo-local default. mkdir so a fresh host's first night works."""
+    root = Path(environ.get("FUND_JOURNALS") or (ROOT / "journals"))
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+```
+
+Change `reflect_and_log`'s signature to:
+
+```python
+def reflect_and_log(conn, slack, clock, run_turn, journals_root=None) -> dict:
+```
+
+and add to its docstring:
+
+```
+    `journals_root` is where written reflections are projected (#57's journal
+    half, improvement.md §8 (b)) — a windowed, idempotent sweep in the
+    `finally`, beside the drain, so whatever the night managed to write is
+    journaled even when a later turn raised. Unbound (None) is a named log
+    line, not a crash: tests and older callers, never production, which
+    threads journals_root_from(environ) from main(). The sweep is guarded
+    like the drain: a projection failure (a read-only disk) must not eat the
+    rollup alert, the drain, or the night's exit code.
+```
+
+In the `finally` block, before the `drain(...)` line:
+
+```python
+        if journals_root is None:
+            log("journals_root unbound — reflections not journaled")
+        else:
+            try:
+                counts_j = journal_reflections(
+                    conn, journals_root, window=_window(run_date),
+                    run_date=run_date)
+                log(f"journaled {counts_j['journaled']}"
+                    f" · already {counts_j['already']}")
+            except Exception as exc:
+                log(f"JOURNAL PROJECTION FAILED ({type(exc).__name__}:"
+                    f" {exc}) — reflections stand in the DB, journal catches"
+                    " up on the next fire")
+```
+
+In `main()`, change the call to:
+
+```python
+    reflect_and_log(conn, slack, clock, run_turn,
+                    journals_root=journals_root_from(environ))
+```
+
+- [ ] **Step 4: Run the job tests, then the full suite**
+
+Run: `.venv/bin/python3 -m pytest tests/test_reflect_job.py -v && make test`
+Expected: PASS. The existing `reflect_and_log` tests pass unchanged (the new parameter defaults to `None`, whose only effect is one log line).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/reflect_day.py tests/test_reflect_job.py
+git commit -m "feat(scripts): reflect_day projects the night's reflections into the PM journal"
+```
+
+---
+
+### Task 3: Docs close-out and the PR
+
+**Files:**
+- Modify: `specs/design.md:104` (Nightly 1 row), `specs/acceptance.md` (item (b))
+
+- [ ] **Step 1: `specs/design.md` Nightly 1 row**
+
+Replace, in the §3 cadence table's Nightly 1 row, the fragment:
+
+```markdown
+the `reflect` seat writes one reflection per decision → `resolutions.reflection` column only. Projection into journals is #57 (`specs/improvement.md` §8 (b)); the original Slack threads stay deferred
+```
+
+with:
+
+```markdown
+the `reflect` seat writes one reflection per decision → `resolutions.reflection`, and the same job projects it into the PM's journal via `state/journal.py` (#57's journal half, `specs/improvement.md` §8 (b)); the original Slack threads stay deferred
+```
+
+- [ ] **Step 2: Tick acceptance item (b)**
+
+`specs/acceptance.md` Phase 2b: `- [ ] Reflections reach the brief (#57): …` → `- [x]`, appending ` — journal sink only; the Slack-thread sink stays deferred (design.md §3).`
+
+- [ ] **Step 3: Full suite, then commit**
+
+Run: `make test`
+Expected: PASS.
+
+```bash
+git add specs/design.md specs/acceptance.md
+git commit -m "docs: Nightly 1 projects reflections into the PM journal; acceptance (b) ticked"
+```
+
+- [ ] **Step 4: Open the PR**
+
+Title: `feat: Phase 2b (b) — reflections reach the PM journal (#205)`. Body:
+
+1. The §8 (b) sentence and acceptance item (b).
+2. **What this deliberately does not do:** the Slack-thread sink — #57's other half. `design.md` §3 defers it with no owner; whether it survives at all (a per-decision thread post is a VISION-era question) is Benjamin's decision. #57 stays open until he rules; a comment on #57 records the split.
+3. **No expected-value changes to existing tests.** No DDL, no tool, no charter, no config.
+4. Deploy note: code-only — droplet pull suffices; **no unit change** (per #220, that is the check that would have been skipped: `cmp` still run, expected SAME on all seven).
+5. The issue-number rule: `#205` and `#57` referenced with no closing keyword anywhere in the body.
+
+Then comment on #57: "The journal half landed with Phase 2b (b) (PR #<n>): written reflections are swept into `journals/pm.md` nightly, windowed and idempotent. The Slack-thread half remains deferred per design.md §3 — whether it survives at all is Benjamin's call; this issue stays open for that decision."
+
+---
+
+## Self-review
+
+**Spec coverage:** acceptance (b)'s every clause has an assertion — frame and prose in the journal (Task 1 test 1, Task 2 test 1), the deciding seat is the PM (`DECIDING_SEAT`, asserted by file path), via `append_entry` only (the implementation's only write; the idempotence test asserts byte-identical on re-run, which a rewrite would break), and "the next morning's `journal` section" on the rendered brief (Task 2's last test, through the real handler). §0.4 append-only: the marker check reads, `append_entry` appends, nothing truncates.
+
+**Placeholder scan:** none; every step has code and an expected outcome.
+
+**Type consistency:** `journal_reflections(conn, journals_root, *, window, run_date) -> dict` identical at definition (Task 1), monkeypatch signature (Task 2 test 4), and call site (Task 2 step 3). `_window(run_date)` returns `(start, end)` — matches the `window` tuple. `journals_root_from(environ) -> Path` used in `main()` only.
+
+**Two things the reviewer should push on:** (1) the marker (`reflection.splitlines()[0]`) assumes `store_reflection` always stores the frame first — true today by construction (`f"{frame}\n\n{prose}"`), but worth a reviewer confirming nothing writes `resolutions.reflection` by another path; (2) the sweep journals reflections for held/rejected decisions too (they are graded and reflected on by design) — confirm that is wanted in the PM's journal, or whether executed-only was intended; the plan takes "all written reflections" because the reflect turn already includes held/rejected on purpose (`reflect_day.py`'s `_DUE_WHERE` comment).


### PR DESCRIPTION
Implementation plan for `specs/improvement.md` §8 (b) / `specs/acceptance.md` Phase 2b item "Reflections reach the brief" — the **journal half of #57 only**. Three tasks: a pure projection in `orchestrator/reflect.py`, its wiring into `scripts/reflect_day.py`'s `finally`, docs close-out. No DDL, no tool, no charter, no config, no new alert code.

**Two rounds of fresh-context adversarial review, both mutation-tested.** Round 1 NOT-READY, and it earned it — it demonstrated three silent-permanent-loss mechanisms the first draft never weighed, plus one test that failed against its own correct implementation and two tests that could not detect the thing they claimed to pin. Round 2 READY-WITH-MINORS with one real major left; that is fixed here.

**The four design choices, each an answer to a demonstrated failure:**
1. **Unwindowed sweep.** The turn loop is windowed because turns cost money; appends are free. A windowed sweep minted a silent-loss class (reflection written → projection fails once → window moves past it → no alarm anywhere, since the aged-out alert only sees `reflection IS NULL`). Unwindowed, any later fire catches up — and it self-heals a journal restored from backup.
2. **Synthetic, line-anchored idempotence marker.** A substring scan on the frame's first line was demonstrated suppressible by prose quoting another decision's frame — which reflect seats naturally do. The marker is a line no seat sees before writing, matched with `re.M`.
3. **Seat prose is defanged (`#{2,}` → `#`) at projection time.** This lane introduces the journal file's first seat-authored free text, and two consumers read raw bytes: `_append_entry_once`'s substring key and `recent_entries`' `"\n## "` split. Prose containing `## ` was demonstrated to forge a future-dated header — which would make `run_close` silently skip that day's PM record forever — and to fragment the section. Verified against the real `state/journal.py`: frame unchanged, one section, no forged headers, prose still readable.
4. **One aggregated section under `## {night} · reflections`.** The suffix means neither writer's idempotence check can match the other's sections, and aggregation stops a multi-reflection night evicting the PM's own daily record from the brief's 3-section window.

**Not here, and it needs your ruling:** #57's **Slack-thread sink**. `design.md` §3 defers it with no owner; whether a per-decision thread post survives at all is a VISION-era question, not a lane's. #57 stays open for that decision.

Deploy is code-only. The first post-deploy 16:35 fire backfills every historical written reflection in one section (≤38 decisions ever).

---

## Landed by the 2026-09-12 orphan-sweep lane

**Reviewer:** the orphan-sweep lane's review subagent (session `lane orphan sweep overseer`), Spec axis against `origin/master` = `e8d4ce4`. Verdict: **APPROVE WITH NOTES**, none blocking. The plan file is the whole diff; it is merged as the plan of record, unamended (a land lane does not extend a branch). The notes below are for the implementer of piece (b) and are mirrored on #205.

Demonstrated: every code claim in the plan resolves on `e8d4ce4` (23 citations checked — `daily.py:29,:430-438,:477`, `schema.sql:63,:99`, `fund_server.py:101,:480-483,:555-595`, `run_day.py:677-678`, `reflect_day.py:247,:273-289,:308-317`, `reflect.py:87-94`, `journal.py:18,:30`, `improvement.md:34-36,:159-162,:511-517`, `acceptance.md:45-47`, `design.md:104`, `contracts.md:349,:370`); no new field/table/tool/transition; the single journal write is `append_entry`; no free-text extraction; no wall clock. `#57` and `#205` carry zero 🔏 rulings (checked today). Scope matches piece (b) exactly and stays out of #57's Slack-thread half.

Notes for the implementer:
1. **The projection's failure path reaches no detector.** Plan lines 557-560 make a raised projection a `log(...)` line only; every other failure class in this job alerts (`reflect_day.py:34-47`), and `scripts/audit_day.py` never mentions journals. A persistent failure (read-only disk, wrong `FUND_JOURNALS`) silently un-holds acceptance (b). Either add `run_day._alert(conn, clock, "reflect_journal_failed", …)` in the `except` — the neighbouring shape — or state why journald-only is acceptable; and extend the posture list at `reflect_day.py:34-47`.
2. `append_entry`'s `run_date` parameter receives `"{run_date} · reflections"`; `state/journal.py:3-4,:12` document the header as `## {run_date}`. Add that docstring to Task 3's doc edits.
3. "appended via `state/journal.py:append_entry` only" is not pinned by any test — a one-line `monkeypatch` spy on `orchestrator.reflect.append_entry` closes it. And the acceptance tick should carry the `##`→`#` defang caveat, since the line as written promises the prose verbatim.
4. With `JOURNAL_ENTRIES = 3` and one reflections section per night, the PM's brief window becomes `[D-1·reflections, D, D·reflections]` — ~1.5 days of its own decision lines instead of 3. Spec-permitted (`improvement.md:159-162`); state it in the implementation PR body.

Re-verified: `make test` on a local merge of this branch onto `e8d4ce4` → 1824 passed, 1 skipped, 10 deselected. No closing keyword by design: #205 stays open for pieces (b)–(g), #57 for the Slack-thread ruling.

https://claude.ai/code/session_016Y5fp1VYGbMYatypWXCr59
