### PR TITLE
fix: bump alpaca-mcp-server to 2.3.1 — fastmcp 4 broke the server at import

### DIFF
--- a/agents/seats.py
+++ b/agents/seats.py
@@ -28,7 +28,23 @@ CHARTERS_DIR = Path(__file__).resolve().parents[1] / "charters"
 # derive THIS spec: the guard, the warm cache, and the thing guarded cannot
 # drift apart. An upgrade is a deliberate commit with a green
 # `make schema-pin`.
-ALPACA_MCP_SPEC = "alpaca-mcp-server@2.2.1"
+#
+# 2.2.1 -> 2.3.1, 2026-09-02, and the reason is that pinning the APP does not
+# pin the RESOLUTION. 2.2.1 declares `fastmcp>=3.1.0` with no upper bound, so
+# uvx resolved fastmcp 4.0.2, which moved `fastmcp.tools.tool` —
+# `alpaca_mcp_server/security.py:14` imports it, so the server raised at
+# STARTUP. Every seat turn hit `required MCP server(s) not connected after
+# 30.0s: {'alpaca': 'failed'}` and defaulted to HOLD (invariant 4 working).
+# The fund stopped trading after 2026-08-31 and lost 09-01, 09-02 and 9
+# reflections. Upstream shipped 2.3.1 on 09-01 declaring `fastmcp<4,>=3.1.0`:
+# this bump takes THEIR bound rather than carrying a local `--with` override,
+# so there is one constraint to maintain instead of two that can disagree.
+#
+# WHY THREE DAYS PASSED. `uvx <spec> --version|--help` exits inside click
+# before importing `.server`, so every cache-warm check in ops/README.md stayed
+# green while the server could not start at all. Those checks now start the
+# transport instead — that is the probe that would have caught this on day one.
+ALPACA_MCP_SPEC = "alpaca-mcp-server@2.3.1"
 
 
 def load_seat_config(path: str | Path) -> dict:

--- a/config/broker_tool_surface.yaml
+++ b/config/broker_tool_surface.yaml
@@ -14,7 +14,14 @@
 #
 # The surface is a function of BOTH lines below. A toolset change moves it as
 # surely as a version bump, so neither is inferable from the other.
-spec: alpaca-mcp-server@2.2.1
+# 2.2.1 -> 2.3.1 on 2026-09-02. The tool NAMES below are unchanged and were
+# re-enumerated, not re-recorded: both versions list the same 38 tools, with
+# nothing appeared and nothing disappeared against this file. The only schema
+# movement was additive — `get_account_activities` and
+# `get_account_activities_by_type` gained an optional `order_id`, and
+# `replace_order_by_id` gained the `IEX`/`MEMX` routing enum values.
+# `place_stock_order`, the one gate/tickets.py validates, did not move.
+spec: alpaca-mcp-server@2.3.1
 toolsets: account,trading,stock-data
 
 # Mutations authorised by a gate ticket. Adding one here is not enough: see

--- a/ops/README.md
+++ b/ops/README.md
@@ -108,7 +108,13 @@ bump.
 
 ```bash
 set -a; . /etc/fund/env; set +a
-uvx "$(.venv/bin/python3 -c 'from agents.seats import ALPACA_MCP_SPEC as s; print(s)')" --help
+# Derive the WHOLE argv, not just the spec: it carries the `--with fastmcp<4`
+# constraint, and a pre-warm that omits it caches a resolution the seats never use.
+# `--transport stdio </dev/null`, NOT `--help`: click exits before importing
+# `.server`, so `--help` stayed green for the three days the server could not
+# start at all (2026-08-31 → 09-02). Only starting the transport imports it.
+uvx $(.venv/bin/python3 -c 'from agents.seats import ALPACA_MCP_ARGS as a; print(" ".join(a))') \
+    --transport stdio < /dev/null 2>&1 | tail -5
 ```
 
 ### Secrets
@@ -258,8 +264,11 @@ places orders under a ticket-id namespace the new host has never seen.
 ```bash
 make test                       # offline suite
 make schema-pin                 # the REAL tool schema, at the pinned version
-# broker tools reachable — the same pinned spec the seats launch, never bare
-uvx "$(.venv/bin/python3 -c 'from agents.seats import ALPACA_MCP_SPEC as s; print(s)')" --help
+# broker tools reachable — the same pinned argv the seats launch, never bare.
+# Starts the transport rather than asking `--help`, which cannot fail on a
+# server that is broken at import time.
+uvx $(.venv/bin/python3 -c 'from agents.seats import ALPACA_MCP_ARGS as a; print(" ".join(a))') \
+    --transport stdio < /dev/null 2>&1 | tail -5
 python scripts/run_day.py       # market closed -> exit 0, writes nothing
 ```
 

