### PR TITLE
fix: services names which alerts fired, and degradations reads alert codes

### DIFF
--- a/devcheck/checks.py
+++ b/devcheck/checks.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections import Counter
+
 from devcheck.model import Finding, Snapshot
 
 
@@ -101,8 +103,18 @@ _DEGRADATION_CODES = ("gate_error", "pm_timeout", "critic_timeout", "missing_sig
 
 
 def check_degradations(s: Snapshot) -> Finding:
-    """Invariant 4 — every error resolves to HOLD. Correct, and worth seeing."""
-    seen = [c for c in s.scorecard_codes if c in _DEGRADATION_CODES]
+    """Invariant 4 — every error resolves to HOLD. Correct, and worth seeing.
+
+    Reads alert CODES. It was fed event `kind`s until 2026-09-02, which made it
+    green on every day the fund had ever run: `kind` is alert/digest/pnl and can
+    never equal `pm_timeout`. The function was fine; its input was the wrong
+    column, and only the composition root could see that.
+    """
+    if s.alert_codes is None:
+        return Finding("degradations", "warn",
+                       "alert codes were not read, so whether any stage degraded to its "
+                       "default is unknown — not a clean day, an unmeasured one")
+    seen = [c for c in s.alert_codes if c in _DEGRADATION_CODES]
     if not seen:
         return Finding("degradations", "ok", "no stage degraded to its default")
     return Finding(
@@ -211,6 +223,28 @@ def check_deploy_state(s: Snapshot) -> Finding:
     )
 
 
+def _alert_codes_line(s: Snapshot) -> str:
+    """What actually alerted, appended to a red `services`.
+
+    WHY. A unit's exit status says a run failed, never WHICH failure it was, so
+    a new failure under a standing red is invisible. `services` was red for nine
+    days on #141's `accounting_shortfall`; on 2026-08-31 the Alpaca MCP server
+    stopped importing and raised `seat_turn_failed` instead. The line looked
+    identical, the fund placed no order for three days, and the 09-02 EOD digest
+    attributed it to #141 in writing. The distinguishing evidence was one query
+    away the whole time.
+    """
+    if s.alert_codes is None:
+        return " — alert codes UNREAD, so which failure this is was never established"
+    if not s.alert_codes:
+        day = f" on {s.alert_date}" if s.alert_date else ""
+        return f" — no alert rows{day}, so the exit code is the only evidence"
+    counts = Counter(s.alert_codes)
+    codes = ", ".join(f"{c} x{n}" if n > 1 else c for c, n in sorted(counts.items()))
+    day = f" {s.alert_date}" if s.alert_date else ""
+    return f" — alerts{day}: {codes}"
+
+
 def check_services(s: Snapshot) -> Finding:
     """The scheduled units that constitute the fund actually running."""
     bad = [r for r in s.services.values() if r.result != "success"]
@@ -218,7 +252,7 @@ def check_services(s: Snapshot) -> Finding:
         names = ", ".join(sorted(s.services))
         return Finding("services", "ok", f"last run succeeded: {names}" if names else "no units read")
     parts = [f"{r.unit}: {r.result}" + (f" at {r.last_run}" if r.last_run else "") for r in bad]
-    return Finding("services", "alert", "; ".join(sorted(parts)))
+    return Finding("services", "alert", "; ".join(sorted(parts)) + _alert_codes_line(s))
 
 
 def check_database(s: Snapshot) -> Finding:

--- a/devcheck/model.py
+++ b/devcheck/model.py
@@ -54,7 +54,14 @@ class Snapshot:
     checkpoints: Sequence[tuple[str, str, str]]   # (run_date, stage, status)
     journals_written: frozenset[str] | set[str]
     seats_participating: frozenset[str] | set[str]
-    scorecard_codes: Sequence[str]
+    # Alert CODES (`payload.code`) on the droplet's most recent run date — not
+    # event `kind`s. The distinction is the whole point: this field used to be
+    # fed `kind`, whose values are alert/digest/pnl/scorecard, while
+    # check_degradations filters it for gate_error/pm_timeout/... Those sets
+    # never intersect, so `degradations` was green on every day the fund has
+    # ever run, including 2026-09-02, when pm_timeout fired three times.
+    # None = not read; never an empty list, which reads as "no alerts".
+    alert_codes: Sequence[str] | None
     positions: Sequence[Position] | None   # None = not read; never inferred
     open_orders: Sequence[OpenOrder]
     due_unresolved: Sequence[int]       # decision ids past horizon with no resolution
@@ -62,6 +69,7 @@ class Snapshot:
     origin_master: str
     commits_behind: int
     services: Mapping[str, ServiceResult]
+    alert_date: str = ""               # the run date alert_codes came from, for display
     broker_error: str = ""             # why the book was unread, when it was
     db_read_ok: bool = True            # False = the fund DB could not be read at all
     suppressed: frozenset[str] = field(default_factory=frozenset)

--- a/scripts/dev_status.py
+++ b/scripts/dev_status.py
@@ -320,6 +320,7 @@ def build_snapshot() -> Snapshot:
 
     positions, _open_orders, broker_fills, broker_error = _positions_and_coverage()
     head, origin, behind = _deploy_state()
+    alert_codes, alert_date = _alert_codes()
 
     return Snapshot(
         droplet_env=_droplet_env(),
@@ -331,7 +332,8 @@ def build_snapshot() -> Snapshot:
         checkpoints=[(str(r["run_date"]), str(r["stage"]), str(r["status"])) for r in checkpoint_rows],
         journals_written=_journals_written(run_date),
         seats_participating={str(r["agent"]) for r in participants} & set(SEATS),
-        scorecard_codes=_scorecard_codes(),
+        alert_codes=alert_codes,
+        alert_date=alert_date,
         positions=positions,
         open_orders=[],
         due_unresolved=[int(r["id"]) for r in due_rows],
@@ -366,13 +368,58 @@ def _journals_written(run_date: str) -> set[str]:
     return {Path(n.strip()).stem for n in raw.splitlines() if n.strip()} & set(SEATS)
 
 
-def _scorecard_codes() -> list[str]:
-    """Alert codes raised on the droplet's most recent run date."""
+def parse_alert_codes(rows: list[dict]) -> list[str]:
+    """`events.payload` JSON -> the `code` of each row, one entry per alert.
+
+    Split out from the query so it can be tested against real captured payloads.
+    Its predecessor selected `kind` while claiming in its docstring to return
+    alert codes; `kind` is alert/digest/pnl/scorecard and check_degradations
+    filters for gate_error/pm_timeout/..., so those sets never intersected and
+    `degradations` was green on every day the fund had ever run. Nothing caught
+    it because the checks are tested against hand-written Snapshots and this
+    layer had no tests at all.
+
+    An unparsable payload is still an alert that happened, so it is returned as
+    `unparsable_payload` rather than dropped: losing one here makes the day read
+    quieter than it was, which is the direction that hides things.
+
+    Repeats are kept, not deduped. `pm_timeout` fired once per ticker on
+    2026-09-02; collapsing to a set reports one degraded stage where there were
+    three.
+    """
+    codes = []
+    for row in rows:
+        raw = row.get("payload")
+        if not raw:
+            continue
+        try:
+            code = json.loads(raw).get("code")
+        except (ValueError, TypeError, AttributeError):
+            codes.append("unparsable_payload")
+            continue
+        codes.append(str(code) if code else "uncoded_alert")
+    return codes
+
+
+def _alert_codes() -> tuple[list[str] | None, str]:
+    """(alert codes on the droplet's most recent run date, that date).
+
+    `None` means the read failed — never `[]`, which reads as "nothing alerted".
+
+    The date bound is the latest date across ALL events, not the latest date
+    carrying an alert. Scoping it to alerts would print last week's codes beside
+    today's failed unit as though they were today's, which is a worse failure
+    than printing none.
+    """
     rows = _sql(
-        "select kind from events where date(created_at) = "
+        "select payload from events where kind = 'alert' and date(created_at) = "
         "(select max(date(created_at)) from events)"
-    ) or []
-    return [str(r["kind"]) for r in rows if r.get("kind")]
+    )
+    if rows is None:
+        return None, ""
+    day = _sql("select max(date(created_at)) as d from events") or []
+    date = str(day[0].get("d") or "") if day else ""
+    return parse_alert_codes(rows), date
 
 
 def main() -> int:

--- a/tests/test_dev_status_job.py
+++ b/tests/test_dev_status_job.py
@@ -51,3 +51,48 @@ def test_missing_descriptor_suppresses_nothing(tmp_path):
     """Negative control: no file means no suppression, never a crash."""
     m = _load()
     assert m.read_suppressed(tmp_path / "absent.md") == frozenset()
+
+
+# --- the builder's parsing, which had no tests until 2026-09-02 ---------------
+# The bug this covers: `_scorecard_codes` selected `kind` while its docstring
+# claimed alert codes. `check_degradations` filters for gate_error/pm_timeout,
+# `kind` is alert/digest/pnl, so the sets never intersected and `degradations`
+# was green on every day the fund had ever run. The CHECK was tested and
+# correct; nothing tested what the builder fed it. Payloads below are real rows
+# from 2026-09-02.
+
+def test_parse_alert_codes_reads_the_code_not_the_kind():
+    from scripts.dev_status import parse_alert_codes
+
+    rows = [
+        {"payload": '{"text": "pm_timeout AAPL \\u2014 defaulted to hold", "code": "pm_timeout"}'},
+        {"payload": '{"text": "analyst_turn_failed \\u2014 ExecTurnViolation: required MCP '
+                    'server(s) not connected", "code": "seat_turn_failed"}'},
+        {"payload": '{"text": "audit 2026-09-02 FAILED", "code": "audit_failed"}'},
+    ]
+    codes = parse_alert_codes(rows)
+    assert codes == ["pm_timeout", "seat_turn_failed", "audit_failed"]
+    # The precise regression: none of these is an event `kind`.
+    assert not {"alert", "digest", "pnl", "scorecard"} & set(codes)
+
+
+def test_parse_alert_codes_keeps_a_broken_row_as_an_alert():
+    """An unparsable payload is still an alert that happened. Dropping it makes
+    the day read quieter than it was, which is the direction that hides things."""
+    from scripts.dev_status import parse_alert_codes
+
+    codes = parse_alert_codes([
+        {"payload": "not json at all"},
+        {"payload": '{"text": "no code field here"}'},
+        {"payload": ""},
+    ])
+    assert codes == ["unparsable_payload", "uncoded_alert"]
+
+
+def test_parse_alert_codes_counts_repeats_rather_than_deduping():
+    """`pm_timeout` fired three times on 2026-09-02, once per ticker. Collapsing
+    to a set would report one degraded stage where there were three."""
+    from scripts.dev_status import parse_alert_codes
+
+    rows = [{"payload": '{"code": "pm_timeout"}'}] * 3
+    assert parse_alert_codes(rows) == ["pm_timeout"] * 3

--- a/tests/test_devcheck_checks.py
+++ b/tests/test_devcheck_checks.py
@@ -25,7 +25,8 @@ def _snap(**over) -> Snapshot:
         checkpoints=[],
         journals_written=set(),
         seats_participating=set(),
-        scorecard_codes=[],
+        alert_codes=[],
+        alert_date="2026-09-02",
         positions=[],
         open_orders=[],
         due_unresolved=[],
@@ -133,13 +134,13 @@ def test_degradations_warn_on_gate_error():
     """Invariant 4 says a gate_error resolves to HOLD, which is correct
     behaviour — so this warns, it does not alert. The day was not wrong;
     it was degraded, and a degraded day that nobody sees becomes normal."""
-    f = _only(evaluate(_snap(scorecard_codes=["gate_error"])), "degradations")
+    f = _only(evaluate(_snap(alert_codes=["gate_error"])), "degradations")
     assert f.severity == "warn"
     assert "gate_error" in f.detail
 
 
 def test_degradations_warn_on_pm_timeout():
-    f = _only(evaluate(_snap(scorecard_codes=["pm_timeout"])), "degradations")
+    f = _only(evaluate(_snap(alert_codes=["pm_timeout"])), "degradations")
     assert f.severity == "warn"
 
 
@@ -359,3 +360,69 @@ def test_unread_book_names_why_it_could_not_be_read():
               "position_coverage")
     assert f.severity == "alert"
     assert "no ALPACA_API_KEY in this shell" in f.detail
