### PR TITLE
ci: probe that the Alpaca MCP server still imports at the pinned spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,31 @@ jobs:
         run: python3 scripts/check_purity.py
       - name: Full test suite (no network, no keys; includes frozen golden numbers)
         run: python3 -m pytest tests/
+
+  # SEPARATE JOB ON PURPOSE. This one needs the network; `test` above must not.
+  # `make test` being offline is a property other things rest on, and a network
+  # step inside it would void that silently rather than loudly.
+  #
+  # It needs NO secrets. The probe imports the server module directly rather
+  # than starting the server, because the CLI validates credentials before
+  # importing and so exits identically on a working and a broken build — see
+  # scripts/mcp_import_probe.py, which documents that with the measurements.
+  #
+  # What it buys: on 2026-08-31 an unpinned transitive dep (fastmcp 4) broke
+  # alpaca-mcp-server at import and the fund placed no order for three days
+  # while `test` above stayed green the whole time. This is the job that goes
+  # red for that.
+  mcp-import:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@v5
+      # The probe reads ALPACA_MCP_SPEC out of agents/seats.py, which imports
+      # claude_agent_sdk — so the lock is needed here too, for the read alone.
+      - name: Install deps (from requirements.lock)
+        run: pip install -r requirements.lock
+      - name: Alpaca MCP server still imports at the pinned spec
+        run: python3 scripts/mcp_import_probe.py

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # fund — see CLAUDE.md for what each mode means.
 
-.PHONY: test lint sim-day replay live-day live-paper close-pnl resolve weights reflect schema-pin surface-pin score-day preflight dev-status
+.PHONY: test lint sim-day replay live-day live-paper close-pnl resolve weights reflect schema-pin surface-pin score-day preflight dev-status mcp-probe
 .PHONY: staging-day staging-reset eval eval-report critic-g1 critic-gate
 .PHONY: register-spec
 .PHONY: eval-critic-dev eval-critic-holdout
@@ -259,6 +259,20 @@ register-spec: deps
 critic-gate: deps
 	@test -n "$(LABEL)" || { echo "critic-gate: LABEL=<run-label> is required (see ops/README.md)" >&2; exit 2; }
 	$(PYTHON) scripts/critic_gate.py $(LABEL) --split holdout
+
+# Does the Alpaca MCP server still IMPORT at the spec the seats launch?
+#
+# NOT part of `make test`, deliberately: it needs the network, and `make test`
+# being offline is a property other things rest on. Needs no keys — the probe
+# imports the server module rather than starting the server, because the CLI
+# checks credentials before importing and so cannot tell a broken build from a
+# working one without them. scripts/mcp_import_probe.py carries the numbers.
+#
+# This is the check that was missing on 2026-08-31, when an unpinned transitive
+# dependency broke the server at import and the fund placed no order for three
+# days with `make test` green throughout.
+mcp-probe: deps
+	$(PYTHON) scripts/mcp_import_probe.py
 
 # Read-only production health check for developers: is every stated invariant
 # and Phase 2 acceptance criterion still true on the box that trades?