--- a/tests/test_broker_surface_pin.py
+++ b/tests/test_broker_surface_pin.py
@@ -44,8 +44,22 @@ def _qualified(name: str) -> str:
 def test_the_pin_records_what_the_surface_is_a_function_of(pin):
     """A tool list alone is not reproducible. The same package at a different
     toolset selection exposes a different surface, so a reader who cannot see
-    both cannot tell whether the list is still true."""
-    assert pin["spec"] == "alpaca-mcp-server@2.2.1"
+    both cannot tell whether the list is still true.
+
+    Deliberately a LITERAL and not `ALPACA_MCP_SPEC`: deriving it would make
+    this test agree with every future bump silently, which is the opposite of
+    what a pin is for. Changing this line is meant to cost a human a look.
+
+    2.2.1 -> 2.3.1 on 2026-09-02, and what that look found: both versions were
+    enumerated over this same toolset selection and listed the SAME 38 tools —
+    nothing appeared, nothing disappeared, so the three buckets below are
+    untouched. Schema movement was additive only (an optional `order_id` on the
+    two `get_account_activities*` reads; `IEX`/`MEMX` added to
+    `replace_order_by_id`'s routing enum). `place_stock_order`, the one
+    `gate/tickets.py` validates, did not move. The bump itself was forced: 2.2.1
+    declares `fastmcp>=3.1.0` unbounded, fastmcp 4 broke its import, and every
+    seat defaulted to HOLD from 2026-08-31 — see agents/seats.py."""
+    assert pin["spec"] == "alpaca-mcp-server@2.3.1"
     assert pin["toolsets"] == "account,trading,stock-data"
 
 


### PR DESCRIPTION
## The outage

**The fund has placed no order since 2026-08-31.** Every seat turn on 09-01 and 09-02 failed with:

```
ExecTurnViolation: required MCP server(s) not connected after 30.0s:
{'alpaca': 'failed'}; turn does not run; stage default applies (default is HOLD)
```

Invariant 4 worked exactly as designed — no guess, no order. But 09-01 and 09-02 are gone, and all **9 reflection turns** on 09-02 wrote nothing and are now on their 7-night perishable clock.

## Root cause

Pinning the app did not pin the resolution. `alpaca-mcp-server@2.2.1` declares `fastmcp>=3.1.0` with **no upper bound**, so `uvx` resolved fastmcp 4.0.2, which moved `fastmcp.tools.tool`. `alpaca_mcp_server/security.py:14` imports it, so the server raised at **startup**:

```
ModuleNotFoundError: No module named 'fastmcp.tools.tool'
```

Reproduced on the droplet as the `fund` user with the service environment.

## Why three days passed

`uvx <spec> --version` and `--help` exit inside click **before** importing `.server`. Both cache-warm checks in `ops/README.md` are `--help`, so they stayed green the whole time the server could not start at all. The thing they proved was not the thing that runs.

Those checks now start the transport (`--transport stdio </dev/null`) instead — the probe that would have caught this on day one.

## Why the bump rather than a local constraint

Upstream shipped **2.3.1 on 2026-09-01** declaring `fastmcp<4,>=3.1.0` — they hit the same break and fixed it the same way. Taking their bound leaves one constraint to maintain instead of two that can disagree. The alternative (`--with fastmcp<4` on 2.2.1) was built first and reverted; it works, but it duplicates a bound upstream now owns.

## Surface re-enumerated, not re-recorded

`config/broker_tool_surface.yaml` and `tests/test_broker_surface_pin.py` both carry the version, and CLAUDE.md forbids re-recording a pin to make a test pass. So the surface was enumerated at both versions over the same toolset selection before either was touched:

- **Same 38 tools.** Nothing appeared, nothing disappeared. The three buckets are untouched.
- **Additive schema movement only** — optional `order_id` on `get_account_activities` and `get_account_activities_by_type`; `IEX`/`MEMX` added to `replace_order_by_id`'s routing enum.
- **`place_stock_order` did not move** — the one `gate/tickets.py` validates, and the 2026-08-17 outage class.

`test_broker_surface_pin.py` keeps a **hardcoded literal** rather than deriving from `ALPACA_MCP_SPEC`: deriving it would agree with every future bump silently, which is the opposite of what a pin is for.

## Verification

- `1808 passed, 1 skipped` — same baseline as #219.
- `PURITY LINT: clean`.
- 2.3.1 confirmed to start the transport on the droplet with the real service credentials (read-only; no tool called, no order placed).

## Not covered here

- **Deploy.** `/opt/fund` still runs the old code; this fixes nothing in production until it is pulled and the units restart. That step is Benjamin's.
- **#108** (a seat with no Alpaca tools still cannot run unless the Alpaca MCP server connects) is what turned one dependency break into a total outage. Not addressed here, and not closed by this.
- The branch name predates the final approach — it constrains nothing now, it bumps.