### PR TITLE
docs: README architecture diagram matches the firm as it runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,49 +14,81 @@ Agents decide inside a deterministic control envelope. That is the whole idea.
 
 ## Architecture
 
-The following diagram traces one market day, from the scheduled fire to the
-Slack projection, with SQLite as the source of truth and Slack as a read-only
+### The firm's clock
+
+Nothing in the firm starts because a human or an agent asked it to. Every seat
+turn is assigned by code on a schedule (invariant 6), and there are two fires a
+day, not one — the trading day and the post-close job, which is where the seats
+that think about *yesterday* live:
+
+```
+  fund-daily.timer    09:35 ET Mon-Fri  ->  scripts/run_day.py
+    the trading day, below                  4 LLM turns: analyst, news, pm, exec
+
+  fund-pnl.timer      16:35 ET Mon-Fri  ->  five legs, in order, halting on the first failure
+    close_pnl.py  ->  resolve_day.py  ->  weights_day.py  ->  reflect_day.py  ->  critic_g1.py
+    P&L vs SPY        resolutions         scoreboard         reflect seat        critic seat
+    (deterministic)   (deterministic)     (deterministic)    2 LLM turns, budget spent last
+
+  fund-backup.timer   17:30 ET daily    ->  ops/backup.sh
+  fund-alert@.service on any unit failing ->  ops/notify_failure.sh  ->  Slack
+
+  make register-spec BRIEF=<path>       ->  scripts/register_spec.py  ->  quant seat
+    hand-run, deliberately never on a timer: no sponsorship mechanism exists in code yet
+```
+
+Seven seats are staffed — a charter in `charters/`, a config in `agents/config/`,
+and a tool cap in `SEAT_CAPS`. Six of them wake on a timer; the quant seat wakes
+only when a human runs the job. The Critic is staffed for **G1 strategy-spec
+review only**: the trading day still runs on the orchestrator's own
+`no_critic_seat` default rows (`orchestrator/daily.py`'s `run_decision`), and
+wiring the Critic into the Decision stage is deliberately out of scope.
+
+### The trading day
+
+The following diagram traces the 09:35 fire, from the timer to the Slack
+projection, with SQLite as the source of truth and Slack as a read-only
 projection of it:
 
 ```
-                       ┌──────────────── one fire per market day ─────────────┐
-                       │  launchd 09:35 ET  ->  scripts/run_day.py            │
-                       │  (the ONLY place real clock/Slack/Alpaca/LLM meet)   │
-                       └──────────────────────┬──────────────────────────────┘
-                                              │ market closed? exit 0, trade nothing
-                                              v
+                     ┌──────────────── the 09:35 fire ──────────────────────┐
+                     │  systemd fund-daily.timer  ->  scripts/run_day.py    │
+                     │  (the ONLY place real clock/Slack/Alpaca/LLM meet)   │
+                     └────────────────────┬─────────────────────────────────┘
+                                          │ market closed? exit 0, trade nothing
+                                          v
    orchestrator/  ── stages, sequential, each behind a checkpoint CAS ──────────
    pre_gate -> research -> decision -> gate -> execution -> reconciliation -> close
        │           │          │         │         │            │          │
        │           v          v         │         v            │          v
        │      ┌─────────┐ ┌───────┐     │    ┌────────┐        │      EOD digest
-       │      │ analyst │ │  pm   │     │    │  exec  │        │
-       │      │  seat   │ │ seat  │     │    │  seat  │        │
-       │      └────┬────┘ └───┬───┘     │    └───┬────┘        │
-       │           │ MCP tools│         │        │             │
-       │           v          v         │        v             │
-       │    submit_signal  submit_decision   list_open_tickets  │
-       │    (analyst-only) (pm-only)         (exec-only)        │
-       │           │          │              │                 │
-       │           └──────────┴──────┬───────┘                  │
-       │                             v                          │
-       │                  ╔══════════════════════╗              │
-       └─ allowed actions ║   gate/  (NO LLM)    ║              │
-          {buy:n, sell:n} ║  vol/corr tiers      ║              │
-                          ║  cash + sector caps  ║              │
-                          ║  8-position limit    ║              │
-                          ║  -3% circuit breaker ║              │
-                          ╚═══════════╤══════════╝              │
-                                      │ ticket (id == client_order_id, TTL 45m)
-                                      v                         │
-                       PreToolUse hook: no valid ticket -> DENY  │
-                                      │                         │
-                                      v                         v
-                        mcp__alpaca__place_* ──────────> Alpaca paper broker
-                                      │                         │
-                       PostToolUse hook: mirror the fill        │ fill poll
-                                      v                         v
-                          SQLite (source of truth)  ──outbox──> Slack (projection)
+       │      │ analyst │ │   pm  │     │    │  exec  │        │
+       │      │   news  │ │  seat │     │    │  seat  │        │
+       │      └────┬────┘ └───┬───┘     │    └────┬───┘        │
+       │           │          │         │         │            │
+       │           v          v         │         v            │
+       │     submit_signal  submit_decision  list_open_tickets │
+       │     (analyst, news)  (pm only)       (exec only)      │
+       │           │          │                   │            │
+       │           └──────────┴─────────┬─────────┘            │
+       │                                v                      │
+       │                  ╔══════════════════════════╗         │
+       └─ allowed actions ║  gate/  (NO LLM)         ║         │
+          {buy:n, sell:n} ║  vol tier x corr mult    ║         │
+                          ║  cash + 60% sector cap   ║         │
+                          ║  8-position limit        ║         │
+                          ║  -3% circuit breaker     ║         │
+                          ╚═════════════╤════════════╝         │
+                                        │ ticket (id == client_order_id, TTL 45m)
+                                        v                      │
+                     PreToolUse hook: no valid ticket -> DENY  │
+                                        │                      │
+                                        v                      v
+                          mcp__alpaca__place_* ──────> Alpaca paper broker
+                                        │                      │
+                        PostToolUse hook: mirror the fill      │ fill poll
+                                        v                      v
+                        SQLite (source of truth) ──outbox──> Slack (projection)
 ```
 
 Reading it in one line: **agents → MCP tools → deterministic gate → hook → broker**,


### PR DESCRIPTION
The README architecture diagram had drifted since 2026-08-18. The largest gap
was not a missing seat — it was a missing **half of the firm**.

## What was wrong

| Claim in the diagram | What the code says |
|---|---|
| `launchd 09:35 ET` | production is systemd on the Linux droplet (`ops/README.md`) |
| research = one `analyst` box | `run_day.SEATS["research"] == ("analyst", "news")` |
| "one fire per market day" | **two** — `fund-daily.timer` 09:35 and `fund-pnl.timer` 16:35 |

That third one hid the most: `fund-pnl.service` runs five legs
(`close_pnl` → `resolve_day` → `weights_day` → `reflect_day` → `critic_g1`),
two of which are LLM seat turns. Resolutions, the scoreboard and G1 spec
review were all invisible in the picture.

## What this changes

- Adds a **schedule diagram** above the day trace: all three timers, the
  alert unit, and the hand-run `make register-spec` quant job.
- Corrects the day trace: systemd, `analyst` + `news`, aligned connectors.
- Notes that the Critic is staffed for **G1 only** — the Decision stage still
  runs on `insert_default_critiques`' `no_critic_seat` rows, which is
  deliberate and documented in `SEAT_CAPS`.
- Records that seven seats are staffed, six on timers, quant hand-run.

## Verification

Gate figures were re-read at source rather than carried forward from the old
diagram: `SECTOR_CAP = 0.60`, `MAX_POSITIONS = 8`, `CIRCUIT_BREAKER = -0.03`
(`gate/risk.py:11-13`), `TICKET_TTL_MIN = 45` (`orchestrator/daily.py:35`).
All four still hold.

Diagram connector columns were generated programmatically and asserted
against the stage-spine columns, not eyeballed.

`make test` — 1824 passed, 1 skipped.

## Not in scope

- `README.md:105` still says "518 offline tests"; it is 1824. Left alone as
  outside the diagram — happy to fix here if preferred.
- `specs/design.md` §1 is still the day-one three-box overview and its §2 seat
  table lists ~14 seats against 7 staffed. That is a canonical spec and its
  seat table may be a design surface rather than a staffing claim, so it needs
  a decision rather than a unilateral rewrite.