+
+
+# --- alert codes on a red `services`, and the degradations input --------------
+# Regression cover for 2026-08-31 → 09-02: the Alpaca MCP server stopped
+# importing, every seat defaulted to HOLD, and `services` had ALREADY been red
+# for nine days on #141. The new failure produced an identical line and was
+# attributed to #141 in writing. These pin the difference being visible.
+
+def _units(**results):
+    from devcheck.model import ServiceResult
+    return {u: ServiceResult(u, r, "Wed 2026-09-02 09:36:51 EDT")
+            for u, r in results.items()}
+
+
+def test_a_red_service_names_which_alerts_fired():
+    f = _only(evaluate(_snap(services=_units(**{"fund-daily": "exit-code"}),
+                             alert_codes=["seat_turn_failed"] * 3 + ["pm_timeout"],
+                             alert_date="2026-09-02")), "services")
+    assert f.severity == "alert"
+    assert "seat_turn_failed x3" in f.detail, f.detail
+    assert "pm_timeout" in f.detail and "pm_timeout x" not in f.detail  # count only when >1
+    assert "2026-09-02" in f.detail
+
+
+def test_two_reds_with_different_codes_do_not_read_alike():
+    """The masking failure itself: #141's red and the outage's red must differ."""
+    known = _only(evaluate(_snap(services=_units(**{"fund-daily": "exit-code"}),
+                                 alert_codes=["accounting_shortfall"])), "services")
+    novel = _only(evaluate(_snap(services=_units(**{"fund-daily": "exit-code"}),
+                                 alert_codes=["seat_turn_failed"])), "services")
+    assert known.detail != novel.detail
+    assert "accounting_shortfall" in known.detail
+    assert "seat_turn_failed" in novel.detail
+
+
+def test_unread_alert_codes_are_never_rendered_as_no_alerts():
+    """`None` is 'could not read'. An empty list is 'nothing alerted'. Rendering
+    the first as the second is how absence becomes health."""
+    unread = _only(evaluate(_snap(services=_units(**{"fund-daily": "exit-code"}),
+                                  alert_codes=None)), "services")
+    empty = _only(evaluate(_snap(services=_units(**{"fund-daily": "exit-code"}),
+                                 alert_codes=[], alert_date="2026-09-02")), "services")
+    assert "UNREAD" in unread.detail
+    assert "no alert rows" in empty.detail
+    assert unread.detail != empty.detail
+
+
+def test_degradations_is_unknown_rather_than_clean_when_codes_are_unread():
+    f = _only(evaluate(_snap(alert_codes=None)), "degradations")
+    assert f.severity == "warn"
+    assert "unknown" in f.detail
+
+
+def test_degradations_fires_on_the_codes_the_fund_actually_emits():
+    """The 2026-09-02 defect: this field was fed event `kind`s (alert/digest/
+    pnl), which can never equal a degradation code, so `degradations` was green
+    on every day the fund had ever run. These are real codes from that day."""
+    real = ["seat_turn_failed"] * 12 + ["pm_timeout"] * 3 + ["audit_failed",
+                                                            "reflect_turn_wrote_nothing"]
+    f = _only(evaluate(_snap(alert_codes=real)), "degradations")
+    assert f.severity == "warn", "pm_timeout fired 3x that day; this must not read clean"
+    assert "pm_timeout" in f.detail
+
+    kinds = ["alert", "digest", "pnl", "scorecard"]        # what it used to receive
+    stale = _only(evaluate(_snap(alert_codes=kinds)), "degradations")
+    assert stale.severity == "ok", "event kinds must not look like degradations either"