--- a/scripts/mcp_import_probe.py
+++ b/scripts/mcp_import_probe.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Prove the Alpaca MCP server still IMPORTS at the spec the seats launch.
+
+    make mcp-probe
+
+WHY THIS EXISTS. On 2026-08-31 `alpaca-mcp-server@2.2.1` — an exact pin —
+stopped working because `fastmcp` is NOT pinned by it (`fastmcp>=3.1.0`, no
+upper bound). uv resolved fastmcp 4.0.2, which moved `fastmcp.tools.tool`;
+`alpaca_mcp_server/security.py` imports it, so the server raised
+ModuleNotFoundError at import. Every seat turn hit `required MCP server(s) not
+connected after 30.0s: {'alpaca': 'failed'}` and defaulted to HOLD. The fund
+placed no order for three days.
+
+`make test` was green for all of it, and could not have been anything else: it
+is offline by design and never launches this server. THIS is the check that
+would have caught it, and it is deliberately NOT part of that suite — it needs
+the network, and a network step inside `make test` would silently void an
+offline guarantee several other things rest on.
+
+WHY IT IMPORTS RATHER THAN STARTS THE SERVER. The obvious probe —
+`uvx <spec> --transport stdio` — does not work without credentials, and was
+written into the first draft of the design before being tested:
+
+    $ uvx alpaca-mcp-server@2.2.1 --transport stdio    # BROKEN build
+    Error: ALPACA_API_KEY and ALPACA_SECRET_KEY must be set.   exit=1
+    $ uvx alpaca-mcp-server@2.3.1 --transport stdio    # WORKING build
+    Error: ALPACA_API_KEY and ALPACA_SECRET_KEY must be set.   exit=1
+
+The CLI validates credentials BEFORE importing `.server`, so broken and working
+are byte-identical without them and the probe would have been green through the
+whole outage. Importing the module directly skips the CLI's credential gate and
+reaches the import that actually failed — which is why this runs
+`python -c "import alpaca_mcp_server.server"` and not the entry point.
+
+Demonstrated to discriminate, credential-free (this is the probe's manufactured
+red, run before it was written):
+
+    alpaca-mcp-server@2.2.1, unpinned  -> ModuleNotFoundError: fastmcp.tools.tool
+    alpaca-mcp-server@2.3.1            -> IMPORT OK
+
+WHAT IT DOES NOT PROVE. That the server runs, that its tools behave, or that the
+broker surface has not moved — listing tools needs a live server and therefore
+credentials. `make schema-pin` and `make surface-pin` remain the guards for
+that, live and human-run. This proves the import, which is the failure that cost
+three days.
+
+The spec is read from agents/seats.py rather than restated here: a probe that
+tests a launch nobody makes is the same defect in a new place.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+# The module whose import broke. Importing the PACKAGE is not enough —
+# `alpaca_mcp_server/__init__.py` does not pull in `.server`, so a package
+# import stays green on exactly the failure this exists to catch.
+TARGET_MODULE = "alpaca_mcp_server.server"
+
+
+def probe_argv() -> list[str]:
+    """The uvx argv, derived from the same constant the seats launch with."""
+    from agents.seats import ALPACA_MCP_SPEC
+
+    argv = ["uvx"]
+    try:                                    # present once Part 1 of the design lands
+        from agents.seats import ALPACA_MCP_ARGS
+    except ImportError:
+        argv += ["--from", ALPACA_MCP_SPEC]
+    else:
+        # ALPACA_MCP_ARGS ends with the spec; --from takes its place so uvx runs
+        # `python` from that package's environment instead of its entry point.
+        argv += [a for a in ALPACA_MCP_ARGS if a != ALPACA_MCP_SPEC]
+        argv += ["--from", ALPACA_MCP_SPEC]
+    return argv + ["python", "-c", f"import {TARGET_MODULE}"]
+
+
+def main() -> int:
+    argv = probe_argv()
+    print(" ".join(argv))
+    try:
+        done = subprocess.run(argv, capture_output=True, text=True, timeout=300)
+    except FileNotFoundError:
+        print("PROBE INCONCLUSIVE: uvx not on PATH — install uv", file=sys.stderr)
+        return 2                            # not 1: nothing was proved either way
+    except subprocess.TimeoutExpired:
+        print("PROBE INCONCLUSIVE: uvx timed out after 300s", file=sys.stderr)
+        return 2
+
+    if done.returncode == 0:
+        print(f"MCP IMPORT OK — {TARGET_MODULE} imports at the launched spec")
+        return 0
+
+    # Print the whole thing. The useful line is the ModuleNotFoundError, and
+    # which module moved is the entire finding.
+    print(f"MCP IMPORT FAILED (exit {done.returncode}) — the seats cannot start "
+          "this server, and every seat turn will default to HOLD:", file=sys.stderr)
+    sys.stderr.write(done.stdout)
+    sys.stderr.write(done.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Part 3a of `docs/superpowers/specs/2026-09-02-lock-launch-path-and-unmask-reds-design.md`, shipped on its own because it is the check that was missing.

## Why

`make test` was **green for all three days the fund was down** (2026-08-31 → 09-02), and could not have been otherwise — it is offline by design and never launches the Alpaca MCP server. `alpaca-mcp-server@2.2.1` declares `fastmcp>=3.1.0` with no upper bound, uv resolved fastmcp 4.0.2, `fastmcp.tools.tool` moved, and the server raised `ModuleNotFoundError` at import. Every seat turn defaulted to HOLD.

This job goes red for that.

## It imports rather than starting the server, and that is the point

The obvious probe was in the first draft of the design and does not work:

```
uvx alpaca-mcp-server@2.2.1 --transport stdio   # BROKEN build, no creds
Error: ALPACA_API_KEY and ALPACA_SECRET_KEY must be set.   exit=1
uvx alpaca-mcp-server@2.3.1 --transport stdio   # WORKING build, no creds
Error: ALPACA_API_KEY and ALPACA_SECRET_KEY must be set.   exit=1
```

The CLI validates credentials **before** importing `.server`, so broken and working are indistinguishable without them — that probe would have been green through the entire outage. Importing the module directly skips the credential gate and reaches the failure, so **this needs no secrets in CI**.

It targets `alpaca_mcp_server.server`, not the package. Verified that matters:

```
uvx --from alpaca-mcp-server@2.2.1 python -c "import alpaca_mcp_server"         -> OK    (misses it)
uvx --from alpaca-mcp-server@2.2.1 python -c "import alpaca_mcp_server.server"  -> ModuleNotFoundError
```

## Manufactured red before it was trusted

| spec | result |
|---|---|
| `2.2.1` unpinned — the real broken combination | `ModuleNotFoundError: fastmcp.tools.tool`, exit 1 |
| `2.3.1` — what `#222` shipped | `MCP IMPORT OK`, exit 0 |

## Notes

- **Separate CI job on purpose.** It needs the network; `make test` being offline is a property other things rest on, and a network step inside it would void that silently.
- **Exit 2 for "uvx missing" or "timed out"** keeps *could not check* distinct from *checked and broken* — the same rule `_ssh` already follows in `dev_status.py`.
- The spec is read from `agents/seats.py`, never restated. It already tolerates `ALPACA_MCP_ARGS` arriving when Part 1 of the design lands.
- `1808 passed, 1 skipped`; purity and alert-code lints clean.

## Not in this PR

Part 1 (`--exclude-newer` resolution pin), Part 2 (alert codes on the `services` line), Part 3b/3c (Renovate). This proves the import; `make schema-pin` and `make surface-pin` remain the live, human-run guards for whether the tool *surface* moved.