### PR DESCRIPTION
Part 2 of the [outage design](docs/superpowers/specs/2026-09-02-lock-launch-path-and-unmask-reds-design.md), plus a live defect found while implementing it.

## Two defects, one root

**`devcheck/`'s checks are tested against hand-written Snapshots, and nothing tested what `build_snapshot()` actually puts in them.** Both bugs below live in that untested gap.

### 1. `services` never said which failure it was

It printed an exit status and nothing else. It had been red for **nine days** on #141's `accounting_shortfall` when the Alpaca MCP server stopped importing on 2026-08-31 and started raising `seat_turn_failed`. Identical-looking line; the fund placed no order for three days; the 09-02 EOD digest attributed it to #141 in writing.

On real production data now:

```
🔴 services | fund-daily: exit-code at Wed 2026-09-02 09:36:51 EDT
             — alerts 2026-09-02: audit_failed, pm_timeout x3,
               reflect_turn_wrote_nothing, seat_turn_failed x12
```

On 09-01 that line would have read `seat_turn_failed x12`, not `accounting_shortfall`. Visible on day one.

### 2. `degradations` was green on every day the fund has ever run

`_scorecard_codes()` selected `kind` — whose values are `alert`/`digest`/`pnl`/`scorecard` — while its docstring claimed alert codes. `check_degradations` filters for `gate_error`/`pm_timeout`/… Those sets **never intersect**, so it could not fire.

On 2026-09-02 `pm_timeout` fired three times and it reported *"no stage degraded to its default."* Verified against the live DB:

```
payload codes: seat_turn_failed x12, pm_timeout x3, audit_failed, reflect_turn_wrote_nothing
degradation codes present: ['pm_timeout']
reported: "no stage degraded to its default"     ← false
```

**The check already had passing tests** feeding it `["pm_timeout"]` directly. The function was never wrong — its *input* was the wrong column, and only the composition root could see that.

## ⚠️ One thing for review, not fixed here

`.claude/health.md` suppresses `degradations` because *"`model_fallback_used` fires at severity 3 every day."* That code is not in `_DEGRADATION_CODES` and could never have reached this check while it was broken — so the stated rationale cannot be what was observed. **Now that the check works, the suppression hides a true finding** (`pm_timeout x3` today). Left alone deliberately: it is a descriptor and a noise judgment, not a code fix.

## Design notes

- `parse_alert_codes()` is split from the query so it is testable, and tested against **real captured payloads** from 2026-09-02. That is the layer that had no tests at all.
- `alert_codes` is `| None` — `None` is "could not read", `[]` is "nothing alerted". Rendering the first as the second is how absence becomes health, the same rule `_ssh` and `_sql` already document.
- The date bound is the latest date across **all** events, not the latest date carrying an alert — otherwise last week's codes print beside today's failed unit as if they were today's.
- An unparsable payload returns `unparsable_payload` rather than being dropped: losing one makes the day read quieter than it was.
- Repeats are kept, not deduped — `pm_timeout` fired once per ticker; a set would report one degraded stage where there were three.

## Verification

Every test manufactured red before being trusted:

| break | tests that failed |
|---|---|
| remove the codes line from `services` | 3 |
| let unread codes render as a clean day | 1 |
| read `kind` instead of `code` | 2 |

`1816 passed, 1 skipped` (8 new). Purity and alert-code lints clean. End-to-end run against the live droplet shown above.

## Follow-up

The root cause — a builder nothing tests — is only partly closed here. The general fix is for `test_devcheck_checks.py`'s healthy-world fixture to be *produced by the builder from captured production rows* rather than hand-written, so a wrong column cannot survive anywhere. Separate change.